### PR TITLE
Use "int" type instead of "integer" deprecated type

### DIFF
--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -111,7 +111,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Product
 {
     /**
-     * @ODM\Id(strategy="INCREMENT", type="integer")
+     * @ODM\Id(strategy="INCREMENT", type="int")
      */
     private $id;
 
@@ -170,7 +170,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Offer
 {
     /**
-     * @ODM\Id(strategy="INCREMENT", type="integer")
+     * @ODM\Id(strategy="INCREMENT", type="int")
      */
     private $id;
 


### PR DESCRIPTION
"integer" type was deprecated in doctrine/mongodb-odm 2.1 and will be removed in 3.0. Use "int" instead.