### PR TITLE
Added note about acl dependency

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -27,6 +27,8 @@ Then we need to generate the public and private keys used for signing JWT tokens
         setfacl -dR -m u:www-data:rX -m u:"$(whoami)":rwX config/jwt
     '
 
+Note that the `setfacl` command relies on the `acl` package. This is installed by default when using the API Platform docker distribution but may need be installed in your working environment in order to execute the `setfacl` command.
+
 This takes care of using the correct passphrase to encrypt the private key, and setting the correct permissions on the
 keys allowing the web server to read them.
 


### PR DESCRIPTION
Whilst acl is installed in the API Platform docker setup, users may need to install it in their own environment

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
