### PR TITLE
Added serialization config to complete the YAML format example.

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -118,6 +118,16 @@ App\Entity\Book:
             groups: ['write']
 ```
 
+```yaml
+# api/config/serialization/Book.yaml
+App\Entity\Book:
+    attributes:
+        name:
+            groups: ['read', 'write']
+        author:
+            groups: ['write']
+```
+
 In the previous example, the `name` property will be visible when reading (`GET`) the object, and it will also be available
 to write (`PUT/POST`).  The `author` property will be write-only; it will not be visible when serialized responses are 
 returned by the API.


### PR DESCRIPTION
The serialization groups section mentions "You can also use the YAML configuration format", but only shows the API Platform portion of the YAML format.

For developers choosing to define everything in YAML, they also need the `/config/serialization/Book.yaml` file to be defined.

In other discussions I've read on the subject, it's mentioned that the serialization component is already  documented elsewhere. I think it's important to deliver the config on a silver platter so there is nothing left for interpretation which may take the developer down a rabbit hole.