### PR TITLE
Fix fos_user provider for jwt example security.yaml

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -28,7 +28,7 @@ security:
 
     providers:
         fos_userbundle:
-            id: fos_user.user_provider.username
+            id: fos_user.user_provider.username_email
 
     firewalls:
         login:


### PR DESCRIPTION
Login firewall requires username_path email, therefore user_provider should utilize email field as well.

Without this change example is broken.