### PR TITLE
[ADMIN] Add missing code in example

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -83,6 +83,10 @@ const myApiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoin
     const books = api.resources.find(({ name }) => 'books' === name);
     const description = books.fields.find(f => 'description' === f.name);
 
+    description.field = props => (
+      <RichTextField {...props} source="description" />
+    );
+
     description.input = props => (
       <RichTextInput {...props} source="description" />
     );


### PR DESCRIPTION
Must've been forgotten:
- `import { RichTextField } from 'react-admin';` is imported but never actually used
- "The `field` property of the `Field` class allows to set the component used to render a property in list and show screens." - however, the field property is never set

Code was validated to work.