### PR TITLE
Add how to change the GraphQL entrypoint URL

### DIFF
--- a/core/graphql.md
+++ b/core/graphql.md
@@ -19,7 +19,8 @@ You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 *Note:* If you used [Symfony Flex to install API Platform](../distribution/index.md#using-symfony-flex-and-composer-advanced-users),
 the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
 
-### Changing the Location of GraphQL endpoint
+## Changing Location of the GraphQL Endpoint
+
 Sometimes you may want to have the GraphQL endpoint at a different location. This can be done by manually configuring the GraphQL controller.
 ```yaml    
 # api/config/routes.yaml
@@ -28,7 +29,7 @@ api_graphql_entrypoint:
     controller: api_platform.graphql.action.entrypoint
 # ...
 ```
-Change /api/graphql to the URI you wish GrahpQL to be accessible on.
+Change `/api/graphql` to the URI you wish the GraphQL endpoint to be accessible on.
 
 ## GraphiQL
 

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -22,6 +22,7 @@ the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
 ## Changing Location of the GraphQL Endpoint
 
 Sometimes you may want to have the GraphQL endpoint at a different location. This can be done by manually configuring the GraphQL controller.
+
 ```yaml    
 # api/config/routes.yaml
 api_graphql_entrypoint:
@@ -29,6 +30,7 @@ api_graphql_entrypoint:
     controller: api_platform.graphql.action.entrypoint
 # ...
 ```
+
 Change `/api/graphql` to the URI you wish the GraphQL endpoint to be accessible on.
 
 ## GraphiQL

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -19,6 +19,17 @@ You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 *Note:* If you used [Symfony Flex to install API Platform](../distribution/index.md#using-symfony-flex-and-composer-advanced-users),
 the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
 
+### Changing the Location of GraphQL endpoint
+Sometimes you may want to have the GraphQL endpoint at a different location. This can be done by manually configuring the GraphQL controller.
+```yaml    
+# api/config/routes.yaml
+api_graphql_entrypoint:
+    path: /api/graphql
+    controller: api_platform.graphql.action.entrypoint
+# ...
+```
+Change /api/graphql to the URI you wish GrahpQL to be accessible on.
+
 ## GraphiQL
 
 If Twig is installed in your project, go to the GraphQL endpoint with your browser. You will see a nice interface provided by GraphiQL to interact with your API.


### PR DESCRIPTION
It was not mentioned in the docs, so I thought it may be useful for other developers.

I tried to stick to the structure of the docs, more-or-less copying the existing [changing-the-location-of-swagger-ui](https://api-platform.com/docs/core/swagger/#changing-the-location-of-swagger-ui).

This is my first contribution to Api Platform docs, so please feel free to correct or improve my proposal.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

-->
