### PR TITLE
Change text/csv to application/csv

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -25,7 +25,7 @@ Format                                                          | Format name  |
 [JSON:API](http://jsonapi.org/)                                 | `jsonapi`    | `application/vnd.api+json`    | yes
 [HAL](http://stateless.co/hal_specification.html)               | `jsonhal`    | `application/hal+json`        | yes
 [YAML](http://yaml.org/)                                        | `yaml`       | `application/x-yaml`          | no
-[CSV](https://tools.ietf.org/html/rfc4180)                      | `csv`        | `text/csv`                    | no
+[CSV](https://tools.ietf.org/html/rfc4180)                      | `csv`        | `application/csv`             | no
 [HTML](https://whatwg.org/) (API docs)                          | `html`       | `text/html`                   | no
 [XML](https://www.w3.org/XML/)                                  | `xml`        | `application/xml`, `text/xml` | no
 [JSON](https://www.json.org/)                                   | `json`       |  `application/json`           | no


### PR DESCRIPTION
text/csv isn't supported. This PR changes that in content negotiation doc to application/csv, as suggested in the error.

https://nextcloud.clauzier.dev/s/LFCrDSg5BZ5K7mq
