### PR TITLE
Update import of `history` package

### DIFF
--- a/client-generator/react.md
+++ b/client-generator/react.md
@@ -75,7 +75,7 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { reducer as form } from 'redux-form';
 import { Route, Switch } from 'react-router-dom';
-import createBrowserHistory from 'history/createBrowserHistory';
+import { createBrowserHistory } from "history";
 import {
   ConnectedRouter,
   connectRouter,


### PR DESCRIPTION
Update import of `history` package to avoid the following error:
```
Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.
```