### PR TITLE
isMethodSafe() has been deprecated Symfony 4.4

### DIFF
--- a/core/form-data.md
+++ b/core/form-data.md
@@ -39,7 +39,7 @@ final class DeserializeListener
 
     public function onKernelRequest(GetResponseEvent $event): void {
         $request = $event->getRequest();
-        if ($request->isMethodSafe(false) || $request->isMethod(Request::METHOD_DELETE)) {
+        if ($request->isMethodCacheable(false) || $request->isMethod(Request::METHOD_DELETE)) {
             return;
         }
 


### PR DESCRIPTION
User Deprecated: Passing arguments to "Symfony\Component\HttpFoundation\Request::isMethodSafe()" has been deprecated since Symfony 4.4; use "Symfony\Component\HttpFoundation\Request::isMethodCacheable()" to check if the method is cacheable instead.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
