### PR TITLE
correct a few typos

### DIFF
--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -17,7 +17,7 @@ For a given resource, you can implement two kind of interfaces:
 * the [`ItemDataProviderInterface`](https://github.com/api-platform/core/blob/master/src/DataProvider/ItemDataProviderInterface.php)
   is used when fetching items.
 
-In the following examples we will create custom data providers for an entity class class called `AppBundle\Entity\BlogPost`.
+In the following examples we will create custom data providers for an entity class called `AppBundle\Entity\BlogPost`.
 
 ## Custom Collection Data Provider
 

--- a/core/operations.md
+++ b/core/operations.md
@@ -297,7 +297,7 @@ together.
 Here we consider that DunglasActionBundle is installed (the default when using the API Platform distribution). This
 action will be automatically registered as a service (the service name is the same as the class name: `AppBundle\Action\BookSpecial`).
 
-API Platform automatically retrieve the appropriate PHP entity then then deserializes it, and for `POST` and `PUT` requests
+API Platform automatically retrieves the appropriate PHP entity then deserializes it, and for `POST` and `PUT` requests
 updates the entity with data provided by the user.
 
 Services (`$myService` here) are automatically injected thanks to the autowiring feature. You can type-hint any service

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -52,10 +52,9 @@ api_platform:
 
 ## Disabling the Pagination
 
-Paginating collection is generally accepted as a good practice. It also allows browsing large collections without to much
+Paginating collections is generally accepted as a good practice. It allows browsing large collections without too much
 overhead as well as preventing [DOS attacks](https://en.wikipedia.org/wiki/Denial-of-service_attack).
-It allows to browse large collections and prevent. However, for small collections, it can be convenient to fully disable
-the pagination.
+However, for small collections, it can be convenient to fully disable the pagination.
 
 ### Globally
 

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -436,12 +436,12 @@ Oops, we missed to add the title. But submit the request anyway. You should get 
 
 Did you notice that the error was automatically serialized in JSON-LD and respect the Hydra Core vocabulary for errors?
 It allows the client to easily extract useful information from the error. Anyway, it's bad to get a SQL error when submitting
-a request. It means that we doesn't use a valid input, and [it's a very bad and dangerous practice](https://www.owasp.org/index.php/Input_Validation_Cheat_Sheet).
+a request. It means that we didn't use a valid input, and [it's a very bad and dangerous practice](https://www.owasp.org/index.php/Input_Validation_Cheat_Sheet).
 
 API Platform comes with a bridge with [the Symfony Validator Component](http://symfony.com/doc/current/validation.html).
 Adding some of [its numerous validation constraints](http://symfony.com/doc/current/validation.html#supported-constraints)
 (or [creating custom ones](http://symfony.com/doc/current/validation/custom_constraint.html)) to our entities is enough
-to get validate user submitted data. Let's add some validation rules to our data model:
+to validate user submitted data. Let's add some validation rules to our data model:
 
 ```php
 <?php


### PR DESCRIPTION
Correcting a few typos in the documentation. I understand those corrections should be branched off from 2.0.