### PR TITLE
Fix typo.

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -450,7 +450,7 @@ You can control the path of subresources with the `path` option of the `subresou
  * ...
  * @ApiResource(
  *      subresourceOperations={
- *          "answer_get_subresource"= {
+ *          "answer_get_subresource"={
  *              "method"="GET",
  *              "path"="/questions/{id}/all-answers"
  *          },


### PR DESCRIPTION
This generates a warning when copy-pasting. 

```
Warning: Unterminated comment starting line 23 in vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/TokenParser.php on line 56
```