### PR TITLE
Getting Started external link broken

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -213,7 +213,7 @@ The API Platform's configuration (annotations, `YAML` or `XML`) only allow to co
 * The `denormalization_context` key will be passed as 4th argument of [the `Serializer::deserialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_deserialize)
 
 
-To configure the serialization groups of classes's properties, you must use directly [the Symfony Serializer's configuration files or annotations]( https://symfony.com/doc/current/components/serializer.html#attributes-groups).
+To configure the serialization groups of classes's properties, you must use directly [the Symfony Serializer's configuration files or annotations](https://symfony.com/doc/current/components/serializer.html#attributes-groups).
 
 **You're done!**
 


### PR DESCRIPTION
there's a whitespace causing the link for __'the Symfony Serializer's configuration files or annotations.'__ to be rendered not absolute on api-platform.com. github is more forgiving so the link works here when rendered as markdown. 

See broken link: https://api-platform.com/docs/core/getting-started