### PR TITLE
The IRI for a resource is generated from an itemOperation

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -486,7 +486,7 @@ automatically instantiated and injected, without having to declare it explicitly
 In the following examples, the built-in `GET` operation is registered as well as a custom operation called `special`.
 The `special` operation reference the Symfony route named `book_special`.
 
-Note: By default, API Platform uses the first `GET` operation defined in `collectionOperations` to generate the IRI for
+Note: By default, API Platform uses the first `GET` operation defined in `itemOperations` to generate the IRI for
 a resource class.
 
 Note: With custom operation, you will probably want to properly document it. See the [swagger](swagger.md) part of the documentation to do so.


### PR DESCRIPTION
From my experience, I always need to define a GET operation for the item to generate the IRI, not a collection operation. [This line of code](https://github.com/api-platform/core/blob/35edfb6ae999cf77e04caf81d9c33cbda9aa3890/src/Bridge/Symfony/Routing/IriConverter.php#L89) seems to confirm that.