### PR TITLE
Add missing allow_plain_identifiers option to conf reference

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -24,6 +24,9 @@ api_platform:
     # Specify a path name generator to use.
     path_segment_name_generator: 'api_platform.path_segment_name_generator.underscore'
 
+    # Allow using plain IDs for JSON format
+    allow_plain_identifiers: false
+
     eager_loading:
         # To enable or disable eager loading.
         enabled: true


### PR DESCRIPTION
Adds `allow_plain_identifiers` option to configuration reference.