### PR TITLE
Update file-upload.md for Symfony 4.3+

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -183,7 +183,7 @@ use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use App\Entity\MediaObject;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Vich\UploaderBundle\Storage\StorageInterface;
 
@@ -203,7 +203,7 @@ final class ResolveMediaObjectContentUrlSubscriber implements EventSubscriberInt
         ];
     }
 
-    public function onPreSerialize(GetResponseForControllerResultEvent $event): void
+    public function onPreSerialize(ViewEvent $event): void
     {
         $controllerResult = $event->getControllerResult();
         $request = $event->getRequest();


### PR DESCRIPTION
Conform to this article, the "GetResponseForControllerResultEvent " has been renamed to "ViewEvent" for Symfony 4.3 +

https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching#updated-httpkernel-event-classes

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
