### PR TITLE
Fix: GetResponseEvent deprecation

### DIFF
--- a/core/form-data.md
+++ b/core/form-data.md
@@ -19,7 +19,7 @@ namespace App\EventListener;
 
 use ApiPlatform\Core\Util\RequestAttributesExtractor;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use ApiPlatform\Core\EventListener\DeserializeListener as DecoratedListener;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
@@ -37,7 +37,7 @@ final class DeserializeListener
         $this->decorated = $decorated;
     }
 
-    public function onKernelRequest(GetResponseEvent $event): void {
+    public function onKernelRequest(RequestEvent $event): void {
         $request = $event->getRequest();
         if ($request->isMethodCacheable(false) || $request->isMethod(Request::METHOD_DELETE)) {
             return;


### PR DESCRIPTION
GetResponseEvent is deprecated since Symfony 4.3, use RequestEvent instead

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
