### PR TITLE
Includes `request` to available variables in security

### DIFF
--- a/core/security.md
+++ b/core/security.md
@@ -100,7 +100,11 @@ In this example:
 * Only users having the `ROLE_ADMIN` or owning the current object can replace an existing book (configured on the `put` operation)
 * Only users having the `ROLE_ADMIN` can view or modify the `adminOnlyProperty` property. Only users having the `ROLE_ADMIN` can create a new resource specifying `adminOnlyProperty` value.
 
-Available variables are `user` (the current logged in object, if any), and `object` (the current resource, or collection of resources for collection operations).
+Available variables are:
+
+* `user`: the current logged in object, if any
+* `object`: the current resource, or collection of resources for collection operations
+* `request`: the current request
 
 Access control checks in the `security` attribute are always executed before the [denormalization step](serialization.md).
 It means than for `PUT` requests, `object` doesn't contain the value submitted by the user, but values currently stored in [the persistence layer](data-persisters.md).


### PR DESCRIPTION
Includes `request` to available variables in security.