### PR TITLE
Custom operation: enhancing the visibility of an important remark

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -561,7 +561,8 @@ This action will be automatically registered as a service (the service name is t
 
 API Platform automatically retrieves the appropriate PHP entity using the data provider then deserializes user data in it,
 and for `POST` and `PUT` requests updates the entity with data provided by the user.
-By convention, the action's parameter must be called `$data`.
+
+**Warning: the `__invoke()` method parameter MUST be called `$data`**, otherwise, it will not be filled correctly!
 
 Services (`$myService` here) are automatically injected thanks to the autowiring feature. You can type-hint any service
 you need and it will be autowired too.

--- a/core/operations.md
+++ b/core/operations.md
@@ -562,7 +562,7 @@ This action will be automatically registered as a service (the service name is t
 API Platform automatically retrieves the appropriate PHP entity using the data provider then deserializes user data in it,
 and for `POST` and `PUT` requests updates the entity with data provided by the user.
 
-**Warning: the `__invoke()` method parameter MUST be called `$data`**, otherwise, it will not be filled correctly!
+**Warning: the `__invoke()` method parameter [MUST be called `$data`](https://symfony.com/doc/current/routing/extra_information.html)**, otherwise, it will not be filled correctly!
 
 Services (`$myService` here) are automatically injected thanks to the autowiring feature. You can type-hint any service
 you need and it will be autowired too.


### PR DESCRIPTION
The information about necessity that the `__invoke()` method’s parameter must be called `$data` was easy to miss in the large amount of information. This proposal makes it more visible by putting it in its own paragraph and by writing it in bold.