### PR TITLE
Config file path correction

### DIFF
--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -22,7 +22,7 @@ If you are using the API Platform Standard Edition, you will need to enable the 
 configuration options:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# api/config/packages/framework.yaml
 framework:
     form: { enabled: true }
 ```


### PR DESCRIPTION
The framework form configuration should be in the `api/config/packages/framework.yaml` file, not `api/config/packages/api_platform.yaml`