### PR TITLE
add @ORM\Table(name="fos_user") to user entity

### DIFF
--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -59,6 +59,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity
+ * @ORM\Table(name="fos_user")
  * @ApiResource(
  *     normalizationContext={"groups"={"user", "user:read"}},
  *     denormalizationContext={"groups"={"user", "user:write"}}


### PR DESCRIPTION
this is to not use the default protected word User for an sql table https://symfony.com/doc/master/bundles/FOSUserBundle/index.html#a-doctrine-orm-user-class