### PR TITLE
Add pagination info for custom data providers

### DIFF
--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -166,7 +166,7 @@ final class BlogPostItemDataProvider implements ItemDataProviderInterface, Seria
 
 ## Injecting Extensions (Pagination, Filter, EagerLoading etc.)
 
-API Platform provides a few extensions that you can reuse in your custom DataProvider.
+API Platform provides a vendor specific extensions that you can reuse in your custom DataProvider.
 Note that there are a few kinds of extensions which are detailed in [their own chapter of the documentation](extensions.md).
 Because extensions are tagged services, you can use the [injection of tagged services](https://symfony.com/blog/new-in-symfony-3-4-simpler-injection-of-tagged-services):
 

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -542,3 +542,15 @@ class BookRepository extends ServiceEntityRepository
     }
 }
 ```
+
+## Pagination for Customer Data Providers
+
+If you're using a customer Data Providers, and not the Doctrine ORM, ODM or
+ElasticSearch provides, then if you want your results to be paginated then
+you'll need to return an instance of a
+`\ApiPlatform\Core\DataProvider\PartialPaginatorInterface` or
+`\ApiPlatform\Core\DataProvider\PaginatorInterface`.  A few existing classes are
+provided to get you started with these…
+
+* `\ApiPlatform\Core\DataProvider\ArrayPaginator`
+* `\ApiPlatform\Core\DataProvider\TraversablePaginator`


### PR DESCRIPTION
Adds details of new TraversablePaginator provided by https://github.com/api-platform/core/pull/3783.

It also includes some minor improvements to the documentation for pagination in customer Data Providers