### PR TITLE
Change comment text to refer to correct file name

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -323,7 +323,7 @@ class Book
 
 ```php
 <?php
-// src/AppBundle/Entity/Entity.php
+// src/AppBundle/Entity/Review.php
 
 namespace AppBundle\Entity;
 


### PR DESCRIPTION
The comment is for the `AppBundle\Entity\Review` class. :koala: 