### PR TITLE
Use null instead of boolean in serialize_payload_fields to prevent fatal error

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -351,7 +351,7 @@ You can retrieve the payload field by setting the `serialize_payload_fields` opt
 
 api_platform:
     validator:
-        serialize_payload_fields: true
+        serialize_payload_fields: ~
 ```
 
 Then, the serializer will return all payload values in the error response.


### PR DESCRIPTION
https://github.com/api-platform/core/blob/5503d65e8ad6535539ac4f6b1bcc89962457bc98/src/Serializer/AbstractConstraintViolationListNormalizer.php#L35 constructor accepts either `null` or `array`, but not `boolean`.

When boolean is used, we get the following error:

```
Argument 2 passed to ApiPlatform\Core\Hydra\Serializer\ConstraintViolationListNormalizer::__construct() must be of the type array or null, boolean given, called in /app/var/cache/dev/Container1ozwx3I/srcApp_KernelDevDebugContainer.php on line 848</p>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/api-platform/docs/848)
<!-- Reviewable:end -->
