### PR TITLE
Use `security` attribute instead of deprecated `access_control`

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -64,7 +64,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  *         "post"={
  *             "controller"=CreateMediaObjectAction::class,
  *             "deserialize"=false,
- *             "access_control"="is_granted('ROLE_USER')",
+ *             "security"="is_granted('ROLE_USER')",
  *             "validation_groups"={"Default", "media_object_create"},
  *             "openapi_context"={
  *                 "requestBody"={


### PR DESCRIPTION
Just a little patch to replace the deprecated attribute `access_control` with `security`. Don't know if the patch should target this branch or master. Let me know if I need to change.
