### PR TITLE
W.I.P Document the reference docker compose setup for production

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -20,11 +20,8 @@ cache. This ensures that the content served will always be fresh, because the ca
 most specific cases such as the invalidation of collections when a document is added or removed or for relationships and
 inverse relations is built-in.
 
-Integration with Varnish and Doctrine ORM is shipped with the core library, and [Varnish](https://varnish-cache.org/) is
-included in the Docker setup provided with the [API Platform distribution](../distribution/index.md). If you use the distribution,
-this feature works out of the box.
-
-If you don't use the distribution, add the following configuration to enable the cache invalidation system:
+Integration with Varnish and Doctrine ORM is shipped with the core library.
+Add the following configuration to enable the cache invalidation system:
 
 ```yaml
 api_platform:

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -16,9 +16,8 @@ The easiest and most powerful way to get started is to download the API Platform
   microframework](https://symfony.com/doc/current/setup/flex.html) and [the Doctrine ORM](https://www.doctrine-project.org/projects/orm.html) (optional)
 * [a dynamic JavaScript admin](../admin/), leveraging the hypermedia capabilities of API Platform (or any Hydra API), built on top of [React Admin](https://marmelab.com/react-admin/)
 * [a client generator](../client-generator/) to scaffold [React](https://reactjs.org), [Vue](https://vuejs.org/), [React Native](https://facebook.github.io/react-native/), [Next.js](https://nextjs.org/) and [Quasar](https://quasar.dev/) apps in one command, from any Hydra API
-* a [Docker](https://docker.com)-based setup to bootstrap the project in a single command, providing:
+* a [Docker](https://docker.com)-based development setup to bootstrap the project in a single command, providing:
   * servers for the API and JavaScript apps
-  * a [Varnish Cache](http://varnish-cache.org/) server enabling [API Platform's built-in invalidation cache mechanism](../core/performance.md#enabling-the-built-in-http-cache-invalidation-system)
   * a development HTTP/2 and HTTPS proxy (allowing, for instance, to test the provided [service workers](https://developer.mozilla.org/fr/docs/Web/API/Service_Worker_API))
   * a [Helm](https://helm.sh/) chart to deploy the API in any [Kubernetes](https://kubernetes.io/) cluster
 


### PR DESCRIPTION
Hey @teohhanhui and @dunglas,

I stumbled over this issue (https://github.com/api-platform/docs/issues/873) and removed mentions of  Varnish being a part of the development setup already. As I was searching through the documentation I made myself some notes since a couple questions came up.

- `cache-proxy` is part of the custom docker-compose.yml file shown in traefik.md, do you count this occurance as prod or dev?
- Where would be the best place to document the new reference setup for production? Do you guys want a seperate file in the distribution folder?
- Should I document all variations of the docker-compose production files found in the api-platform repository or just the `.prod.yml`?

Hope you can help me out here, because I'd happily support api-platform. ❤️