### PR TITLE
fix enum type without properties

### DIFF
--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -402,7 +402,8 @@ A config file generating an enum class:
 
 ```yaml
 types:
-    OfferItemCondition: ~ # The generator will automatically guess that OfferItemCondition is subclass of Enum
+    OfferItemCondition: # The generator will automatically guess that OfferItemCondition is subclass of Enum
+      properties: {} # Remove all properties of the parent class
 ```
 
 The related PHP class:


### PR DESCRIPTION
To corresponding to the example given on the related PHP class part, the ```enum``` type ```OfferItemCondition``` needs to have:
```yaml
  properties: {}
```  