### PR TITLE
Remove links to removed resources

### DIFF
--- a/index.md
+++ b/index.md
@@ -145,10 +145,9 @@
 
 1.  [The Project's Philosophy](philosophy.md)
 2.  [Troubleshooting](troubleshooting.md)
-3.  [Contribution Guides](https://github.com/api-platform/api-platform/blob/master/CONTRIBUTING.md)
-    1.  [API Platform Distribution](https://github.com/api-platform/api-platform/blob/master/CONTRIBUTING.md)
-    2.  [API Platform Core Library](https://github.com/api-platform/core/blob/master/CONTRIBUTING.md)
-    3.  [API Platform Schema Generator](https://github.com/api-platform/schema-generator/blob/master/CONTRIBUTING.md)
-    4.  [API Platform Admin](https://github.com/api-platform/admin/blob/master/CONTRIBUTING.md)
-    5.  [API Platform CRUD Generator](https://github.com/api-platform/client-generator/blob/master/CONTRIBUTING.md)
+3.  Contribution Guides
+    1.  [API Platform Core Library](https://github.com/api-platform/core/blob/master/CONTRIBUTING.md)
+    2.  [API Platform Schema Generator](https://github.com/api-platform/schema-generator/blob/master/CONTRIBUTING.md)
+    3.  [API Platform Admin](https://github.com/api-platform/admin/blob/master/CONTRIBUTING.md)
+    4.  [API Platform CRUD Generator](https://github.com/api-platform/client-generator/blob/master/CONTRIBUTING.md)
 4.  [Contributor Code Of Conduct](conduct.md)


### PR DESCRIPTION
They were removed in
https://github.com/api-platform/api-platform/commit/d2a9272a610013671ffc3215c1c65e79b1c496c8