### PR TITLE
Fix JWT URL

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -1,6 +1,6 @@
 # JWT Authentification
 
-> [JSON Web Token (JWT)](jwt.io) is a JSON-based open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for creating access tokens that assert some number of claims. For example, a server could generate a token that has the claim "logged in as admin" and provide that to a client. The client could then use that token to prove that he/she is logged in as admin. The tokens are signed by the server's key, so the server is able to verify that the token is legitimate. The tokens are designed to be compact, URL-safe and usable especially in web browser single sign-on (SSO) context.
+> [JSON Web Token (JWT)](https://jwt.io/) is a JSON-based open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for creating access tokens that assert some number of claims. For example, a server could generate a token that has the claim "logged in as admin" and provide that to a client. The client could then use that token to prove that he/she is logged in as admin. The tokens are signed by the server's key, so the server is able to verify that the token is legitimate. The tokens are designed to be compact, URL-safe and usable especially in web browser single sign-on (SSO) context.
 
 [Wikipedia](https://en.wikipedia.org/wiki/JSON_Web_Token)
 


### PR DESCRIPTION
Wrong path to jwt.io website on page https://api-platform.com/docs/core/jwt.

Fixing https://api-platform.com/docs/core/jwt.io to https://jwt.io/