### PR TITLE
Update index.md in distribution docs

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -633,7 +633,7 @@ Oops, we forgot to add the title. Submit the request anyway, you should get a 50
 
 Did you notice that the error was automatically serialized in JSON-LD and respects the Hydra Core vocabulary for errors?
 It allows the client to easily extract useful information from the error. Anyway, it's bad to get a SQL error when submitting
-a request. It means that we didn't use a valid input, and [it's a bad and dangerous practice](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Input_Validation_Cheat_Sheet.md).
+a request. It means that we didn't use a valid input, and [it's a bad and dangerous practice](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html).
 
 API Platform comes with a bridge with [the Symfony Validator Component](https://symfony.com/doc/current/validation.html).
 Adding some of [its numerous validation constraints](https://symfony.com/doc/current/validation.html#supported-constraints)


### PR DESCRIPTION
External link updated because it redirected to a .md working source.

As said in the README of [OWASP's Cheat Sheets repository](https://github.com/OWASP/CheatSheetSeries), markdown documents are not meant to be referenced :

> 🚩 Markdown files are the working sources and are not intended to be referenced in any external documentation, books or websites.