### PR TITLE
Add a tip to use MakerBundle to create resources

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -143,6 +143,12 @@ class Offer
 It is the minimal configuration required to expose `Product` and `Offer` entities as JSON-LD documents through an hypermedia
 web API.
 
+**Tip**: if you create your entities with Symfony's [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html), you can also create your API resource entities with the `--api-resource` argument:
+
+```sh
+php bin/console make:entity --api-resource
+```
+
 If you are familiar with the Symfony ecosystem, you noticed that entity classes are also mapped with Doctrine ORM annotations
 and validation constraints from [the Symfony Validator Component](http://symfony.com/doc/current/book/validation.html).
 This isn't mandatory. You can use [your preferred persistence](data-providers.md) and [validation](validation.md) systems.

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -145,7 +145,7 @@ web API.
 
 **Tip**: if you create your entities with Symfony's [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html), you can also create your API resource entities with the `--api-resource` argument:
 
-```sh
+```bash
 php bin/console make:entity --api-resource
 ```
 

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -143,10 +143,10 @@ class Offer
 It is the minimal configuration required to expose `Product` and `Offer` entities as JSON-LD documents through an hypermedia
 web API.
 
-**Tip**: if you create your entities with Symfony's [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html), you can also create your API resource entities with the `--api-resource` argument:
+**Tip**: you can also use Symfony [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html) thanks to the `--api-resource` option:
 
 ```bash
-php bin/console make:entity --api-resource
+docker-compose exec php bin/console make:entity --api-resource
 ```
 
 If you are familiar with the Symfony ecosystem, you noticed that entity classes are also mapped with Doctrine ORM annotations

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -143,12 +143,6 @@ class Offer
 It is the minimal configuration required to expose `Product` and `Offer` entities as JSON-LD documents through an hypermedia
 web API.
 
-**Tip**: you can also use Symfony [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html) thanks to the `--api-resource` option:
-
-```bash
-docker-compose exec php bin/console make:entity --api-resource
-```
-
 If you are familiar with the Symfony ecosystem, you noticed that entity classes are also mapped with Doctrine ORM annotations
 and validation constraints from [the Symfony Validator Component](http://symfony.com/doc/current/book/validation.html).
 This isn't mandatory. You can use [your preferred persistence](data-providers.md) and [validation](validation.md) systems.

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -348,6 +348,12 @@ class Review
 }
 ```
 
+**Tip**: you can also use Symfony [MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html) thanks to the `--api-resource` option:
+
+```bash
+docker-compose exec php bin/console make:entity --api-resource
+```
+
 As you can see there are two typical PHP objects with the corresponding PHPDoc (note that entities's and properties's descriptions
 included in their PHPDoc will appear in the API documentation).
 


### PR DESCRIPTION
When API Platform is installed, an argument for Symfony MakerBundle's `make:entity` command is added to add some default configurations for API resources.
It looks like this tip is not documented, so this PR adds this information to the _Getting Started_ page.