### PR TITLE
Update Xdebug to 2.7.2

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -13,7 +13,7 @@ it's recommended to add a custom stage to the end of the `api/Dockerfile`.
 # api/Dockerfile
 FROM api_platform_php as api_platform_php_dev
 
-ARG XDEBUG_VERSION=2.7.1
+ARG XDEBUG_VERSION=2.7.2
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
 	pecl install xdebug-$XDEBUG_VERSION; \
@@ -59,5 +59,5 @@ version should be displayed in the output.
 $ docker-compose exec php php --version
 
 PHP …
-    with Xdebug v2.7.1 …
+    with Xdebug v2.7.2 …
 ```


### PR DESCRIPTION
[2019-05-06] — Xdebug 2.7.2
Fixed Bugs
Fixed bug #1488: Rewrite DBGp 'property_set' to always use eval
Fixed bug #1586: error_reporting()'s return value is incorrect during debugger's 'eval' command
Fixed bug #1615: Turn off Zend OPcache when remote debugger is turned on
Fixed bug #1656: remote_connect_back alters header if multiple values are present
Fixed bug #1662: __debugInfo should not be used for user-defined classes