### PR TITLE
Fix : GetResponseForControllerResultEvent depreciation

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -35,7 +35,7 @@ use App\Entity\Product;
 use App\Exception\ProductNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 final class ProductManager implements EventSubscriberInterface
@@ -47,7 +47,7 @@ final class ProductManager implements EventSubscriberInterface
         ];
     }
 
-    public function checkProductAvailability(GetResponseForControllerResultEvent $event): void
+    public function checkProductAvailability(ViewEvent $event): void
     {
         $product = $event->getControllerResult();
         if (!$product instanceof Product || !$event->getRequest()->isMethodSafe(false)) {


### PR DESCRIPTION
- GetResponseForControllerResultEvent is deprecated since Symfony 4.3, use ViewEvent instead

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
