### PR TITLE
demo: links to the related demo code

### DIFF
--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -77,6 +77,8 @@ register and use this data provider. The optional attribute `priority` allows yo
 data providers are called. The first data provider not throwing a `ApiPlatform\Core\Exception\ResourceClassNotSupportedException`
 will be used.
 
+You can find a full working example in the [API Platform's demo application](https://github.com/api-platform/demo/blob/master/api/src/DataProvider/TopBookCollectionDataProvider.php).
+
 ## Custom Item Data Provider
 
 The process is similar for item data providers. Create a `BlogPostItemDataProvider` implementing the [`ItemDataProviderInterface`](https://github.com/api-platform/core/blob/master/src/DataProvider/ItemDataProviderInterface.php)
@@ -124,6 +126,8 @@ services:
         # Uncomment only if autoconfiguration is disabled
         #tags: [ 'api_platform.item_data_provider' ]
 ```
+
+You can find a full working example in the [API Platform's demo application](https://github.com/api-platform/demo/blob/master/api/src/DataProvider/TopBookItemDataProvider.php).
 
 ## Injecting the Serializer in an `ItemDataProvider`
 

--- a/core/extensions.md
+++ b/core/extensions.md
@@ -6,6 +6,8 @@ Extensions are specific to Doctrine and Elasticsearch-PHP, and therefore, the Do
 reading support must be enabled to use this feature. If you use custom providers it's up to you to implement your own
 extension system or not.
 
+You can find a working example of a custom data provider using a pagination extension in the [API Platform's demo application](https://github.com/api-platform/demo/blob/master/api/src/DataProvider/Extension/TopBookPaginationExtension.php).
+
 ## Custom Doctrine ORM Extension
 
 Custom extensions must implement the `ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface` and / or the `ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryItemExtensionInterface` interfaces, to be run when querying for a collection of items and when querying for an item respectively.


### PR DESCRIPTION
This update is related to the following PR on APIP demo application: https://github.com/api-platform/demo/pull/162

The idea is to add cross-links between docs and the demo so it's easier for people to navigate and find useful stuff.