### PR TITLE
Mercure: fix an error in an environment variable name

### DIFF
--- a/core/mercure.md
+++ b/core/mercure.md
@@ -26,7 +26,7 @@ Finally, 3 environment variables [must be set](https://symfony.com/doc/current/c
 
 * `MERCURE_PUBLISH_URL`: the URL that must be used by API Platform to publish updates to your Mercure hub (can be an internal or a public URL)
 * `MERCURE_SUBSCRIBE_URL`: the **public** URL of the Mercure hub that clients will use to subscribe to updates
-* `MERCURE_JWT`: a valid Mercure [JSON Web Token (JWT)](https://jwt.io/) allowing API Platform to publish updates to the hub
+* `MERCURE_JWT_SECRET`: a valid Mercure [JSON Web Token (JWT)](https://jwt.io/) allowing API Platform to publish updates to the hub
 
 The JWT **must** contain a `mercure.publish` property containing an array of targets.
 This array can be empty to allow publishing anonymous updates only.


### PR DESCRIPTION
The current doc of Mercure's usage with API Platform states that we need to create three variables in the `.env` file in order to enable pushing to the Hub: `MERCURE_PUBLISH_URL`, `MERCURE_SUBSCRIBE_URL` and `MERCURE_JWT`. But the last one is not correct, and must actually be named `MERCURE_JWT_SECRET`.