### PR TITLE
Note about serialization groups related to DTO

### DIFF
--- a/core/dto.md
+++ b/core/dto.md
@@ -82,8 +82,7 @@ final class BookInput {
 }
 ```
 
-> Note: When using serialization group annotations (@Groups("book") for example) the fields in the data transformers (for example BookInput::isbn) which are to be serialized should also have their serialization group annotation added.
-
+When using serialization groups, you need to specify these to the class and also to the Input itself.
 We can transform the `BookInput` to a `Book` resource instance:
 
 ```php

--- a/core/dto.md
+++ b/core/dto.md
@@ -82,6 +82,8 @@ final class BookInput {
 }
 ```
 
+> Note: When using serialization group annotations (@Groups("book") for example) the fields in the data transformers (for example BookInput::isbn) which are to be serialized should also have their serialization group annotation added.
+
 We can transform the `BookInput` to a `Book` resource instance:
 
 ```php


### PR DESCRIPTION
Currently it is not quite clear that serialization group annotations should be used on classes used for data transformation. At least not explicitly. See the note for inclusion proposal.
