### PR TITLE
Update operation-path-naming.md

### DIFF
--- a/core/operation-path-naming.md
+++ b/core/operation-path-naming.md
@@ -32,29 +32,36 @@ Make sure the custom resolver implements [`ApiPlatform\Core\PathResolver\Operati
 ```php
 <?php
 
-// api/src/PathResolver/NoSeparatorsOperationPathResolver.php
+// api/src/Operation/SingularPathSegmentNameGenerator.php
 
-namespace App\PathResolver;
+namespace App\Operation;
 
-use ApiPlatform\Core\PathResolver\OperationPathResolverInterface;
-use Doctrine\Common\Inflector\Inflector;
+use ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface;
 
-final class NoSeparatorsOperationPathResolver implements OperationPathResolverInterface
+class SingularPathSegmentNameGenerator implements PathSegmentNameGeneratorInterface
 {
-    public function resolveOperationPath(string $resourceShortName, array $operation, bool $collection) : string
+    /**
+     * Transforms a given string to a valid path name which can be pluralized (eg. for collections).
+     *
+     * @param string $name usually a ResourceMetadata shortname
+     *
+     * @return string A string that is a part of the route name
+     */
+    public function getSegmentName(string $name, bool $collection = true): string
     {
-        $path = Inflector::pluralize(strtolower($resourceShortName));
-        if (!$collection) {
-            $path .= '/{id}';
-        }
-        $path .= '.{_format}';
+        $name = $this->dashize($name);
 
-        return $path;
+        return $name;
+    }
+
+    private function dashize(string $string): string
+    {
+        return strtolower(preg_replace('~(?<=\\w)([A-Z])~', '-$1', $string));
     }
 }
 ```
 
-Note that `$resourceShortName` contains a camel case string, by default the resource class name (e.g. `MyResource`).
+Note that `$name` contains a camel case string, by default the resource class name (e.g. `MyResource`).
 
 ### Registering the Service
 

--- a/core/operation-path-naming.md
+++ b/core/operation-path-naming.md
@@ -25,9 +25,9 @@ api_platform:
 
 Let's assume we need URLs without separators (e.g. `api.tld/myresources`)
 
-### Defining the Operation Path Resolver
+### Defining the Operation Segment Name Generator
 
-Make sure the custom resolver implements [`ApiPlatform\Core\PathResolver\OperationPathResolverInterface`](https://github.com/api-platform/core/blob/master/src/PathResolver/OperationPathResolverInterface.php):
+Make sure the custom segment generator implements [`ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface`](https://github.com/api-platform/core/blob/master/src/Operation/PathSegmentNameGeneratorInterface.php):
 
 ```php
 <?php


### PR DESCRIPTION
Outdated documentation use deprecated ApiPlatform\Core\PathResolver\OperationPathResolverInterface.

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | yes <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | yes
| Tickets       | - <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#...

Example usage of ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface instead deprecated ApiPlatform\Core\PathResolver\OperationPathResolverInterface.