### PR TITLE
Removed "defaults" as example, as client_items_per_page is now under pagination

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -174,8 +174,7 @@ api_platform:
     collection:
         pagination:
             items_per_page_parameter_name: itemsPerPage # Default value
-    defaults:
-        pagination_client_items_per_page: true
+            client_items_per_page: true
 ```
 
 The number of items per page can now be changed adding a query parameter named `itemsPerPage`: `GET /books?itemsPerPage=20`.


### PR DESCRIPTION
If copy n' pasted from the page it will end up in:

> !!  
> !!  In ArrayNode.php line 327:
> !!                                                                                 
> !!    Unrecognized option "defaults" under "api_platform".

but the value moved to collection.pagination as of https://api-platform.com/docs/core/configuration/.