### PR TITLE
Corrected typo in BookContextBuilder example: admin_input vs admin:input

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -396,7 +396,7 @@ final class BookContextBuilder implements SerializerContextBuilderInterface
         $resourceClass = $context['resource_class'] ?? null;
         
         if ($resourceClass === Book::class && isset($context['groups']) && $this->authorizationChecker->isGranted('ROLE_ADMIN') && false === $normalization) {
-            $context['groups'][] = 'admin_input';
+            $context['groups'][] = 'admin:input';
         }
 
         return $context;


### PR DESCRIPTION
The serialization documentation section `Changing the Serialization Context Dynamically` defines a serialization group as `admin:input` in the entity exampe, however it was being added as `admin_input` in the `BookContextBuilder` example.

i.e. changed from:
```
$context['groups'][] = 'admin_input';
```

to:
```
$context['groups'][] = 'admin:input';
```