### PR TITLE
Revert "Prevent a warning related to React Router"

### DIFF
--- a/client-generator/react.md
+++ b/client-generator/react.md
@@ -40,7 +40,7 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { reducer as form } from 'redux-form';
-import { Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import createBrowserHistory from 'history/createBrowserHistory';
 import { syncHistoryWithStore, routerReducer as routing } from 'react-router-redux'
 


### PR DESCRIPTION
Reverts api-platform/docs#304

It prevents the warning, but it breaks the routing... Reverting for now.