### PR TITLE
[Messenger] Add information about multiple handlers return value

### DIFF
--- a/core/messenger.md
+++ b/core/messenger.md
@@ -103,6 +103,9 @@ If you want it to be consumed asynchronously (e.g. by a worker machine), [config
 API Platform automatically uses the `Symfony\Component\Messenger\Stamp\HandledStamp` when set.
 It means that if you use a synchronous handler, the data returned by the `__invoke` method replaces the original data.
 
+In cases where multiple handlers are registered, the last handler return value will be used as output. If none are returned, ensure resource configuration defines no output with `output=false`.
+Handler ordering can be configured [using messenger priority tag](https://symfony.com/doc/current/messenger.html#manually-configuring-handlers).
+
 ## Detecting Removals
 
 When a `DELETE` operation occurs, API Platform automatically adds a `ApiPlatform\Core\Bridge\Symfony\Messenger\RemoveStamp` ["stamp"](https://symfony.com/doc/current/components/messenger.html#adding-metadata-to-messages-envelopes) instance to the "envelope".


### PR DESCRIPTION
When using Messenger integration, the current documentation specifies :
- use `output=false` to return blank response
- remove `output=false` if you want to return Data returned by your MessageHandler

However, no information is given on situation where multiple handlers are handling the same message.
- if the last handler returns void and resource configuration specifies that an output must be generated, a `No item route associated with the type` error is thrown due to the absence of any `GET` item operation configuration on the resource
- Ensuring that the handler returning data to be returned in the HTTP response process the message last solves this issue
