### PR TITLE
A RessourceGuesser was missing in on of the examples

### DIFF
--- a/admin/handling-relations.md
+++ b/admin/handling-relations.md
@@ -104,6 +104,7 @@ export default () => (
       name="books"
       list={BooksList}
     />
+    <ResourceGuesser name="authors" />
   </HydraAdmin>
 );
 ```


### PR DESCRIPTION
As per the [ReferenceField](https://marmelab.com/react-admin/Fields.html) description, React Admin needs the Resource for the referenced resource to be declared in the app to be able to get the data:

```
Note: You must add a <Resource> for the reference resource - react-admin needs it to fetch the reference data. You can omit the list prop in this reference if you want to hide it in the sidebar menu.
```
