### PR TITLE
Update example to traefik v2

### DIFF
--- a/deployment/traefik.md
+++ b/deployment/traefik.md
@@ -11,13 +11,6 @@ This tutorial will help you to define your own routes for your client, api and m
 Use this custom API Platform `docker-compose.yml` file which implements ready-to-use Traefik container configuration. Override
 ports and add labels to tell Traefik to listen on the routes mentioned and redirect routes to specified container.
 
-  ```yaml
-  services:
-  #  ...
-    api:
-      labels: 
-        - traefik.frontend.rule=Host:api.localhost
-  ``` 
 ```yaml
 # docker-compose.yml
 version: '3.4'
@@ -39,7 +32,7 @@ services:
       - --entrypoints.postgresql.address=:5432 # postgresql port
       - --log.level=INFO # log level
       - --providers.docker # enable docker provider
-      - --providers.docker.exposedbydefault=false # disable automatich provisioning
+      - --providers.docker.exposedbydefault=false # disable automatic provisioning
     ports:
       - "80:80"
       - "8080:8080"

--- a/deployment/traefik.md
+++ b/deployment/traefik.md
@@ -26,6 +26,7 @@ services:
   traefik:
     image: traefik:2.0.2
     command:
+      # Do not use api.insecure in production https://docs.traefik.io/v2.0/operations/api/#configuration
       - --api.insecure # dashboard URL: http://localhost:8080/dashboard/
       - --entrypoints.web.address=:80 # http port
       - --entrypoints.websecure.address=:443 # https port


### PR DESCRIPTION
Ive updated the following:
- update example to traefik v2
- set specific image tag for traefik
- automatic http to https direction
- merged the multiple examples on this page into one
- removed the part about multiple traefik instances. I don't have this setup so didn't test. You could argue if this should be a part of this example. If you want it back, let me know.
- accidentally updated postgresql tag from 10 to 11. Do you want me to revert this or do you want this updated in the main repo as well? I think 11 is mainstream at the moment?

<!-- Please update this template with something that matches your PR -->
| Q             | A
| ------------- | ---
| Bug fix?      | no <!-- if yes, please use the branch of the current version of API Platform -->
| New feature?  | no <!-- if yes, please use the master branch -->
| BC breaks?    | no
| Deprecations? | no
| Tickets       | fixes #... <!-- prefix each issue number with "fixes #", if any -->
| License       | MIT
| Doc PR        | api-platform/docs#953

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility.
 - Bug fixes should be based against the current stable version branch.
 - Features and deprecations must be submitted against master branch.
 - Legacy code removals go to the master branch.
 - Update CHANGELOG.md file.
-->
