### PR TITLE
Install react-native-router-flux sub dependencies

### DIFF
--- a/client-generator/react-native.md
+++ b/client-generator/react-native.md
@@ -16,7 +16,7 @@ Create a React Native application using [Expo CLI](https://docs.expo.io/versions
 
 Install the required dependencies:
 
-    $ yarn add redux react-redux redux-thunk redux-form react-native-elements react-native-router-flux react-native-vector-icons prop-types whatwg-url buffer react-native-event-source
+    $ yarn add redux react-redux redux-thunk redux-form react-native-elements react-native-router-flux react-native-vector-icons prop-types whatwg-url buffer react-native-event-source react-native-gesture-handler react-native-reanimated react-native-screens
 
 ## Generating a Native App
 


### PR DESCRIPTION
React-native-router-flux has sub dependencies that are not currently being installed. As of npm@3, neither yarn nor npm install sub dependencies by default.

If a new user is not familiar with the "has unmet peer dependency" warning and fails to install the listed sub dependencies, then expo will fail with errors. By adding the sub dependencies onto the existing yarn command then the new user will have one less thing to troubleshoot.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
