### PR TITLE
fix the subresource operation name when overriding path

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -207,7 +207,7 @@ You can control the path of subresources with the `path` option of the `subresou
  * ...
  * @ApiResource(
  *      subresourceOperations={
- *          "api_questions_answer_get_subresource"={
+ *          "answer_get_subresource"={
  *              "method"="GET",
  *              "path"="/questions/{id}/all-answers"
  *          },


### PR DESCRIPTION
This operation name was wrong.
The prefix must be removed when overriding a path