### PR TITLE
Fix the list of services and their ports on the Distribution page

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -82,7 +82,6 @@ This starts the following services:
 | api      | The HTTP server for the API (NGINX)                               | n/a                                                         | all                                                |
 | vulcain  | The [Vulcain](https://vulcain.rocks) gateaway                     | 8443                                                        | all (prefer using a managed service in prod)       |
 | mercure  | The Mercure hub, [for real-time capabilities](../core/mercure.md) | 1337                                                        | all (prefer using the managed version in prod)     |
-| h2-proxy | A HTTP/2 and HTTPS development proxy for all apps                 | 443 (client)<br>444 (admin)<br>8443 (api)<br>1338 (mercure) | dev (configure properly your web server in prod)   |
 
 To see the container's logs, run:
 

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -77,9 +77,10 @@ This starts the following services:
 |----------|-------------------------------------------------------------------|-------------------------------------------------------------|----------------------------------------------------|
 | php      | The API with PHP, PHP-FPM 7.3, Composer and sensitive configs     | n/a                                                         | all                                                |
 | db       | A PostgreSQL database server                                      | 5432                                                        | all (prefer using a managed service in prod)       |
-| client   | A development server for the Progressive Web App                  | 80                                                          | dev (use a static website hosting service in prod) |
-| admin    | A development server for the admin                                | 81                                                          | dev (use a static website hosting service in prod) |
-| api      | The HTTP server for the API (NGINX)                               | 8080                                                        | all                                                |
+| client   | A development server for the Progressive Web App                  | 443                                                         | dev (use a static website hosting service in prod) |
+| admin    | A development server for the admin                                | 444                                                         | dev (use a static website hosting service in prod) |
+| api      | The HTTP server for the API (NGINX)                               | n/a                                                         | all                                                |
+| vulcain  | The [Vulcain](https://vulcain.rocks) gateaway                     | 8443                                                        | all (prefer using a managed service in prod)       |
 | mercure  | The Mercure hub, [for real-time capabilities](../core/mercure.md) | 1337                                                        | all (prefer using the managed version in prod)     |
 | h2-proxy | A HTTP/2 and HTTPS development proxy for all apps                 | 443 (client)<br>444 (admin)<br>8443 (api)<br>1338 (mercure) | dev (configure properly your web server in prod)   |
 


### PR DESCRIPTION
The list of services was out of date:

- Add Vulcain in the services list
- Update the opened ports