### PR TITLE
Correct typo in example App.js

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -21,7 +21,7 @@ Edit the `src/App.js` file like the following:
 
 ```javascript
 import React, { Component } from 'react';
-import { HydraAdmin } from '@api-platform-admin';
+import { HydraAdmin } from '@api-platform/admin';
 
 class App extends Component {
   render() {


### PR DESCRIPTION
The provided example does not compile correctly. With this correction it works fine. 