### PR TITLE
Fix incorrect serialize_payload_fields default

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -436,7 +436,7 @@ You can retrieve the payload field by setting the `serialize_payload_fields` to 
 
 api_platform:
     validator:
-        serialize_payload_fields: []
+        serialize_payload_fields: ~
 ```
 
 Then, the serializer will return all payload values in the error response.


### PR DESCRIPTION
The current docs state that to serialize ALL payload fields, use `serialize_payload_fields: []`

Actually, this means NONE of the payload fields are serialized.

The default value, to serialize ALL payload fields, should be `serialize_payload_fields: ~`

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
