### PR TITLE
Update data-persisters.md

### DIFF
--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -80,7 +80,7 @@ Here is an implementation example which sends new users a welcome email after a 
 ```php
 namespace App\DataPersister;
 
-use ApiPlatform\Core\Bridge\Doctrine\Common\DataPersister;
+use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use App\Entity\User;
 use Symfony\Component\Mailer\MailerInterface;
@@ -90,7 +90,7 @@ final class UserDataPersister implements ContextAwareDataPersisterInterface
     private $decorated;
     private $mailer;
 
-    public function __construct(DataPersister $decorated, MailerInterface $mailer)
+    public function __construct(DataPersisterInterface $decorated, MailerInterface $mailer)
     {
         $this->decorated = $decorated;
         $this->mailer = $mailer;


### PR DESCRIPTION
In section: 
## Decorating the Built-In Data Persisters
The code in the example breaks autowiring, it should be using the interfaces, not the classes.
use ApiPlatform\Core\Bridge\Doctrine\Common\DataPersister; 
instead of:
use ApiPlatform\Core\DataPersister\DataPersisterInterface;
and the __construct is
public function __construct(DataPersister $decorated, MailerInterface $mailer)
Should be:
public function __construct(DataPersisterInterface $decorated, MailerInterface $mailer)

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
