### PR TITLE
Fixes #424 - Wrong Kernel Event / EventPriorities in Errors Example

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -43,7 +43,7 @@ final class ProductManager implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['checkProductAvailability', EventPriorities::POST_DESERIALIZE],
+            KernelEvents::VIEW => ['checkProductAvailability', EventPriorities::PRE_VALIDATE],
         ];
     }
 


### PR DESCRIPTION
Hi,

So I made a new PR with the correct branch (2.2).

It fixes the example that doesn't work because the `KernelEvents::REQUEST` returns a `GetResponseEvent` instead of the required `GetResponseForControllerResultEvent`.
So as suggested in the issue #424 it's changed to the first hook available in `KernelEvents::VIEW` to get a `GetResponseForControllerResultEvent` : `PRE_VALIDATE`.