### PR TITLE
Describe the fact that first GET collectionOperation is used for resourceClass IRI

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -485,6 +485,8 @@ automatically instantiated and injected, without having to declare it explicitly
 In the following example, the built-in `GET` operation is registered as well as a custom operation called `special`.
 The `special` operation reference the Symfony route named `book_special`.
 
+Note: For performance reasons API Platform is using the first operation (with GET method) defined in collectionOperations to generate the IRI for this resourceClass. This means that as long as you dont want to overwrite the IRI for this resourceClass by intention, the default collectionOperation called "get" should be the first operation defined inside collectionOperations.
+
 ```php
 <?php
 // src/Entity/Book.php

--- a/core/operations.md
+++ b/core/operations.md
@@ -485,7 +485,7 @@ automatically instantiated and injected, without having to declare it explicitly
 In the following example, the built-in `GET` operation is registered as well as a custom operation called `special`.
 The `special` operation reference the Symfony route named `book_special`.
 
-Note: For performance reasons API Platform is using the first operation (with GET method) defined in collectionOperations to generate the IRI for this resourceClass. This means that as long as you dont want to overwrite the IRI for this resourceClass by intention, the default collectionOperation called "get" should be the first operation defined inside collectionOperations.
+Note: API Platform uses the first operation (with `GET` method) defined in `collectionOperations` to generate the IRI for this resource class. This means that as long as you dont want to overwrite the IRI for this resource class by intention, the default collection operation associated with the `GET` method should be the first operation defined inside collection operations.
 
 ```php
 <?php


### PR DESCRIPTION
Users sometimes create custom collection operation and add it as first item of collectionOperation but dont do that with the intention to overwrite the default resource Class IRI. If the route path contains custom route params this results in an error though and debugging it is quite hard (need do make your way down into IriConverter to discover the custom route is used for router).