### PR TITLE
Update xdebug installation guide

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -17,7 +17,7 @@ it's recommended to add a custom stage to the end of the `api/Dockerfile`.
 # api/Dockerfile
 FROM api_platform_php as api_platform_php_dev
 
-ARG XDEBUG_VERSION=2.7.2
+ARG XDEBUG_VERSION=2.9.2
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
 	pecl install xdebug-$XDEBUG_VERSION; \
@@ -63,5 +63,5 @@ version should be displayed in the output.
 $ docker-compose exec php php --version
 
 PHP …
-    with Xdebug v2.7.2 …
+    with Xdebug v2.9.2 …
 ```


### PR DESCRIPTION
XDEBUG_VERSION=2.7.2 is not compatible with php 7.4 and therefore has to be a higher version for api-platform 2.5.4

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
