### PR TITLE
Delete extra `}` in hydra context

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -121,7 +121,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 /**
  * @ApiResource(itemOperations={
  *     "get"={"method"="GET", "path"="/grimoire/{id}"},
- *     "put"={"method"="PUT", "path"="/grimoire/{id}/update", "hydra_context"={"foo"="bar"}},
+ *     "put"={"method"="PUT", "path"="/grimoire/{id}/update", "hydra_context"={"foo"="bar"},
  * })
  */
 class Book


### PR DESCRIPTION
This makes the example syntactically correct.