### PR TITLE
Missing ArrayCollection use in relations validation

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -467,6 +467,9 @@ For example:
 ```
 
 ```php
+
+use Doctrine\Common\Collections\ArrayCollection;
+
 final class Brand
 {
     // ...


### PR DESCRIPTION
In the relations validation, there is a ArrayCollection usage without its use.

I'm not sure wether or not this kind of fix are useful, but I regularly have to look for the path of a class in API Platform documentation example so I create quick PRs.

Feel free to decline and/or stop me