### PR TITLE
[Core/Serialization] Use correct ContextAwareNormalizerInterface

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -405,7 +405,7 @@ The Normalizer class is a bit harder to understand because it has to make sure t
 
 namespace App\Serializer;
 
-class BookAttributeNormalizer implements NormalizerInterface, SerializerAwareInterface
+class BookAttributeNormalizer implements ContextAwareNormalizerInterface, SerializerAwareInterface
 {
     use SerializerAwareTrait;
 


### PR DESCRIPTION
Related to : https://github.com/api-platform/docs/blob/2.2/core/serialization.md#changing-the-serialization-context-on-a-per-item-basis

The class used in custom normalization example implements `NormalizerInterface` but the `supportsNormalization()` method is the one from the `ContextAwareNormalizerInterface`, and it must be this one to access `$context` variable and avoid call loops.

This doc is very valuable, thanks !