### PR TITLE
Update serialization.md

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -86,7 +86,7 @@ class Book
     /**
      * @Groups("write")
      */
-    private $author;
+    public $author;
 
     // ...
 }


### PR DESCRIPTION
It seems that you cant have $author as private.
If $author is private, without setter he will be readonly so the example fail and if you create a setter the groups have to be on the methods.