### PR TITLE
Removing check in normalizer to prevent multiple calls

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -452,8 +452,8 @@ services:
             - { name: 'serializer.normalizer', priority: 64 }
 ```
 
-The Normalizer class is a bit harder to understand, because it must ensure that it is only called once and that there is no recursion.
-To accomplish this, it needs to be aware of the parent Normalizer instance itself.
+The Normalizer class is a bit harder to understand: it needs to be aware of the parent normalizer so
+that it can normalize the object, and making any changes to the context.
 
 Here is an example:
 

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -473,8 +473,6 @@ class BookAttributeNormalizer implements ContextAwareNormalizerInterface, Normal
 {
     use NormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'BOOK_ATTRIBUTE_NORMALIZER_ALREADY_CALLED';
-
     private $tokenStorage;
 
     public function __construct(TokenStorageInterface $tokenStorage)
@@ -488,18 +486,11 @@ class BookAttributeNormalizer implements ContextAwareNormalizerInterface, Normal
             $context['groups'][] = 'can_retrieve_book';
         }
 
-        $context[self::ALREADY_CALLED] = true;
-
         return $this->normalizer->normalize($object, $format, $context);
     }
 
     public function supportsNormalization($data, $format = null, array $context = [])
     {
-        // Make sure we're not called twice
-        if (isset($context[self::ALREADY_CALLED])) {
-            return false;
-        }
-
         return $data instanceof Book;
     }
 


### PR DESCRIPTION
Hi again!

This could be me misunderstanding things, as usual :). I don't understand the `ALREADY_CALLED` check. In fact, if I'm returning a collection of books, I DO want the `normalize()` method to be called and multiple times and for my logic to be run each time. I tested this locally - by removing this check, I can give some books in my collection the `can_retrieve_book` group, but not others.

I'm sure that this logic was there at least originally for some reason. Is it still needed? If so, why?

Cheers!