### PR TITLE
initializing groups key, renaming class and small tweaks

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -420,11 +420,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
         $resourceClass = $context['resource_class'] ?? null;
 
-        if (!isset($context['groups'])) {
-            $context['groups'] = [];
-        }
-
-        if ($resourceClass === Book::class && $this->authorizationChecker->isGranted('ROLE_ADMIN') && false === $normalization) {
+        if ($resourceClass === Book::class && isset($context['groups']) && $this->authorizationChecker->isGranted('ROLE_ADMIN') && false === $normalization) {
             $context['groups'][] = 'admin:input';
         }
 


### PR DESCRIPTION
o/

A few things that I *think* might help:

1) You can only have one context builder per app (right?) so let's make that more clear by calling it `SerializerContextBuilder` instead of `BookContextBuilder`. The name led me to initially expect you to be able to have one context builder per resource.

2) And some minor fixes...

Cheers!