### PR TITLE
Wrong exemple file name

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -26,7 +26,7 @@ final class ProductNotFoundException extends \Exception
 
 ```php
 <?php
-// src/EventSubscriber/CartManager.php
+// src/EventSubscriber/ProductManager.php
 
 namespace App\EventSubscriber;
 


### PR DESCRIPTION
The name of the class is `CartManager` so I renamed `ProductManager.php` to `CartManager.php`