### PR TITLE
Revert "Remove mention of deprecated "api_platform.metadata_cache" parameter"

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -140,6 +140,16 @@ API Platform internally uses a [PSR-6](http://www.php-fig.org/psr/psr-6/) cache.
 Best performance is achieved using [APCu](https://github.com/krakjoe/apcu). Be sure to have the APCu extension installed
 on your production server. API Platform will automatically use it.
 
+This parameter can be changed by changing the value of `api_platform.metadata_cache`:
+
+```yaml
+# api/config/config.yaml
+
+parameters:
+    # Enable the metadata cache to speedup the builds
+    api_platform.metadata_cache: true
+```
+
 ## Using PPM (PHP-PM)
 
 Response time of the API can be improved up to 15x by using [PHP Process Manager](https://github.com/php-pm/php-pm). If


### PR DESCRIPTION
Reverts api-platform/docs#766

Related: https://github.com/api-platform/core/pull/2648

See discussion in https://github.com/api-platform/core/issues/2644