### PR TITLE
Add the cache clear command to the Graphql section

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -643,9 +643,9 @@ ISBN isn't valid...
 ## Adding GraphQL Support
 
 Isn't API Platform a REST **and** GraphQL framework? That's true! GraphQL support isn't enabled by default, to add it we
-need to install the [graphql-php](https://webonyx.github.io/graphql-php/) library. Run the following command:
+need to install the [graphql-php](https://webonyx.github.io/graphql-php/) library. Run the following command (the cache needs to be cleared twice):
 
-    $ docker-compose exec php composer req webonyx/graphql-php
+    $ docker-compose exec php composer req webonyx/graphql-php && bin/console cache:clear
 
 You now have a GraphQL API! Open `https://localhost:8443/graphql` to play with it using the nice [GraphiQL](https://github.com/graphql/graphiql)
 UI that is shipped with API Platform:


### PR DESCRIPTION
Fix issue https://github.com/api-platform/docs/issues/602 
Following the instructions on the GraphQL part, the route ```/graphql``` is not found after requiring graphql-php. So I added the cache:clear command in order to fix it. 