### PR TITLE
Invalid tag: normalizer should be denormalizer

### DIFF
--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -98,11 +98,11 @@ final class UuidNormalizer implements DenormalizerInterface
 }
 ```
 
-Tag this service as a `api_platform.identifier.normalizer`:
+Tag this service as a `api_platform.identifier.denormalizer`:
 
 ```xml
   <service id="App\Identifier\UuidNormalizer" class="App\Identifier\UuidNormalizer" public="false">
-      <tag name="api_platform.identifier.normalizer" />
+      <tag name="api_platform.identifier.denormalizer" />
   </service>
 ```
 
@@ -110,7 +110,7 @@ Tag this service as a `api_platform.identifier.normalizer`:
 services:
     App\Identifier\UuidNormalizer:
         tags:
-            - { name: api_platform.identifier.normalizer }
+            - { name: api_platform.identifier.denormalizer }
 ```
 
 Your `PersonDataProvider` will now work as expected!


### PR DESCRIPTION
The document says to tag the service with  `api_platform.identifier.normalizer` but this should be `api_platform.identifier.denormalizer` in order to work correctly.