### PR TITLE
Update Xdebug for PHP 7.3 compatibility

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -13,7 +13,7 @@ it's recommended to add a custom stage to the end of the `api/Dockerfile`.
 # api/Dockerfile
 FROM api_platform_php as api_platform_php_dev
 
-ARG XDEBUG_VERSION=2.6.0
+ARG XDEBUG_VERSION=2.7.1
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
 	pecl install xdebug-$XDEBUG_VERSION; \
@@ -55,12 +55,9 @@ services:
 Inspect the installation with the following command. The requested Xdebug
 version should be displayed in the output.
 
-```bash
+```console
 $ docker-compose exec php php --version
 
-PHP 7.2.8 (cli) (built: Jul 21 2018 08:09:37) ( NTS )
-Copyright (c) 1997-2018 The PHP Group
-Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
-    with Zend OPcache v7.2.8, Copyright (c) 1999-2018, by Zend Technologies
-    with Xdebug v2.6.0, Copyright (c) 2002-2018, by Derick Rethans
+PHP …
+    with Xdebug v2.7.1 …
 ```


### PR DESCRIPTION
Xdebug 2.7.0 add compatibility with PHP 7.1+ (7.1, 7.2, 7.3).