### PR TITLE
Change Interface of decorated DataPersister

### DIFF
--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -90,7 +90,7 @@ final class UserDataPersister implements ContextAwareDataPersisterInterface
     private $decorated;
     private $mailer;
 
-    public function __construct(DataPersisterInterface $decorated, MailerInterface $mailer)
+    public function __construct(ContextAwareDataPersisterInterface $decorated, MailerInterface $mailer)
     {
         $this->decorated = $decorated;
         $this->mailer = $mailer;

--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -81,7 +81,6 @@ Here is an implementation example which sends new users a welcome email after a 
 namespace App\DataPersister;
 
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
-use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
 use App\Entity\User;
 use Symfony\Component\Mailer\MailerInterface;
 


### PR DESCRIPTION
If the decorated DataPersister is from type `DataPersisterInterface` there is no `$context` argument.
Alternatively we could stay with `DataPersisterInterface` and remove the `$context` argument in `supports()`, `persist()` and `remove()`

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
