### PR TITLE
Add --rm parameter to docker-compose run command examples

### DIFF
--- a/deployment/docker.md
+++ b/deployment/docker.md
@@ -7,8 +7,8 @@ stack is shipped with the API Platform distribution.
 To install it, run the following commands (Docker must be installed on your system):
 
     docker-compose up # Download, build and run Docker images
-    docker-compose run web composer install -o -n # Install Composer dependencies
-    docker-compose run web bin/console doctrine:schema:create # Create the MySQL schema
+    docker-compose run --rm web composer install -o -n # Install Composer dependencies
+    docker-compose run --rm web bin/console doctrine:schema:create # Create the MySQL schema
 
 Your project will be accessible at the URL `http://127.0.0.1`.
 

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -62,9 +62,9 @@ almost everything.
 
 Now, in another shell, install the project's PHP dependencies:
 
-    $ docker-compose run web composer install --no-interaction
+    $ docker-compose run --rm web composer install --no-interaction
 
-The `web` container is where your project stands. Prefixing a command by `docker-compose run web` allows to execute the
+The `web` container is where your project stands. Prefixing a command by `docker-compose run --rm web` allows to execute the
 given command in the container. You may want [to create an alias](http://www.linfo.org/alias.html) to easily run commands
 inside the container. Here, we are installing libraries required by the project using the `composer` tool included in the
 API Platform image.
@@ -72,7 +72,7 @@ API Platform image.
 The API Platform Standard Edition comes with a dummy entity for test purpose: `src/AppBundle/Entity/Foo.php`. We will remove
 it later, but for now, create the related database table:
 
-    docker-compose run web bin/console doctrine:schema:create
+    docker-compose run --rm web bin/console doctrine:schema:create
 
 If you're used to the PHP ecosystem, you probably guessed that this test entity uses the industry-leading [Doctrine ORM](http://www.doctrine-project.org/projects/orm.html)
 library as persistence system.
@@ -270,12 +270,12 @@ or in Kévin's book "[Persistence in PHP with the Doctrine ORM](https://www.amaz
 As we used private properties (but API Platform as well as Doctrine can also work with public ones), we need to create the
 corresponding accessor methods. Run the following command or use the code generation feature of your IDE to generate them:
 
-    $ docker-compose run web bin/console doctrine:generate:entities AppBundle
+    $ docker-compose run --rm web bin/console doctrine:generate:entities AppBundle
 
 Then, delete the file `src/AppBundle/Entity/Foo.php`, this demo entity isn't useful anymore.
 Finally, tell Doctrine to sync the database's tables structure with our new data model:
 
-    $ docker-compose run web bin/console doctrine:schema:update --force
+    $ docker-compose run --rm web bin/console doctrine:schema:update --force
 
 We now have a working data model that you can persist and query. To create an API endpoint with CRUD capabilities corresponding
 to an entity class, we just have to mark it with an annotation called `@ApiResource`:

--- a/distribution/testing.md
+++ b/distribution/testing.md
@@ -156,7 +156,7 @@ Feature: Manage books and their reviews
 
 The API Platform flavor of Behat also comes with a temporary SQLite database dedicated to tests. It works out of the box.
 
-Just run `docker-compose run web vendor/bin/behat` and everything should be green:
+Just run `docker-compose run --rm web vendor/bin/behat` and everything should be green:
 
 Your Linked Data API is now specified and tested thanks to Behat!
 


### PR DESCRIPTION
Each time you run a docker-compose run command it will create a new container and not reuse an older one. So when the command you've run is finished the container stop but remain in memory. In order to avoid creating deads containers each time you run a command it's better to add the --rm parameter.