### PR TITLE
Minor changes to the Swagger documentation page

### DIFF
--- a/core/swagger.md
+++ b/core/swagger.md
@@ -70,8 +70,8 @@ final class SwaggerDecorator implements NormalizerInterface
 
 ## Using the Swagger Context
 
-Sometimes you may want to have additional information included in your Swagger documentation.
-The following configuration will provide additional context to your Swagger definitions:
+Sometimes you may want to change the information included in your Swagger documentation.
+The following configuration will give you total control over your Swagger definitions:
 
 ```php
 <?php
@@ -255,9 +255,9 @@ Change `/docs` to your desired URI you wish Swagger to be accessible on.
 You can also dump your current Swagger documentation using the provided command:
 
 ```
-$ docker-compose exe php bin/console api:swagger:export
+$ docker-compose exec php bin/console api:swagger:export
 # Swagger documentation in JSON format...
 
-$ docker-compose exe php bin/console api:swagger:export --yaml
+$ docker-compose exec php bin/console api:swagger:export --yaml
 # Swagger documentation in YAML format...
 ```


### PR DESCRIPTION
> The following configuration will provide additional context to your Swagger definitions
- In api-platform ^2.1 this is not the case. Defining a custom `swagger_context` has the effect of wiping out any default documentation. Therefore this wasn't being treated as "additional context" and should not be referred as such.

> docker-compose exe php
- Fixed the wrong docker compose command "exe" instead of "exec".