### PR TITLE
Remove obsolete informations

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -15,14 +15,6 @@ Now, go to the newly created `my-admin` directory:
 
     $ cd my-admin
 
-React and React DOM will be directly provided as dependencies of Admin On REST. As having different versions of React
-causes issues, remove `react` and `react-dom` from the `dependencies` section of the generated `package.json` file:
-
-```patch
--    "react": "^15.6.1",
--    "react-dom": "^15.6.1"
-```
-
 Finally, install the `@api-platform/admin` library:
 
     $ yarn add @api-platform/admin


### PR DESCRIPTION
admin-on-rest has moved react and react-dom to its **dev** dependencies since https://github.com/marmelab/admin-on-rest/commit/9836464ca275b1fbf84d932e27b4d7f3fb35d374#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L66

Following this step from the getting-started guide leads to compilation error (module missing from node_modules)