### PR TITLE
Fix typo on subresourceOperations.access_control

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -468,19 +468,18 @@ The `subresourceOperations` attribute also allows you to add an access control o
 
 ```php
 <?php
-// api/src/Entity/Question.php
+// api/src/Entity/Answer.php
 
 /**
  * ...
  * @ApiResource(
  *     subresourceOperations={
- *          "answer_get_subresource"= {
- *              "method"="GET",
+ *          "api_questions_answer_get_subresource"= {
  *              "access_control"="has_role('ROLE_AUTHENTICATED')"
  *          }
  *      }
  * )
- class Question
+ class Answer
  {
  }
 ```


### PR DESCRIPTION
Given, the following entities:
```php
/**
 * @ApiResource(subresourceOperations={
 *     "quizzes_get_subresource"={
 *         "access_control"="is_granted('ROLE_ADMIN')"
 *     }
 * })
 */
class User
{
    // ...
    /**
     * @ApiSubresource
     */
    private $quizzes;
}
```
```php
/**
 * @ApiResource
 */
class UserQuiz
```
Requesting `/users/{id}/quizzes` should be restricted to `ROLE_ADMIN` users, but anybody can access it. After some searches, the `access_control` option must be declared in the `subresourceOperations` key in the subresource.