### PR TITLE
automatically join dose not need fetch=eager

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -292,8 +292,7 @@ The generated JSON using previous settings is below:
 }
 ```
 
-In order to optimize such embedded relations, the default Doctrine data provider will automatically join entities on relations
-marked as [`EAGER`](http://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/reference/annotations-reference.html#manytoone).
+These optimization will be done automatically, if one of the related objects's properties can be normalize(properties dose not have different validation groups).
 This avoids the need for extra queries to be executed when serializing the related objects.
 
 ### Denormalization


### PR DESCRIPTION
These optimization will be done automatically, if one of the related objects's properties can be normalize.

i am sorry, i can not speak english good, maybe we should ignore this pull request and someone rewrite this part of docs