### PR TITLE
Feature/document api respond parameters

### DIFF
--- a/core/dto.md
+++ b/core/dto.md
@@ -9,6 +9,7 @@ someone has lost its password.
 So let's create a basic DTO for this request:
 
 ```php
+<?php
 // api/src/Api/Dto/ForgotPasswordRequest.php
 
 namespace App\Api\Dto;
@@ -121,4 +122,230 @@ services:
             - '@app.manager.user'
         # Uncomment the following line only if you don't use autoconfiguration
         #tags: [ 'kernel.event_subscriber' ]
+```
+
+## How to use a DTO for Reading
+
+Sometimes, you need to retrieve data not related to an Entity.
+For example, the application can send the
+[list of supported locales](https://github.com/symfony/demo/blob/master/config/services.yaml#L6)
+and the default locale.
+
+So let's create a basic DTO for this datas:
+
+```php
+<?php
+// api/src/Dto/LocalesList.php
+
+namespace App\Dto;
+
+final class LocalesList
+{
+    /**
+     * @var array
+     */
+    public $locales;
+
+    /**
+     * @var string
+     */
+    public $defaultLocale;
+}
+```
+
+And create a controller to send them:
+
+```php
+<?php
+// api/src/Controller/LocaleController.php
+
+namespace App\Controller;
+
+use App\DTO\LocalesList;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LocaleController extends AbstractController
+{
+    /**
+     * @Route(
+     *     path="/api/locales",
+     *     name="api_get_locales",
+     *     methods={"GET"},
+     *     defaults={
+     *          "_api_respond"=true,
+     *          "_api_normalization_context"={"api_sub_level"=true}
+     *     }
+     * )
+     */
+    public function __invoke(): LocalesDTO
+    {
+        $response = new LocalesList();
+        $response->locales = explode('|', $this->getParameter('app_locales'));
+        $response->defaultLocale = $this->getParameter('locale');
+
+        return $response;
+    }
+}
+```
+
+As you can see, the controller don't return a `Response`, but the object directly.
+Behind, the `SerializeListener` catch the response, and thanks to `_api_respond`
+params, serialize the object correctly.
+To deal with arrays, we have to set `"_api_normalization_context"={"api_sub_level"=true}`
+to avoid ApiPlatform Serializers to search an ApiResourceClass not declared.
+
+### Adding this custom DTO reading in Swagger documentation.
+
+By default, ApiPlatform Swagger UI integration will display documentation only
+for ApiResource operations.
+In this case, our DTO is not declared as ApiResource, so no documentation will
+be displayed.
+
+There is two solutions to achieve that:
+
+#### 1. Use Swagger decorator
+
+By following the doc about [Override the Swagger Documentation](swagger.md##overriding-the-swagger-documentation)
+and adding the ability to retrieve a `_api_swagger_context` in route
+parameters, you should be able to display your custom endpoint.
+
+```php
+<?php
+// src/App/Swagger/ControllerSwaggerDecorator
+
+namespace App\Swagger;
+
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+final class ControllerSwaggerDecorator implements NormalizerInterface
+{
+    private $decorated;
+
+    private $router;
+
+    public function __construct(
+        NormalizerInterface $decorated,
+        RouterInterface $router
+    ) {
+        $this->decorated = $decorated;
+        $this->router = $router;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decorated->normalize($object, $format, $context);
+        $mimeTypes = $object->getMimeTypes();
+        foreach ($this->router->getRouteCollection()->all() as $routeName => $route) {
+            $swaggerContext = $route->getDefault('_api_swagger_context');
+            if (!$swaggerContext) {
+                // No swagger_context set, continue
+                continue;
+            }
+
+            $methods = $route->getMethods();
+            $uri = $route->getPath();
+
+            foreach ($methods as $method) {
+                // Add available mimesTypes
+                $swaggerContext['produces'] ?? $swaggerContext['produces'] = $mimeTypes;
+
+                $docs['paths'][$uri][\strtolower($method)] = $swaggerContext;
+            }
+        }
+
+        return $docs;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->decorated->supportsNormalization($data, $format);
+    }
+}
+```
+
+Register it as a service:
+
+```yaml
+#config/services.yaml
+# ...
+    'App\Swagger\ControllerSwaggerDecorator':
+        decorates: 'api_platform.swagger.normalizer.documentation'
+        arguments: [ '@App\Swagger\ControllerSwaggerDecorator.inner']
+        autoconfigure: false
+```
+
+And finally, complete the Route annotation of your controller like this:
+
+```php
+<?php
+// api/src/Controller/LocaleController.php
+
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Swagger\Annotations as SWG;
+
+//...
+
+    /**
+     * @Route(
+     *     path="/api/locales",
+     *     name="api_get_locales",
+     *     methods={"GET"},
+     *     defaults={
+     *          "_api_respond"=true,
+     *          "_api_normalization_context"={"api_sub_level"=true},
+     *          "_api_swagger_context"={
+     *              "tags"={"Locales"},
+     *              "summary"="Retrieve locales availables",
+     *              "parameters"={},
+     *              "responses"={
+     *                  "200"={
+     *                      "description"="List of available locales and the default locale",
+     *                      "schema"={
+     *                          "type"="object",
+     *                          "properties"={
+     *                              "defaultLocale"={"type"="string"},
+     *                          }
+     *                      }
+     *                  }
+     *              }
+     *          }
+     *     }
+     * )
+     */
+    public function __invoke()
+```
+
+#### 2. Use [NelmioApiDoc](nelmio-api-doc.md)
+
+With NelmioApiDoc, you should be able to add annotations to your controllers :
+
+```php
+<?php
+// api/src/Controller/LocaleController.php
+
+use Nelmio\ApiDocBundle\Annotation\Model;
+use Swagger\Annotations as SWG;
+
+//...
+
+    /**
+     * @Route(
+     *     path="/api/locales",
+     *     name="api_get_locales",
+     *     methods={"GET"},
+     *     defaults={
+     *          "_api_respond"=true,
+     *          "_api_normalization_context"={"api_sub_level"=true}
+     *     }
+     * )
+     * @SWG\Tag(name="Locales")
+     * @SWG\Response(
+     *     response=200,
+     *     description="List of available locales and the default locale",
+     *     @SWG\Schema(ref=@Model(type=LocalesList::class)),
+     * )
+     */
+    public function __invoke()
 ```

--- a/core/dto.md
+++ b/core/dto.md
@@ -1,6 +1,6 @@
 # Handling Data Transfer Objects (DTOs)
 
-## How to use a DTO for Writing
+## How to Use a DTO for Writing
 
 Sometimes it's easier to use a DTO than an Entity when performing simple
 operation. For example, the application should be able to send an email when
@@ -124,9 +124,9 @@ services:
         #tags: [ 'kernel.event_subscriber' ]
 ```
 
-## How to use a DTO for Reading
+## How to Use a DTO for Reading
 
-Sometimes, you need to retrieve data not related to an Entity.
+Sometimes, you need to retrieve data not related to an entity.
 For example, the application can send the
 [list of supported locales](https://github.com/symfony/demo/blob/master/config/services.yaml#L6)
 and the default locale.
@@ -189,13 +189,14 @@ class LocaleController extends AbstractController
 }
 ```
 
-As you can see, the controller don't return a `Response`, but the object directly.
-Behind, the `SerializeListener` catch the response, and thanks to `_api_respond`
-params, serialize the object correctly.
-To deal with arrays, we have to set `"_api_normalization_context"={"api_sub_level"=true}`
-to avoid ApiPlatform Serializers to search an ApiResourceClass not declared.
+As you can see, the controller doesn't return a `Response`, but the data object directly.
+Behind the scene, the `SerializeListener` catch the response, and thanks to the `_api_respond`
+flag, it serializes the object correctly.
 
-### Adding this custom DTO reading in Swagger documentation.
+To deal with arrays, we have to set the `api_sub_level` context option to `true`.
+It prevents API Platform's normalizers to look for a non-existing class marked as an API resource.
+
+### Adding this Custom DTO reading in Swagger Documentation.
 
 By default, ApiPlatform Swagger UI integration will display documentation only
 for ApiResource operations.
@@ -204,7 +205,7 @@ be displayed.
 
 There is two solutions to achieve that:
 
-#### 1. Use Swagger decorator
+#### Use Swagger Decorator
 
 By following the doc about [Override the Swagger Documentation](swagger.md##overriding-the-swagger-documentation)
 and adding the ability to retrieve a `_api_swagger_context` in route
@@ -317,7 +318,7 @@ use Swagger\Annotations as SWG;
     public function __invoke()
 ```
 
-#### 2. Use [NelmioApiDoc](nelmio-api-doc.md)
+#### Use [NelmioApiDoc](nelmio-api-doc.md)
 
 With NelmioApiDoc, you should be able to add annotations to your controllers :
 

--- a/core/events.md
+++ b/core/events.md
@@ -106,7 +106,7 @@ Constant           | Event             | Priority |
 `PRE_RESPOND`      | `kernel.view`     | 9        |
 `POST_RESPOND`     | `kernel.response` | 0        |
 
-Some of those built-in listeners can be enabled/disabled by setting request attributes ([for instance in the `defaults` 
+Some of those built-in listeners can be enabled/disabled by setting request attributes ([for instance in the `defaults`
 attribute of an operation](operations.md#recommended-method)):
 
 Listener              | Parameter      | Values         | Default | Description                            |
@@ -114,3 +114,4 @@ Listener              | Parameter      | Values         | Default | Description
 `ReadListener`        | `_api_receive` | `true`/`false` | `true`  | set to `false` to disable the listener |
 `DeserializeListener` | `_api_receive` | `true`/`false` | `true`  | set to `false` to disable the listener |
 `ValidateListener`    | `_api_receive` | `true`/`false` | `true`  | set to `false` to disable the listener |
+`SerializeListener`   | `_api_respond` | `true`/`false` | `true`  | set to `false` to disable the listener |


### PR DESCRIPTION
Hello,

As discussed in Slack, I create this PR to document a little bit the `_api_respond` parameters. I added it in the events page, but I don't know if it's enough or should I add more info.

I also add a big part on the DTO page, to explain how use it without an `ApiResource` declared.

My initial need was to retrieve a Settings custom in my application, but I didn't think it was a good example. 
I thought also to propose the retrievement of the `kernel.environment` parameter, but I didn't find it pertinent. 
Finally, browsing the [symfony/demo](https://github.com/symfony/demo) repository, I found the Locales list, so I based my example on it. 
Let me know if the example is pertinent or not. 

Thanks all of you for your awesome works !