### PR TITLE
Remove "Registering a Custom Format in the Negotiation Library" section

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -42,52 +42,6 @@ Because the Symfony Serializer component is able to serialize objects in XML, se
 `text/xml` string as value is enough to retrieve XML documents from our API. However API Platform knows nothing about the
 `myformat` format. We need to register an encoder and optionally a normalizer for this format.
 
-## Registering a Custom Format in the Negotiation Library
-
-If the format you want to use is not supported by default in the Negotiation library, you must register it using a [compiler
-pass](https://symfony.com/doc/current/components/dependency_injection/compilation.html#creating-a-compiler-pass):
-
-```php
-// src/AppBundle/DependencyInjection/Compiler/MyFormatPass.php
-
-namespace AppBundle\DependencyInjection\Compiler;
-
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-
-final class MyFormatPass implements CompilerPassInterface
-{
-    public function process(ContainerBuilder $container)
-    {
-        // ...
-
-        $container->getDefinition('api.format_negotiator')->addMethodCall('registerFormat', [
-            'myformat', ['application/vnd.myformat'], true,
-        ]);
-    }
-}
-```
-
-Don't forget to register your compiler pass into the container from the `Bundle::build(ContainerBuilder $container)` method of your bundle:
-
-```php
-// src/AppBundle/AppBundle.php
-
-namespace AppBundle;
-
-use AppBundle\DependencyInjection\Compiler\MyFormatPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-
-final class AppBundle extends Bundle
-{
-    public function build(ContainerBuilder $container)
-    {
-        $container->addCompilerPass(new MyFormatPass());
-    }
-}
-```
-
 ## Registering a Custom Serializer
 
 If you are adding support for a format not supported by default by API Platform nor by the Symfony Serializer Component,


### PR DESCRIPTION
Since Negotiation 2.0 this section is useless and doesn't work anymore.