### PR TITLE
Fixed ApiNormalizer config, was giving me an error with default install

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -42,7 +42,7 @@ services:
   # ...
 
     'AppBundle\Serializer\ApiNormalizer':
-        decorates: 'api_platform.jsonld.normalizer.item'
+        decorates: 'api_platform.serializer.normalizer.item'
         arguments: [ '@AppBundle\Serializer\ApiNormalizer.inner' ]
         autoconfigure: false
 ```
@@ -50,7 +50,7 @@ services:
 ```php
 <?php
 
-// src/Appbundle/Serializer/ApiSerializer
+// src/AppBundle/Serializer/ApiNormalizer
 
 namespace AppBundle\Serializer;
 


### PR DESCRIPTION
While following this page I was getting the following error with default APIP setup:

> Symfony\Component\Debug\Exception\FatalThrowableError: Call to a member function normalize() on null in /srv/api-platform/vendor/api-platform/core/src/Serializer/AbstractItemNormalizer.php:423 Stack trace: 
> #0 /srv/api-platform/vendor/symfony/symfony/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php(78)