### PR TITLE
Update getting-started.md - update phpdoc

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -54,7 +54,7 @@ class Product // The class name will be used to name exposed resources
     public $id;
 
     /**
-     * @param string $name A name property - this description will be available in the API documentation too.
+     * @var string $name A name property - this description will be available in the API documentation too.
      *
      * @ORM\Column
      * @Assert\NotBlank


### PR DESCRIPTION
Hi,

The phpdoc of the variable $name was [@]param instead of [@]var. (Other variables don't have it, so i decide to remove it)
http://docs.phpdoc.org/references/phpdoc/tags/param.html

And add the phpdoc to removeOffer.