### PR TITLE
Include information on how to show names instead of IRIs for entities

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -225,6 +225,25 @@ export default class extends Component {
 }
 ```
 
+### Show the Names of your Entities instead of their IRIs
+
+When you install API Platform Admin, you might see objects being referred as their IRIs instead of the name you would expect to see. This is because the component looks for this information in the Hydra data.
+
+To configure which property should be shown to represent your entity, you have to include the following line in the docblock preceding your property:
+
+```php
+// api/src/Entity/Book.php
+
+/**
+ * @ApiProperty(iri="http://schema.org/name")
+ */
+private $name;
+```
+
+Besides, it is also possible to use the documentation to customize some fields automatically while configuring the semantics of your data.
+
+You can use the `http://schema.org/email` and `http://schema.org/url` properties to create an `EmailField` and an `UrlField`, respectively.
+
 ### Using the Hydra Data Provider Directly with react-admin
 
 By default, the `HydraAdmin` component shipped with API Platform Admin will generate a convenient admin interface for every resource and every property exposed by the API. But sometimes, you may prefer having full control over the generated admin.

--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -225,7 +225,7 @@ export default class extends Component {
 }
 ```
 
-### Show the Names of your Entities instead of their IRIs
+### Show the Names of your Entities Instead of their IRIs
 
 When you install API Platform Admin, you might see objects being referred as their IRIs instead of the name you would expect to see. This is because the component looks for this information in the Hydra data.
 

--- a/core/validation.md
+++ b/core/validation.md
@@ -401,7 +401,7 @@ final class Brand
 }
 ```
 
-## Open Vocabulary generated from Validation Metadata
+## Open Vocabulary Generated from Validation Metadata
 
 API Platform automatically detects Symfony's built-in validators and generate schema.org IRI metadata accordingly. This allows for rich clients such as the Admin component to infer the field types for most basic use cases.
 

--- a/core/validation.md
+++ b/core/validation.md
@@ -403,7 +403,7 @@ final class Brand
 
 ## Open Vocabulary Generated from Validation Metadata
 
-API Platform automatically detects Symfony's built-in validators and generate schema.org IRI metadata accordingly. This allows for rich clients such as the Admin component to infer the field types for most basic use cases.
+API Platform automatically detects Symfony's built-in validators and generates schema.org IRI metadata accordingly. This allows for rich clients such as the Admin component to infer the field types for most basic use cases.
 
 The following validation constraints are covered:
 

--- a/core/validation.md
+++ b/core/validation.md
@@ -400,3 +400,27 @@ final class Brand
     }
 }
 ```
+
+## Open Vocabulary generated from Validation Metadata
+
+API Platform automatically detects Symfony's built-in validators and generate schema.org IRI metadata accordingly. This allows for rich clients such as the Admin component to infer the field types for most basic use cases.
+
+The following validation constraints are covered:
+
+Constraints                                                                           | Vocabulary                        |
+--------------------------------------------------------------------------------------|-----------------------------------|
+[`Url`](https://symfony.com/doc/current/reference/constraints/Url.html)               | `http://schema.org/url`           |
+[`Email`](https://symfony.com/doc/current/reference/constraints/Email.html)           | `http://schema.org/email`         |
+[`Uuid`](https://symfony.com/doc/current/reference/constraints/Uuid.html)             | `http://schema.org/identifier`    |
+[`CardScheme`](https://symfony.com/doc/current/reference/constraints/CardScheme.html) | `http://schema.org/identifier`    |
+[`Bic`](https://symfony.com/doc/current/reference/constraints/Bic.html)               | `http://schema.org/identifier`    |
+[`Iban`](https://symfony.com/doc/current/reference/constraints/Iban.html)             | `http://schema.org/identifier`    |
+[`Date`](https://symfony.com/doc/current/reference/constraints/Date.html)             | `http://schema.org/Date`          |
+[`DateTime`](https://symfony.com/doc/current/reference/constraints/DateTime.html)     | `http://schema.org/DateTime`      |
+[`Time`](https://symfony.com/doc/current/reference/constraints/Time.html)             | `http://schema.org/Time`          |
+[`Image`](https://symfony.com/doc/current/reference/constraints/Image.html)           | `http://schema.org/image`         |
+[`File`](https://symfony.com/doc/current/reference/constraints/File.html)             | `http://schema.org/MediaObject`   |
+[`Currency`](https://symfony.com/doc/current/reference/constraints/Currency.html)     | `http://schema.org/priceCurrency` |
+[`Isbn`](https://symfony.com/doc/current/reference/constraints/Isbn.html)             | `http://schema.org/isbn`          |
+[`Issn`](https://symfony.com/doc/current/reference/constraints/Issn.html)             | `http://schema.org/issn`          |
+


### PR DESCRIPTION
By default, without more information, the admin shows IRIs for entities.

This makes it really hard for actual users to parse the information, especially when seeing relations this way. This is an attempt to document how to solve the problem marking the property with Schema.org (thanks @GregoireHebert for the tip in the first place)