### PR TITLE
Copy paste error fix: filter -> order

### DIFF
--- a/core/default-order.md
+++ b/core/default-order.md
@@ -57,7 +57,7 @@ class Book
 }
 ```
 
-It's also possible to configure the default filter on an association property:
+It's also possible to configure the default order on an association property:
 
 ```php
 <?php


### PR DESCRIPTION
Seems like this is a copy paste error. This sentence describes `order`, not `filter`.