### PR TITLE
Update LexikJWTAuthenticationBundle configuration

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -48,7 +48,9 @@ security:
             provider: fos_userbundle
             stateless: true
             anonymous: true
-            lexik_jwt: ~
+            guard:
+                authenticators:
+                    - lexik_jwt_authentication.jwt_token_authenticator
 
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/


### PR DESCRIPTION
Using this configuration is not the recommended way anymore. It triggers 4 deprecation including `"lexik_jwt_authentication.security.authentication.entry_point.main" service is deprecated`