### PR TITLE
User integer user ID instead of passing a User object to Doctrine Query

### DIFF
--- a/core/extensions.md
+++ b/core/extensions.md
@@ -98,7 +98,7 @@ final class CurrentUserExtension implements QueryCollectionExtensionInterface, Q
 
         $rootAlias = $queryBuilder->getRootAliases()[0];
         $queryBuilder->andWhere(sprintf('%s.user = :current_user', $rootAlias));
-        $queryBuilder->setParameter('current_user', $user);
+        $queryBuilder->setParameter('current_user', $user->getId());
     }
 }
 


### PR DESCRIPTION
For some reason, passing `User` object to `setParameter` in extension leads to incorrect query:

```sql
SELECT s0_.id AS id_0, s0_.title AS title_1, s0_.image_id AS image_id_2, s0_.user_id AS user_id_3 
FROM sound_record s0_ 
WHERE s0_.id = 1 
AND s0_.user_id = 0;
```

note `user_id = 0`.

![doctrine](https://user-images.githubusercontent.com/3725595/77643007-aba52000-6f6f-11ea-8f15-77d91ebc07f5.png)


After changing `$user` to `$user->getId()`, everything works as expected:

