### PR TITLE
[GraphQL] Add documentation on how to set contentUrl in CreateMediaObjectResolver

### DIFF
--- a/core/graphql.md
+++ b/core/graphql.md
@@ -1403,9 +1403,20 @@ namespace App\Resolver;
 use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
 use App\Entity\MediaObject;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Vich\UploaderBundle\Storage\StorageInterface;
 
 final class CreateMediaObjectResolver implements MutationResolverInterface
 {
+    /**
+     * @var StorageInterface
+     */
+    private $storage;
+
+    public function __construct(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
     /**
      * @param null $item
      */
@@ -1415,7 +1426,7 @@ final class CreateMediaObjectResolver implements MutationResolverInterface
 
         $mediaObject = new MediaObject();
         $mediaObject->file = $uploadedFile;
-
+        $mediaObject->contentUrl = $this->storage->resolveUri($mediaObject); 
         return $mediaObject;
     }
 }


### PR DESCRIPTION
Added additional lines to the CreateMediaObjectResolver, so that the contentUrl is set in the response of `createMediaObject` mutation.
