### PR TITLE
Fixes annotation typo in "Filters: ApiFilter Annotation" section

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1262,7 +1262,7 @@ class DummyCar
     /**
      * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
      */
-    #[ApiFilter(SearchFilter::class, properties: {'colors.prop' => 'ipartial'])]
+    #[ApiFilter(SearchFilter::class, properties: ['colors.prop' => 'ipartial'])]
     public $colors;
 
     // ...


### PR DESCRIPTION
Spotted a small typo inside the ApiFilter Annotation section.
