### PR TITLE
Update swagger.md - Problem with decoration

### DIFF
--- a/core/swagger.md
+++ b/core/swagger.md
@@ -35,7 +35,7 @@ $ docker-compose exec php bin/console api:openapi:export --output=swagger_docs.j
 ## Overriding the OpenAPI Specification
 
 Symfony allows to [decorate services](https://symfony.com/doc/current/service_container/service_decoration.html), here we
-need to decorate `api_platform.swagger.normalizer.documentation`.
+need to decorate `api_platform.swagger.normalizer.api_gateway` (which is already decorating the initial service `api_platform.swagger.normalizer.documentation`).
 
 In the following example, we will see how to override the title of the Swagger documentation and add a custom filter for
 the `GET` operation of `/foos` path
@@ -44,7 +44,7 @@ the `GET` operation of `/foos` path
 # api/config/services.yaml
 services:
     'App\Swagger\SwaggerDecorator':
-        decorates: 'api_platform.swagger.normalizer.documentation'
+        decorates: 'api_platform.swagger.normalizer.api_gateway'
         arguments: [ '@App\Swagger\SwaggerDecorator.inner' ]
         autoconfigure: false
 ```


### PR DESCRIPTION
Hi guys,

Following the documentation, my decoration of the `api_platform.swagger.normalizer.documentation` service was not working and I figure out that there was another service already decorating this normalizer with a higher priority: `api_platform.swagger.normalizer.api_gateway` (see https://github.com/api-platform/core/blob/5c8820d2ccb1ffb584a668469918477dda6c2d90/src/Bridge/Symfony/Bundle/Resources/config/swagger.xml#L37).

Because decorating `api_platform.swagger.normalizer.api_gateway` does not _sound_ logical to modify the documentation, another solution would be to keep decorating `api_platform.swagger.normalizer.documentation` and add a tag with a higher priority (but loosing the api_gateway feature).

So maybe, there is a much important work on the core regarding this point, I let you the judge of that 👨‍⚖️ 

Jérémy.