### PR TITLE
GraphQL: use the default port

### DIFF
--- a/core/graphql.md
+++ b/core/graphql.md
@@ -14,9 +14,11 @@ Once enabled, you have nothing to do: your schema describing your API is automat
 
 To enable GraphQL and GraphiQL interface in your API, simply require the [graphql-php](https://webonyx.github.io/graphql-php/) package using Composer and clear the cache one more time:
 
-    $ composer require webonyx/graphql-php && bin/console cache:clear
+```bash
+docker-compose exec php composer req webonyx/graphql-php && bin/console cache:clear
+```
 
-You can now use GraphQL at the endpoint: `http://localhost:8080/graphql`.
+You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 
 ## GraphiQL
 

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -16,7 +16,7 @@ To enable GraphQL and GraphiQL interface in your API, simply require the [graphq
 
     $ composer require webonyx/graphql-php && bin/console cache:clear
 
-You can now use GraphQL at the endpoint: `http://localhost/graphql`.
+You can now use GraphQL at the endpoint: `http://localhost:8080/graphql`.
 
 ## GraphiQL
 

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -646,7 +646,9 @@ ISBN isn't valid...
 Isn't API Platform a REST **and** GraphQL framework? That's true! GraphQL support isn't enabled by default, to add it we
 need to install the [graphql-php](https://webonyx.github.io/graphql-php/) library. Run the following command (the cache needs to be cleared twice):
 
-    $ docker-compose exec php composer req webonyx/graphql-php && bin/console cache:clear
+```bash
+docker-compose exec php composer req webonyx/graphql-php && bin/console cache:clear
+```
 
 You now have a GraphQL API! Open `https://localhost:8443/graphql` to play with it using the nice [GraphiQL](https://github.com/graphql/graphiql)
 UI that is shipped with API Platform:


### PR DESCRIPTION
To be in sync with the URL of the distribution