### PR TITLE
Update performance.md

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -58,7 +58,7 @@ namespace App\EventSubscriber;
 use ApiPlatform\Core\EventListener\EventPriorities;
 use App\Entity\User;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class UserResourcesSubscriber implements EventSubscriberInterface
@@ -70,7 +70,7 @@ final class UserResourcesSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function extendResources(GetResponseEvent $event)
+    public function extendResources(RequestEvent $event): void
     {
         $request = $event->getRequest();
         $class = $request->attributes->get('_api_resource_class');


### PR DESCRIPTION
## Why
`GetResponseEvent` is deprecated since 4.3, use RequestEvent instead

https://github.com/symfony/http-kernel/blob/4.4/Event/GetResponseEvent.php#L17
