### PR TITLE
Fix config for custom swagger route

### DIFF
--- a/core/swagger.md
+++ b/core/swagger.md
@@ -268,7 +268,7 @@ api_platform:
 
 ```yaml
 # app/config/routes.yaml
-swagger_ui:
+api_doc:
     path: /docs
     controller: api_platform.swagger.action.ui
 ```


### PR DESCRIPTION
Fixes https://github.com/api-platform/docs/issues/458

The key needs to be `api_doc` to override the existing config for `/docs` in https://github.com/api-platform/core/blob/master/src/Bridge/Symfony/Bundle/Resources/config/routing/docs.xml.

At least to make the given example work. :)
Changing `/docs` to something else doesn't conflict with the existing config.

However, the reason why I tried to use the example was to disable the docs on `/` and only enable them on `/docs`