### PR TITLE
Fix wrong operation name for subresource operation

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -206,7 +206,7 @@ You can control the path of subresources with the `path` option of the `subresou
  * ...
  * @ApiResource(
  *      subresourceOperations={
- *          "answer_get_subresource"={
+ *          "api_questions_answer_get_subresource"={
  *              "method"="GET",
  *              "path"="/questions/{id}/all-answers"
  *          },


### PR DESCRIPTION
Currently the route name is used as the operation name, which is not ideal, but it is what it is.