### PR TITLE
Update File Upload page to match OAS3 specs

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -64,17 +64,21 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  *             "deserialize"=false,
  *             "access_control"="is_granted('ROLE_USER')",
  *             "validation_groups"={"Default", "media_object_create"},
- *             "swagger_context"={
- *                 "consumes"={
- *                     "multipart/form-data",
- *                 },
- *                 "parameters"={
- *                     {
- *                         "in"="formData",
- *                         "name"="file",
- *                         "type"="file",
- *                         "description"="The file to upload",
- *                     },
+ *             "openapi_context"={
+ *                 "requestBody"={
+ *                     "content"={
+ *                         "multipart/form-data"={
+ *                             "schema"={
+ *                                 "type"="object",
+ *                                 "properties"={
+ *                                     "file"={
+ *                                         "type"="string",
+ *                                         "format"="binary"
+ *                                     }
+ *                                 }
+ *                             }
+ *                         }
+ *                     }
  *                 },
  *             },
  *         },


### PR DESCRIPTION
Current version of this page matches OAS2 specifications while the API Platform Distribution uses OAS3.