### PR TITLE
[Releases] Update stable and old-stable branch

### DIFF
--- a/extra/releases.md
+++ b/extra/releases.md
@@ -6,7 +6,7 @@ Only 3 versions are maintained at the same time:
 
 * **stable** (currently the **2.6** branch): regular bug fixes are integrated in this version
 * **old-stable** (currently **2.5** branch): security fixes are integrated in this version, regular bug fixes are **not** backported in it
-* **development** (**master** branch): new features target this branch
+* **development** (**main** branch): new features target this branch
 
 Older versions (1.x, 2.0...) **are not maintained**. If you still use them, you must upgrade as soon as possible.
 

--- a/extra/releases.md
+++ b/extra/releases.md
@@ -4,8 +4,8 @@ API Platform follows the [Semantic Versioning](https://semver.org) strategy.
 
 Only 3 versions are maintained at the same time:
 
-* **stable** (currently the **2.5** branch): regular bug fixes are integrated in this version
-* **old-stable** (currently **2.4** branch): security fixes are integrated in this version, regular bug fixes are **not** backported in it
+* **stable** (currently the **2.6** branch): regular bug fixes are integrated in this version
+* **old-stable** (currently **2.5** branch): security fixes are integrated in this version, regular bug fixes are **not** backported in it
 * **development** (**master** branch): new features target this branch
 
 Older versions (1.x, 2.0...) **are not maintained**. If you still use them, you must upgrade as soon as possible.


### PR DESCRIPTION
Hi :wave: 

With the official release of [2.6.0](https://github.com/api-platform/core/releases/tag/v2.6.0) :tada:, here is my traditionnal PR to update **Release Process** with new stable version

Note that for the moment, the 2.6 branch doesn't exist yet in https://github.com/api-platform/core, so maybe we should wait this branch exist to merge this PR. 


