### PR TITLE
use for ex "/api_doc" instead "/doc" for path

### DIFF
--- a/core/swagger.md
+++ b/core/swagger.md
@@ -282,7 +282,7 @@ api_platform:
 ```yaml
 # app/config/routes.yaml
 swagger_ui:
-    path: /docs
+    path: /api_doc
     controller: api_platform.swagger.action.ui
 ```
 


### PR DESCRIPTION
In case you need to "Manually Registering the Swagger UI Controller", use another path than "/doc" because that make conflict with Symfony and produce a "Serialization for the format html is not supported." error.