### PR TITLE
Add steps to install NelmioApiDocBundle

### DIFF
--- a/core/nelmio-api-doc.md
+++ b/core/nelmio-api-doc.md
@@ -5,7 +5,7 @@
 [NelmioApiDocBundle](https://github.com/nelmio/NelmioApiDocBundle) (since version 2.9) has built-in support for API Platform.
 Installing it will give you access to a human-readable documentation and a nice sandbox. It is an alternative to the builtin API Platform documentation.
 
-If you use the standalone API Platform Core bundle, copy the following configuration:
+If you use the standalone API Platform Core bundle, download and enable the bundle as explained in [NelmioApiDocBundle installation steps](https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/doc/index.rst) (skip routing and configuration steps), and then copy the following configuration:
 
 ```yaml
 # app/config/config.yml


### PR DESCRIPTION
Following steps 1 and 2 from https://github.com/nelmio/NelmioApiDocBundle/blob/master/Resources/doc/index.rst is needed to get NelmioApiDocBundle installed if user started with core API. However, step 3 doesn't seem to be required (routing), and step 4 is done by API Platform docs. Could you please confirm if routing step should be skipped, or should dev still do it?