### PR TITLE
remove useless example

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -407,7 +407,6 @@ Or using YAML:
 App\Entity\Answer:
     collectionOperations:
         api_questions_answer_get_subresource:
-            method: 'GET' # nothing more to add if we want to keep the default controller
             normalization_context: {groups: ['foobar']}
 ```
 


### PR DESCRIPTION
If we keep `method: 'GET'` the result will be an additional unexpected route.

In fact, serialization will work as expected, but a new route will be created (a classic collection route on subresource, wich is not expected, specially when you create a subresource path).

I hope i do not misunderstand the implementation.