### PR TITLE
Add the exact docker command for the generator

### DIFF
--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -52,6 +52,8 @@ types:
 Run the generator with this config file as parameter:
 
     $ vendor/bin/schema generate-types api/src/ api/config/schema.yaml
+      
+> Using docker: `$ docker-compose exec php vendor/bin/schema generate-types src/ config/schema.yaml`
 
 The following classes will be generated:
 


### PR DESCRIPTION
When using docker the paths differ from the standard command where it is necessary to provide the api/ prefix.