### PR TITLE
Add a note about the `/api/` prefix

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -156,7 +156,7 @@ And start the built-in PHP server or the Symfony WebServerBundle:
 All JavaScript components are also [available as standalone libraries](https://github.com/api-platform?language=javascript)
 installable with NPM or Yarn.  
 
-**Note:** when installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `https://localhost/api/` to see the API Platform welcome page.
+**Note:** when installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `https://localhost/api/` to see the API documentation.
 
 ## It's Ready!
 

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -156,6 +156,8 @@ And start the built-in PHP server or the Symfony WebServerBundle:
 All JavaScript components are also [available as standalone libraries](https://github.com/api-platform?language=javascript)
 installable with NPM or Yarn.  
 
+**Note:** when installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `https://localhost/api/` to see the API Platform welcome page.
+
 ## It's Ready!
 
 Open `https://localhost` in your favorite web browser:


### PR DESCRIPTION
So, as a user, I don't see the Symfony welcome page.