### PR TITLE
Replace @type tag by @var tag in the phpdoc

### DIFF
--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -20,7 +20,7 @@ use App\Uuid;
  */
 final class Person {
     /**
-     * @type Uuid
+     * @var Uuid
      * @ApiProperty(identifier=true)
      */
     public $code;


### PR DESCRIPTION
With the @type tag, there is the error 

```
[Semantical Error] The annotation "@type" in property App\Entity\Person::$code was never imported. Did you maybe forget to add a "use" statement for this annotation?
```