### PR TITLE
Fix webonyx/graphql version

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -644,7 +644,7 @@ ISBN isn't valid...
 Isn't API Platform a REST **and** GraphQL framework? That's true! GraphQL support isn't enabled by default. To add it we
 need to install the [graphql-php](https://webonyx.github.io/graphql-php/) library. Run the following command (the cache needs to be cleared twice):
 
-    $ docker-compose exec php composer req webonyx/graphql-php && docker-compose exec php bin/console cache:clear
+    $ docker-compose exec php composer req webonyx/graphql-php:^0.13.9 && docker-compose exec php bin/console cache:clear
 
 You now have a GraphQL API! Open `https://localhost:8443/graphql` (or `https://localhost:8443/api/graphql` if you used Symfony Flex to install API Platform) to play with it using the nice [GraphiQL](https://github.com/graphql/graphiql)
 UI that is shipped with API Platform:


### PR DESCRIPTION
For a few weeks, a new stable version of webonyx/graphql with BC was released. API Platform should release on previous version until being updated.