### PR TITLE
Update file-upload.md

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -218,6 +218,7 @@ We first need to edit our Book resource, and add a new property called `image`.
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Core\Annotation\ApiProperty;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;


### PR DESCRIPTION
Fixes missing import of ApiProperty class in "Linking a MediaObject Resource to Another Resource" example.