### PR TITLE
Update authentication-support.md to fix bug in getParameters

### DIFF
--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -75,7 +75,17 @@ const apiDocumentationParser = entrypoint =>
   parseHydraDocumentation(entrypoint, {
     headers: new Headers(fetchHeaders),
   }).then(
-    ({ api }) => ({ api }),
+    ({ api }) => {
+      api.resources = api.resources.map(resource => {
+        resource.getParameters = () => {
+          return getParameters(resource, {
+            headers: new Headers(fetchHeaders)
+          });
+        };
+        return resource;
+      });
+      return { api }
+    },
     result => {
       const { api, status } = result;
 


### PR DESCRIPTION
`getParameters` on each resource is called in `componentDidMount` of `HydraAdmin`.

The default method doesn't send the `Authorization` header. Here is an adjustment to the sample code to do this.

Let me know if there is a better way to solve this