### PR TITLE
Fix incorrect docs for subresource operations

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -387,7 +387,7 @@ namespace App\Entity;
 use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
- * @ApiResource(collectionOperations={
+ * @ApiResource(subresourceOperations={
  *     "api_questions_answer_get_subresource"={
  *         "method"="GET",
  *         "normalization_context"={"groups"={"foobar"}}
@@ -405,7 +405,7 @@ Or using YAML:
 ```yaml
 # api/config/api_platform/resources.yaml
 App\Entity\Answer:
-    collectionOperations:
+    subresourceOperations:
         api_questions_answer_get_subresource:
             normalization_context: {groups: ['foobar']}
 ```


### PR DESCRIPTION
We have just upgraded a big app from `2.3.6` to `2.4.2` and I think documentation is incorrect for subResources.

Without these changes, our tests were failing

1. First of all, I think the new behavior in `2.4.2` is a BC break, because it *did* work before, but doesn't work after upgrading
2. What we did is just replaced `collectionOperations` with `subresourceOperations`, pleasee see the simplified diff

```diff
# This is a subResource config

- collectionOperations:
+ subresourceOperations:
        api_services_service_products_get_subresource:
            normalization_context:
                groups: [...]
```

Why doesn't it work in `2.4.2` anymore?

Because the following code expects sub resources' configuration to be under `subresourceOperations` key:

https://github.com/api-platform/core/blob/ef76e6bc20ca0658a28c5ccccc1b406f47dbbec3/src/Metadata/Resource/ResourceMetadata.php#L179-L182