### PR TITLE
Fix bugs in Managing Files and Images code

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -149,16 +149,8 @@ const myApiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoin
               src: value
             });
 
-            field.field = (
-              <FunctionField
-                key={field.name}
-                render={
-                  record => (
-                    <ImageField key={field.name} record={record} source={`${field.name}.src`}/>
-                  )
-                }
-                source={field.name}
-              />
+            field.field = props => (
+              <ImageField {...props} source={`${field.name}.src`} />
             );
 
             field.input = (
@@ -168,9 +160,9 @@ const myApiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoin
             );
 
             field.normalizeData = value => {
-              if (value[0] && value[0].rawFile instanceof File) {
+              if (value && value.rawFile instanceof File) {
                 const body = new FormData();
-                body.append('file', value[0].rawFile);
+                body.append('file', value.rawFile);
 
                 return fetch(`${entrypoint}/images/upload`, { body, method: 'POST' })
                   .then(response => response.json());


### PR DESCRIPTION
As mentioned in the issue https://github.com/api-platform/admin/issues/146, the code proposed in the documention to handle file upload is not fully working.  
  
In this PR, I removed the useless `<FunctionField>` component. Indeed, I see no interest using it.
Other modifications don't require to be explained (minor fixes such as `value` instead of `value[0]`).  

---

Nevertheless, the following lines (picked from the doc) need to be discussed :  
  
```javascript  
field.normalizeData = value => {  
	if (value[0] && value[0].rawFile instanceof File) {  
		const body = new FormData();  
		body.append('file', value[0].rawFile);  
		  
		return fetch(`${entrypoint}/images/upload`, { body, method: 'POST' })  
		.then(response => response.json());  
	}  
  
return value.src;  
};  
``` 
 
 This part of code is responsible of adding a new request to upload the file. When you click on the creation button, it first sends the file to `/images/upload`. Then, the usual request `/images` (the one for each creation entity) is executed.

It could be resumed with the following graph: 

![image](https://user-images.githubusercontent.com/29781702/53271929-260dcb80-36f0-11e9-8cf9-10356a6c4d27.png)

**It's really important to understand that there are two requests when clicking on the creation button.**
  
However, the documentation of [how to handle file upload in the API Platform back](https://api-platform.com/docs/core/file-upload/#handling-file-upload) is not corresponding to the strategy used in the admin interface.  

Let's see why in different points:  
  
- If we use the previous code in the admin interface with the [Image](https://api-platform.com/docs/core/file-upload/#configuring-the-entity-receiving-the-uploaded-file) class, an error will occur while doing the second request as the file attribute will be null (because the code only edits the rendering of the `contentUrl` attribute).  
We must remove the `@Assert\NotNull()` annotation.
  
- Now, if we try again in the admin interface to upload a file again, two instances of the [Image](https://api-platform.com/docs/core/file-upload/#configuring-the-entity-receiving-the-uploaded-file) class will be saved in the database (as there are two requests). The first one is the one which uploads the file as desired but the second one is empty. Also, the user is redirected to the page of the last image instance (the empty one, so).  
We must then change the condition to:
```php
if ($form->isSubmitted() && $form->isValid() && $image->file != null) {
```
and replace:
```php
throw new ValidationException($this->validator->validate($mediaObject));
```
by:
```php
return $this->imageManager->getLastInsert();
```

It's only now that the whole photo upload system works! 🎉 

Do I need to do a PR to modify the documentation of this [page](https://api-platform.com/docs/core/file-upload/#handling-file-upload) or just add a note in the admin documentation part? 
Maybe an easier solution could be proposed to handle file upload?

*I got many difficulties to explain the problem in this PR in writing. Don't hesitate to ask me questions if I haven't been clear on some points.*
