### PR TITLE
Fix wrong key name in Yaml example for adding security

### DIFF
--- a/core/security.md
+++ b/core/security.md
@@ -74,7 +74,7 @@ App\Entity\Book:
     itemOperations:
         get: ~
         put:
-            security_: 'is_granted("ROLE_ADMIN") or object.owner == user'
+            security: 'is_granted("ROLE_ADMIN") or object.owner == user'
 ```
 
 In this example:


### PR DESCRIPTION
<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes (documentation bug)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | N/a

I believe the key should be `security` instead of `security_`.
