### PR TITLE
[Swagger] Don't disable for changing location

### DIFF
--- a/core/swagger.md
+++ b/core/swagger.md
@@ -348,17 +348,7 @@ Again, you can use the `openapi_context` key instead of the `swagger_context` on
 
 ## Changing the Location of Swagger UI
 
-Sometimes you may want to have the API at one location, and the Swagger UI at a different location. This can be done by disabling the Swagger UI from the API Platform configuration file and manually adding the Swagger UI controller.
-
-### Disabling Swagger UI or of ReDoc
-
-```yaml
-# api/config/packages/api_platform.yaml
-api_platform:
-    # ...
-    enable_swagger_ui: false
-    enable_re_doc: false
-```
+Sometimes you may want to have the API at one location, and the Swagger UI at a different location. This can be done by manually adding the Swagger UI controller.
 
 ### Manually Registering the Swagger UI Controller
 
@@ -370,6 +360,18 @@ swagger_ui:
 ```
 
 Change `/docs` to your desired URI you wish Swagger to be accessible on.
+
+## Disabling Swagger UI or of ReDoc
+
+If you don't want expose the API documentation, this can be done by disabling the Swagger UI from the API Platform configuration 
+
+```yaml
+# api/config/packages/api_platform.yaml
+api_platform:
+    # ...
+    enable_swagger_ui: false
+    enable_re_doc: false
+```
 
 ## Overriding the UI Template
 


### PR DESCRIPTION
In a fresh install of ApiPlatform 2.4, I tried to change SwaggerUI location to /swagger

Following the docs give me this error : 

```
Controller "api_platform.swagger.action.ui" does neither exist as service nor as class
```

It seems that there is no need to disable the UI in configuration.


This is my configuration files and all work fine.
```yaml
# config/packages/api_platform.yaml
api_platform:
    mapping:
        paths: ['%kernel.project_dir%/src/Entity']

    enable_swagger_ui: true
    enable_re_doc: false

# config/routes/api_platform.yaml
api_platform:
    resource: .
    type: api_platform
    prefix: /

api_doc:
    path: /swagger
    controller: api_platform.swagger.action.ui
```