### PR TITLE
Add missing method attribute for YAML example

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -159,6 +159,7 @@ Or using YAML:
 App\Entity\Answer:
     subresourceOperations:
         api_questions_answer_get_subresource:
+            method: 'GET'
             normalization_context: {groups: ['foobar']}
 ```
 


### PR DESCRIPTION
The current documentation mentions that:
```In the previous examples, the method attribute is mandatory, because the operation name doesn't match a supported HTTP method.```

Yet, the method attribute was missing in the YAML example.