### PR TITLE
Prevent uploaded files from being overwritten

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -26,6 +26,7 @@ vich_uploader:
         media_object:
             uri_prefix: /media
             upload_destination: '%kernel.project_dir%/public/media'
+            # Will rename uploaded files using a uniqueid as a prefix.
             namer: Vich\UploaderBundle\Naming\OrignameNamer
 ```
 

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -26,6 +26,7 @@ vich_uploader:
         media_object:
             uri_prefix: /media
             upload_destination: '%kernel.project_dir%/public/media'
+            namer: Vich\UploaderBundle\Naming\OrignameNamer
 ```
 
 ## Configuring the Entity Receiving the Uploaded File


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#...

When someone uploads a file with an already existing name it overwrites the existing file. Easily prevented by providing this configuration.