### PR TITLE
Update client_items_per_page  doc

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -173,8 +173,9 @@ class Book
 api_platform:
     collection:
         pagination:
-            client_items_per_page: true # Disabled by default
             items_per_page_parameter_name: itemsPerPage # Default value
+    defaults:
+        pagination_client_items_per_page: true
 ```
 
 The number of items per page can now be changed adding a query parameter named `itemsPerPage`: `GET /books?itemsPerPage=20`.


### PR DESCRIPTION
Since api-platform/core 2.6: The use of the `collection.pagination.client_items_per_page` has been deprecated in 2.6 and will be removed in 3.0. Use `defaults.pagination_client_items_per_page` instead.