### PR TITLE
Data Persister page - Improved Built-In Data Persisters Usage

### DIFF
--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -140,7 +140,13 @@ Even with service autowiring and autoconfiguration enabled, you must still confi
 services:
     # ...
     App\DataPersister\UserDataPersister:
-        decorates: 'api_platform.doctrine.orm.data_persister'
+        # Use this if you want to pass arguments only instead of replacing the service.
+        bind:
+            $decorated: '@api_platform.doctrine.orm.data_persister'
+        # This configuration replaces "api_platform.doctrine.orm.data_persister" with a new one, but keeps a reference.
+        # The decorates option tells the container that the App\DataPersister\UserDataPersister service replaces the api_platform.doctrine.orm.data_persister service.
+        #decorates: 'api_platform.doctrine.orm.data_persister'
+        
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\DataPersister\UserDataPersister.inner']
         #tags: [ 'api_platform.data_persister' ]


### PR DESCRIPTION
Improved Built-In Data Persisters Usage.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `master` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
