### PR TITLE
add missing return statement in JS code

### DIFF
--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -31,7 +31,7 @@ const apiDocumentationParser = entrypoint => parseHydraDocumentation(entrypoint,
                         api: result.api,
                         customRoutes: [
                             <Route path="/" render={() => {
-                                window.localStorage.getItem("token") ? window.location.reload() : <Redirect to="/login" />
+                                return window.localStorage.getItem("token") ? window.location.reload() : <Redirect to="/login" />
                             }} />
                         ],
                     });


### PR DESCRIPTION
without the return statement JS throws an error: 

> Expected an assignment or function call and instead saw an expression  no-unused-expressions

this commit fixes this issue