### PR TITLE
Call Request::isMethodSafe(false) instead of Request::isMethodSafe()

### DIFF
--- a/core/form-data.md
+++ b/core/form-data.md
@@ -40,7 +40,7 @@ final class DeserializeListener
 
     public function onKernelRequest(GetResponseEvent $event): void {
         $request = $event->getRequest();
-        if ($request->isMethodSafe() || $request->isMethod(Request::METHOD_DELETE)) {
+        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
             return;
         }
 


### PR DESCRIPTION
Solving #690 

According to https://github.com/symfony/http-foundation/blob/master/Request.php#L1429, `isMethodSafe` should be passed `false` as an argument.