### PR TITLE
Correct the project directory from api to bookshop-api the example project 

### DIFF
--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -15,9 +15,7 @@ If you don't already have one, [create an account on Heroku](https://signup.hero
 toolbelt](https://devcenter.heroku.com/articles/getting-started-with-php#set-up). We're guessing you already
 have a working install of [Composer](http://getcomposer.org). Perfect, we will need it.
 
-Create a new API Platform project as usual:
-
-    composer create-project api-platform/api-platform
+Create a new [API Platform project](distribution/index.md#using-symfony-flex-and-composer-advanced-users) which will be used in the rest of this example 
 
 Heroku relies on [environment variables](https://devcenter.heroku.com/articles/config-vars) for its configuration. Regardless
 of what provider you choose for hosting your application, using environment variables to configure your production environment
@@ -52,7 +50,7 @@ The file also tells the Heroku deployment system to build a PHP container and to
 We are almost done, but API Platform (and Symfony) has a particular directory structure which requires further configuration.
 We must tell Heroku that the document root is `public/`, and that all other directories must be private.
 
-Create a new file named `Procfile` in the `api-platform/` directory with the following content:
+Create a new file named `Procfile` in the `bookshop-api/` directory with the following content:
 
 ```yaml
 web: vendor/bin/heroku-php-apache2 public/
@@ -65,7 +63,7 @@ Be sure to add the Apache Pack to your dependencies:
 As Heroku doesn't support Varnish out of the box, let's disable its integration:
 
 ```patch
-# api-platform/config/packages/api_platform.yaml
+# bookshop-api/config/packages/api_platform.yaml
 -    http_cache:
 -        invalidation:
 -            enabled: true
@@ -82,7 +80,7 @@ and persist application logs. Because API Platform writes logs on `STDERR`, it w
 However, if you use Monolog instead of the default logger, you'll need to configure it to output to `STDERR` instead of
 in a file.
 
-Open `api-platform/config/packages/prod/monolog.yaml` and apply the following patch:
+Open `bookshop-api/config/packages/prod/monolog.yaml` and apply the following patch:
 
 ```yaml
 monolog:
@@ -100,7 +98,7 @@ monolog:
 
 We are now ready to deploy our app!
 
-Go to the `api-platform/` directory, then
+Go to the `bookshop-api/` directory, then
 
 1. Initialize a git repository:
 

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -19,7 +19,7 @@ Create a new [API Platform project](distribution/index.md#using-the-official-dis
 
 Heroku relies on [environment variables](https://devcenter.heroku.com/articles/config-vars) for its configuration. Regardless
 of what provider you choose for hosting your application, using environment variables to configure your production environment
-is a best practice supported out of the box by API Platform.
+is a best practice promoted by API Platform.
 
 Create a Heroku's `app.json` file at the root of the `api/` directory to configure the deployment:
 
@@ -50,7 +50,7 @@ The file also tells the Heroku deployment system to build a PHP container and to
 We are almost done, but API Platform (and Symfony) has a particular directory structure which requires further configuration.
 We must tell Heroku that the document root is `public/`, and that all other directories must be private.
 
-Create a new file named `Procfile` in the `bookshop-api/` directory with the following content:
+Create a new file named `Procfile` in the `api/` directory with the following content:
 
 ```yaml
 web: vendor/bin/heroku-php-apache2 public/
@@ -63,7 +63,7 @@ Be sure to add the Apache Pack to your dependencies:
 As Heroku doesn't support Varnish out of the box, let's disable its integration:
 
 ```patch
-# bookshop-api/config/packages/api_platform.yaml
+# api/config/packages/api_platform.yaml
 -    http_cache:
 -        invalidation:
 -            enabled: true
@@ -80,7 +80,7 @@ and persist application logs. Because API Platform writes logs on `STDERR`, it w
 However, if you use Monolog instead of the default logger, you'll need to configure it to output to `STDERR` instead of
 in a file.
 
-Open `bookshop-api/config/packages/prod/monolog.yaml` and apply the following patch:
+Open `api/config/packages/prod/monolog.yaml` and apply the following patch:
 
 ```yaml
 monolog:
@@ -98,7 +98,7 @@ monolog:
 
 We are now ready to deploy our app!
 
-Go to the `bookshop-api/` directory, then
+Go to the `api/` directory, then
 
 1. Initialize a git repository:
 
@@ -120,7 +120,7 @@ Go to the `bookshop-api/` directory, then
 
     git push heroku master
 
-**We're done.** You can play with the demo bookstore API provided with API Platform. It is ready for production and you
+**We're done.** You can play with the demo API provided with API Platform. It is ready for production and you
 can scale it in one click from the Heroku interface.
 
 To see your logs, run `heroku logs --tail`.

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -15,7 +15,7 @@ If you don't already have one, [create an account on Heroku](https://signup.hero
 toolbelt](https://devcenter.heroku.com/articles/getting-started-with-php#set-up). We're guessing you already
 have a working install of [Composer](http://getcomposer.org). Perfect, we will need it.
 
-Create a new [API Platform project](distribution/index.md#using-symfony-flex-and-composer-advanced-users) which will be used in the rest of this example 
+Create a new [API Platform project](distribution/index.md#using-the-official-distribution-recommended) which will be used in the rest of this example 
 
 Heroku relies on [environment variables](https://devcenter.heroku.com/articles/config-vars) for its configuration. Regardless
 of what provider you choose for hosting your application, using environment variables to configure your production environment

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -52,7 +52,7 @@ The file also tells the Heroku deployment system to build a PHP container and to
 We are almost done, but API Platform (and Symfony) has a particular directory structure which requires further configuration.
 We must tell Heroku that the document root is `public/`, and that all other directories must be private.
 
-Create a new file named `Procfile` in the `api/` directory with the following content:
+Create a new file named `Procfile` in the `api-platform/` directory with the following content:
 
 ```yaml
 web: vendor/bin/heroku-php-apache2 public/
@@ -65,7 +65,7 @@ Be sure to add the Apache Pack to your dependencies:
 As Heroku doesn't support Varnish out of the box, let's disable its integration:
 
 ```patch
-# api/config/packages/api_platform.yaml
+# api-platform/config/packages/api_platform.yaml
 -    http_cache:
 -        invalidation:
 -            enabled: true
@@ -82,7 +82,7 @@ and persist application logs. Because API Platform writes logs on `STDERR`, it w
 However, if you use Monolog instead of the default logger, you'll need to configure it to output to `STDERR` instead of
 in a file.
 
-Open `api/config/packages/prod/monolog.yaml` and apply the following patch:
+Open `api-platform/config/packages/prod/monolog.yaml` and apply the following patch:
 
 ```yaml
 monolog:
@@ -100,7 +100,7 @@ monolog:
 
 We are now ready to deploy our app!
 
-Go to the `api/` directory, then
+Go to the `api-platform/` directory, then
 
 1. Initialize a git repository:
 


### PR DESCRIPTION
This is to make it consistent with the project name created with the first command