### PR TITLE
Use the new `pagination_maximum_items_per_page` attribute instead of …

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -220,7 +220,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 
 /**
  * @ApiResource(
- *     attributes={"maximum_items_per_page"=50}
+ *     attributes={"pagination_maximum_items_per_page"=50}
  * )
  */
 class Book
@@ -240,7 +240,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 /**
  * @ApiResource(
  *     collectionOperations={
- *         "get"={"maximum_items_per_page"=50}
+ *         "get"={"pagination_maximum_items_per_page"=50}
  *     }
  * )
  */


### PR DESCRIPTION
Documentation update after fixing https://github.com/api-platform/core/issues/3050.

TL;DR: `maximum_items_per_page` becomes `pagination_maximum_items_per_page`.