### PR TITLE
Updated the configuration.md file for the request_options parameter

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -161,6 +161,9 @@ api_platform:
           # URLs of the Varnish servers to purge using cache tags when a resource is updated.
           varnish_urls: []
 
+          # To pass options to the client charged with the request.
+          request_options: []
+
     # The list of exceptions mapped to their HTTP status code.
     exception_to_status:
         # With a status code.


### PR DESCRIPTION
Following the PR [#1699](https://github.com/api-platform/core/pull/1699), I updated the doc to add the request_option parameter.

As a reminder,  the request_options parameter allows to pass options to the client charged with the BAN request.