### PR TITLE
Do not use stylized form of "NGINX"

### DIFF
--- a/core/push-relations.md
+++ b/core/push-relations.md
@@ -29,9 +29,12 @@ class Book
 }
 ```
 
-By setting the `push` attribute to `true` on a property holding a relation, API Platform will automatically add a valid `Link` HTTP header with the `preload` relation.
-According to the [Preload W3C Candidate Recommendation](https://www.w3.org/TR/preload/), web servers and proxy servers can read this header, fetch the related resource and send it to the client using Server Push.
-[NGINX](https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/), [Apache](https://httpd.apache.org/docs/current/howto/http2.html#push), [Cloudflare](https://www.cloudflare.com/website-optimization/http2/serverpush/), [Fastly](https://docs.fastly.com/guides/performance-tuning/http2-server-push) and [Akamai](https://blogs.akamai.com/2017/03/http2-server-push-the-what-how-and-why.html) honor this header. 
+By setting the `push` attribute to `true` on a property holding a relation, API Platform will automatically add a valid
+`Link` HTTP header with the `preload` relation. According to the [Preload W3C Candidate Recommendation](https://www.w3.org/TR/preload/),
+web servers and proxy servers can read this header, fetch the related resource and send it to the client using Server Push.
+[nginx](https://www.nginx.com/blog/nginx-1-13-9-http2-server-push/), [Apache](https://httpd.apache.org/docs/current/howto/http2.html#push),
+[Cloudflare](https://www.cloudflare.com/website-optimization/http2/serverpush/), [Fastly](https://docs.fastly.com/guides/performance-tuning/http2-server-push)
+and [Akamai](https://blogs.akamai.com/2017/03/http2-server-push-the-what-how-and-why.html) honor this header.
 
-Using this feature maximises HTTP cache hits for your API resources.
-For best performance, this feature should be used in conjunction with [the built-in HTTP cache invalidation system (based on Varnish)](performance.md#enabling-the-built-in-http-cache-invalidation-system).
+Using this feature maximises HTTP cache hits for your API resources. For best performance, this feature should be used
+in conjunction with [the built-in HTTP cache invalidation system](performance.md#enabling-the-built-in-http-cache-invalidation-system).

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -16,7 +16,7 @@ package manager) chart to deploy in a wink on any of these platforms.
 
 ## Creating and Publishing the Docker Images
 
-1. Build the PHP and NGINX Docker images:
+1. Build the PHP and nginx Docker images:
 
         docker build -t gcr.io/test-api-platform/php -t gcr.io/test-api-platform/php:latest api --target api_platform_php
         docker build -t gcr.io/test-api-platform/nginx -t gcr.io/test-api-platform/nginx:latest api --target api_platform_nginx

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -79,7 +79,7 @@ This starts the following services:
 | db       | A PostgreSQL database server                                      | 5432                                                        | all (prefer using a managed service in prod)       |
 | client   | A development server for the Progressive Web App                  | 80                                                          | dev (use a static website hosting service in prod) |
 | admin    | A development server for the admin                                | 81                                                          | dev (use a static website hosting service in prod) |
-| api      | The HTTP server for the API (NGINX)                               | 8080                                                        | all                                                |
+| api      | The HTTP server for the API (nginx)                               | 8080                                                        | all                                                |
 | mercure  | The Mercure hub, [for real-time capabilities](../core/mercure.md) | 1337                                                        | all (prefer using the managed version in prod)     |
 | h2-proxy | A HTTP/2 and HTTPS development proxy for all apps                 | 443 (client)<br>444 (admin)<br>8443 (api)<br>1338 (mercure) | dev (configure properly your web server in prod)   |
 
@@ -145,7 +145,10 @@ And start the built-in PHP server:
 All JavaScript components are also [available as standalone libraries](https://github.com/api-platform?language=javascript)
 installable with npm or Yarn.  
 
-**Note:** when installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `http://localhost:8000/api/` to see the API documentation. If you are deploying API Platform directly on an Apache or NGINX webserver and getting a 404 error on opening this link, you will need to enable the [rewriting rules](https://symfony.com/doc/current/setup/web_server_configuration.html) for your specific webserver software.
+**Note:** When installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `http://localhost:8000/api/`
+to see the API documentation. If you are deploying API Platform directly on an Apache or nginx webserver and getting a
+404 error on opening this link, you will need to enable the [rewriting rules](https://symfony.com/doc/current/setup/web_server_configuration.html)
+for your specific webserver software.
 
 ## It's Ready!
 

--- a/extra/troubleshooting.md
+++ b/extra/troubleshooting.md
@@ -43,7 +43,7 @@ The JMS Serializer service is available as `jms_serializer`.
 
 Some of your API calls fail with a 502 error and the logs for the api container shows the following error message `upstream sent too big header while reading response header from upstream`. 
 
-This can be due to the cache invalidation headers that are too big for NGINX. When you query the API, API Platform adds the ids of all returned entities and their dependencies in the headers like so : `Cache-Tags: /entity/1,/dependent_entity/1,/entity/2`. This can overflow the default header size (4k) when your API gets larger and more complex.
+This can be due to the cache invalidation headers that are too big for nginx. When you query the API, API Platform adds the ids of all returned entities and their dependencies in the headers like so : `Cache-Tags: /entity/1,/dependent_entity/1,/entity/2`. This can overflow the default header size (4k) when your API gets larger and more complex.
 
 You can modify the `api/docker/nginx/conf.d/default.conf` file and set values to `fastcgi_buffer_size` and `fastcgi_buffers` that suit your needs, like so:
 


### PR DESCRIPTION
Problem introduced in #903

See https://github.com/api-platform/docs/pull/903#pullrequestreview-296035235

Note: The "official form" is "nginx": https://nginx.org/en/