### PR TITLE
Fix routePrefix documentation

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -242,7 +242,9 @@ use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
  * ...
- * @ApiResource("attributes"={"routePrefix"="/library"})
+ * @ApiResource(attributes={"route_prefix"="/library"})
+ * or using the shorthand syntax:
+ * @ApiResource(routePrefix="/library")
  */
 class Book
 {

--- a/core/operations.md
+++ b/core/operations.md
@@ -232,7 +232,7 @@ In all the previous examples, you can safely remove the `method` because the met
 
 Sometimes it's also useful to put a whole resource into its own "namespace" regarding the URI. Let's say you want to
 put everything that's related to a `Book` into the `library` so that URIs become `library/book/{id}`. In that case
-you don't need to override all the operations to set the path but configure a `routePrefix` for the whole entity instead:
+you don't need to override all the operations to set the path but configure the `route_prefix` attribute for the whole entity instead:
 
 ```php
 <?php
@@ -241,9 +241,6 @@ you don't need to override all the operations to set the path but configure a `r
 use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
- * ...
- * @ApiResource(attributes={"route_prefix"="/library"})
- * or using the shorthand syntax:
  * @ApiResource(routePrefix="/library")
  */
 class Book
@@ -251,6 +248,8 @@ class Book
     //...
 }
 ```
+
+Alternatively, the more verbose attributes syntax can be used `@ApiResource(attributes={"route_prefix"="/library"})`
 
 ## Subresources
 


### PR DESCRIPTION
It needs to be either
```
@ApiResource(attributes={"route_prefix"="/library"})
```
or 
```
@ApiResource(routePrefix="/library")
```
to work correctly.