### PR TITLE
Add doc for 'api_resources_directory' configuration value.

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -22,6 +22,9 @@ api_platform:
     # Specify a name converter to use.
     name_converter: ~
 
+    # Specify a name for the folder within bundle that contain api resources.
+    api_resources_directory: 'Entity'
+
     eager_loading:
         # To enable or disable eager loading.
         enabled: true


### PR DESCRIPTION
Add documentation for the configuration value that adds the possibility to customize the name of the directory where api resources can be stored.