### PR TITLE
Add an “About API versioning” cookbook page

### DIFF
--- a/core/api-versioning.md
+++ b/core/api-versioning.md
@@ -1,0 +1,7 @@
+# About API versioning
+
+API Platform does not provide any specific tooling for API versioning.
+
+The recommended way to do API versioning is to create a separate project.
+
+The subject has notably been discussed [here](https://github.com/api-platform/core/issues/45) and [here](https://github.com/api-platform/core/issues/972).

--- a/index.md
+++ b/index.md
@@ -123,6 +123,7 @@
     2. [Available Serializers](core/serialization.md#available-serializers)
     3. [Decorating a Serializer and Add Extra Data](core/serialization.md#decorating-a-serializer-and-add-extra-data)
 28. [Handling Data Transfer Objects (DTOs)](core/dto.md)
+29. [About API versioning](core/api-versioning.md)
 
 ## The Schema Generator Component: Generate Data Models from Open Vocabularies
 


### PR DESCRIPTION
Add a very basic page in core conveying this message:

> API versioning is not managed: recommended way is to create a new projet.

I’m a little concerned that this page is quite blunt, I would rather soften the message somehow.

Maybe something like “API versioning is not managed **for now**, the **current** recommended way is to create a new project”. But then I  would be concerned that it could be interpreted as some broken promise :woman_shrugging: 

closes #451 
