### PR TITLE
Clean serialization incomplete informations from getting started section

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -214,13 +214,7 @@ api_platform:
             - '%kernel.project_dir%/config/api_platform' # yaml or xml directory configuration
 ```
 
-The API Platform's configuration (annotations, `YAML` or `XML`) only allow to configure the context passed to the Symfony Serializer:
-
-* The `normalization_context` key will be passed as 3rd argument of [the `Serializer::serialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_serialize)
-* The `denormalization_context` key will be passed as 4th argument of [the `Serializer::deserialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_deserialize)
-
-
-To configure the serialization groups of classes's properties, you must use directly [the Symfony Serializer's configuration files or annotations](https://symfony.com/doc/current/components/serializer.html#attributes-groups).
+If you want to serialize only a subset of your data, please refer to the [Serialization documentation](serialization.md).
 
 **You're done!**
 

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -142,8 +142,11 @@ In the previous example, the `name` property will be visible when reading (`GET`
 to write (`PUT/POST`). The `author` property will be write-only; it will not be visible when serialized responses are 
 returned by the API.
 
-Internally, API Platform passes the value of the `normalization_context` to the Symfony Serializer during the normalization
-process; `denormalization_context` is passed during denormalization (writing).
+Internally, API Platform passes the value of the `normalization_context` as the 3rd argument of [the `Serializer::serialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_serialize) during the normalization
+process; `denormalization_context` is passed as the 4th argument of [the `Serializer::deserialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_deserialize) during denormalization (writing).
+
+To configure the serialization groups of classes's properties, you must use directly [the Symfony Serializer's configuration files or annotations](https://symfony.com/doc/current/components/serializer.html#attributes-groups).
+
 
 In addition to the `groups` key, you can configure any Symfony Serializer option through the `$context` parameter
 (e.g. the `enable_max_depth`key when using [the `@MaxDepth` annotation](https://symfony.com/doc/current/components/serializer.html#handling-serialization-depth)).


### PR DESCRIPTION
The serialization part of the "getting started" section was partial and unuseful. I think it has been moved some time ago but every time I need to find the (de)normalization context, I'm confused by the getting started page !

I replaced it by a link to the serialization page moved the useful links on argument passed to `serialize` / `deserialize` function in the serialization page.

Thanks