### PR TITLE
fix serialization getSum() bad indentation

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -361,7 +361,7 @@ class Greeting
      */
     public function getSum(): int
     {
-            return $this->a + $this->b;
+        return $this->a + $this->b;
     }
 }
 ```


### PR DESCRIPTION
Just fix bad indentation in `core` -> `serialization` -> `Calculated Field` -> `getSum()` method !