### PR TITLE
Operations page - add configuration to completely disable a collection or item

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -135,6 +135,56 @@ class Book
 }
 ```
 
+You can also disable all operations for an item or a collection. This example disable all routes for an item: 
+
+[codeSelector]
+```php
+<?php
+// api/src/Entity/Book.php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+
+/**
+ * ...
+ * @ApiResource(
+ *     collectionOperations={"get"},
+ *     itemOperations={}
+ * )
+ */
+class Book
+{
+    // ...
+}
+```
+
+```yaml
+# api/config/api_platform/resources.yaml
+App\Entity\Book:
+    collectionOperations:
+        get: ~ # nothing more to add if we want to keep the default controller
+    itemOperations: []
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- api/config/api_platform/resources.xml -->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata
+           https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+    <resource class="App\Entity\Book">
+        <collectionOperations>
+            <collectionOperation name="get" />
+        </collectionOperations>
+        <itemOperations />
+    </resource>
+</resources>
+```
+[/codeSelector]
+
 API Platform Core is smart enough to automatically register the applicable Symfony route referencing a built-in CRUD action
 just by specifying the method name as key, or by checking the explicitly configured HTTP method.
 


### PR DESCRIPTION
Hello, 

I add a configuration if we want to disable all routes for a `collection` or an `item`.