### PR TITLE
Fix blackfire installation documentation

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -374,8 +374,9 @@ To configure Blackfire.io follow these simple steps:
 ```dockerfile
         RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
             && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
-            && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
-            && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+            && mkdir -p /tmp/blackfire \
+            && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \                        
+            && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
             && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini
 ```
 


### PR DESCRIPTION
The way the installtion is setup permissions for */tmp* would be changed.
Making a subdirectory and performing installation there is also the recommended way on the official page: 
https://blackfire.io/docs/integrations/docker

Fun Fact: Installing blackfire the old way breaks some api-platform installations as big requests can't be buffered in /tmp anymore.