### PR TITLE
Change confusing reference to removed service definition. 

### DIFF
--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -10,23 +10,7 @@ You need to use serialization groups to hide some properties like `plainPassword
 shown are handled with the [`normalization_context`](serialization-groups-and-relations.md#normalization), while the properties
 you can modify are handled with [`denormalization_context`](serialization-groups-and-relations.md#denormalization).
 
-First register the following service:
-
-```yaml
-# app/config/services.yml
-
-resource.user:
-        parent:    "api.resource"
-        arguments: [ "AppBundle\Entity\User" ]
-        calls:
-            -      method:    "initNormalizationContext"
-                   arguments: [ { groups: [ "user_read" ] } ]
-            -      method:    "initDenormalizationContext"
-                   arguments: [ { groups: [ "user_write" ] } ]
-        tags:      [ { name: "api.resource" } ]
-```
-
-Then create your User entity with serialization groups:
+Create your User entity with serialization groups:
 
 ```php
 <?php

--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -12,6 +12,22 @@ you can modify are handled with [`denormalization_context`](serialization-groups
 
 First register the following service:
 
+```yaml
+# app/config/services.yml
+
+resource.user:
+        parent:    "api.resource"
+        arguments: [ "AppBundle\Entity\User" ]
+        calls:
+            -      method:    "initNormalizationContext"
+                   arguments: [ { groups: [ "user_read" ] } ]
+            -      method:    "initDenormalizationContext"
+                   arguments: [ { groups: [ "user_write" ] } ]
+        tags:      [ { name: "api.resource" } ]
+```
+
+Then create your User entity with serialization groups:
+
 ```php
 <?php
 


### PR DESCRIPTION
Either the service definition should have stayed in the document or the line saying "First register the following service:" should have been removed. I went with the former. Was removed in c500601deb59085928b1b289fab40b4ce221596b.