### PR TITLE
Remove invalid link

### DIFF
--- a/api-bundle/index.md
+++ b/api-bundle/index.md
@@ -102,6 +102,5 @@ This bundle is documented and tested with Behat (take a look at [the `features/`
 
 * (english) [Create API-First Web Apps with API Platform, a PHP Framework](http://blog.runscope.com/posts/create-api-first-web-apps-with-api-platform-a-php-framework)
 * (french) [A la découverte de API Platform (Symfony Live Paris 2015)](https://dunglas.fr/2015/04/mes-slides-du-symfony-live-2015-a-la-decouverte-de-api-platform/)
-* (french) [API-first et Linked Data avec Symfony (sfPot Lille 2015)](https://les-tilleuls.coop/slides/dunglas/slides-sfPot-2015-01-15/#/)
 * (french) [Behat PHP code coverage](http://www.kitpages.fr/fr/cms/204/behat-php-code-coverage)
 


### PR DESCRIPTION
The link returns a 404. I tried to find the page on the blog to find the new link but couldn't find it.
I assume that the post was deleted.
