### PR TITLE
Fix Admin Authentication Support

### DIFF
--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -64,40 +64,39 @@ import { HydraAdmin, hydraClient, fetchHydra as baseFetchHydra } from '@api-plat
 import authProvider from './authProvider';
 import { Redirect } from 'react-router-dom';
 
-const entrypoint = 'https://demo.api-platform.com'; // Change this by your own entrypoint
-const fetchHeaders = {'Authorization': `Bearer ${window.localStorage.getItem('token')}`};
+const fetchHeaders = {'Authorization': `Bearer ${localStorage.getItem('token')}`};
 const fetchHydra = (url, options = {}) => baseFetchHydra(url, {
     ...options,
     headers: new Headers(fetchHeaders),
 });
 const dataProvider = api => hydraClient(api, fetchHydra);
-const apiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoint, { headers: new Headers(fetchHeaders) })
-    .then(
-        ({ api }) => ({ api }),
-        (result) => {
-            switch (result.status) {
-                case 401:
-                    return Promise.resolve({
-                        api: result.api,
-                        customRoutes: [{
-                            props: {
-                                path: '/',
-                                render: () => <Redirect to={`/login`}/>,
-                            },
-                        }],
-                    });
+const apiDocumentationParser = entrypoint =>
+  parseHydraDocumentation(entrypoint, {
+    headers: new Headers(fetchHeaders),
+  }).then(
+    ({ api }) => ({ api }),
+    result => {
+      const { api, status } = result;
 
-                default:
-                    return Promise.reject(result);
-            }
-        },
-    );
+      if (status === 401) {
+        return Promise.resolve({
+          api,
+          status,
+          customRoutes: [
+            <Route path="/" render={() => <Redirect to="/login" />} />,
+          ],
+        });
+      }
 
-export default props => (
+      return Promise.reject(result);
+    }
+  );
+
+export default () => (
     <HydraAdmin
         apiDocumentationParser={apiDocumentationParser}
         authProvider={authProvider}
-        entrypoint={entrypoint}
+        entrypoint="https://demo.api-platform.com" // Change this by your own entrypoint
         dataProvider={dataProvider}
     />
 );

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -62,7 +62,7 @@ import React from 'react';
 import parseHydraDocumentation from '@api-platform/api-doc-parser/lib/hydra/parseHydraDocumentation';
 import { HydraAdmin, hydraClient, fetchHydra as baseFetchHydra } from '@api-platform/admin';
 import authProvider from './authProvider';
-import { Redirect } from 'react-router-dom';
+import { Route, Redirect } from 'react-router-dom';
 
 const fetchHeaders = {'Authorization': `Bearer ${localStorage.getItem('token')}`};
 const fetchHydra = (url, options = {}) => baseFetchHydra(url, {

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -64,6 +64,7 @@ import { HydraAdmin, hydraClient, fetchHydra as baseFetchHydra } from '@api-plat
 import authProvider from './authProvider';
 import { Route, Redirect } from 'react-router-dom';
 
+const entrypoint = 'https://demo.api-platform.com'; // Change this by your own entrypoint
 const fetchHeaders = {'Authorization': `Bearer ${localStorage.getItem('token')}`};
 const fetchHydra = (url, options = {}) => baseFetchHydra(url, {
     ...options,
@@ -96,7 +97,7 @@ export default () => (
     <HydraAdmin
         apiDocumentationParser={apiDocumentationParser}
         authProvider={authProvider}
-        entrypoint="https://demo.api-platform.com" // Change this by your own entrypoint
+        entrypoint={entrypoint}
         dataProvider={dataProvider}
     />
 );


### PR DESCRIPTION
Related issue : https://github.com/api-platform/admin/issues/165

ATM, using the latest version of the admin with the current documentation lead to this error when there is no token in the local storage :
```js
Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

    in Switch (created by RoutesWithLayout)
    in RoutesWithLayout (created by Route)
    in div (created by Layout)
    in main (created by Layout)
    in div (created by Layout)
    in div (created by Layout)
    in Layout (created by WithStyles(Layout))
    in WithStyles(Layout) (created by Route)
    in Route (created by withRouter(WithStyles(Layout)))
    in withRouter(WithStyles(Layout)) (created by Connect(withRouter(WithStyles(Layout))))
    in Connect(withRouter(WithStyles(Layout))) (created by LayoutWithTheme)
    in MuiThemeProvider (created by LayoutWithTheme)
    in LayoutWithTheme (created by Route)
    in Route (created by CoreAdminRouter)
    in Switch (created by CoreAdminRouter)
    in div (created by CoreAdminRouter)
    in CoreAdminRouter (created by Connect(CoreAdminRouter))
    in Connect(CoreAdminRouter) (created by getContext(Connect(CoreAdminRouter)))
    in getContext(Connect(CoreAdminRouter)) (created by Route)
    in Route (created by CoreAdminBase)
    in Switch (created by CoreAdminBase)
    in Router (created by ConnectedRouter)
    in ConnectedRouter (created by CoreAdminBase)
    in TranslationProviderView (created by Connect(TranslationProviderView))
    in Connect(TranslationProviderView) (created by CoreAdminBase)
    in Provider (created by CoreAdminBase)
    in CoreAdminBase (created by withContext(CoreAdminBase))
    in withContext(CoreAdminBase) (created by AdminBuilder)
    in AdminBuilder (created by _default)
    in _default (at App.js:39)
    in App (at src/index.js:7)
```