### PR TITLE
Remove `App` prefix in path to action classes

### DIFF
--- a/core/controllers.md
+++ b/core/controllers.md
@@ -13,7 +13,7 @@ implements the [Action-Domain-Responder](https://github.com/pmjones/adr) pattern
 [MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller).
 
 The distribution of API Platform also eases the implementation of the ADR pattern: it automatically registers action classes
-stored in `api/src/App/Controller` as autowired services.
+stored in `api/src/Controller` as autowired services.
 
 Thanks to the [autowiring](http://symfony.com/doc/current/components/dependency_injection/autowiring.html) feature of the
 Symfony Dependency Injection container, services required by an action can be type-hinted in its constructor, it will be


### PR DESCRIPTION
There is a sentence:

> The distribution of API Platform also eases the implementation of the ADR pattern: it automatically registers action classes
stored in `api/src/App/Controller` as autowired services.

However, all the examples below this sentence use controllers located in `src/Controller` (https://api-platform.com/docs/core/controllers/).

Hence the change - removing the `App` folder in path to action classes.

Moreover, there is no path `api/src/App` in `api-platform/api-platform` distribution.