### PR TITLE
Update debugging.md

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -70,7 +70,7 @@ Note for Mac environments use the following:
         remote_handler=dbgp
 ```
 
-In VSCode, alongside the default php config in `launch.json`, you'll need path mappings for a docker image.
+In VSCode, alongside the default PHP configuration in `launch.json`, you'll need path mappings for the Docker image.
 ```json
 {
     "version": "0.2.0",

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -46,8 +46,10 @@ services:
       XDEBUG_MODE: debug
       XDEBUG_CONFIG: >-
         client_host=host.docker.internal
-        client_port=9003 # default port for Xdebug 3
-        idekey=PHPSTORM # or VSCODE if you are debugging with VSCode
+        # default port for Xdebug 3
+        client_port=9003 
+        # or VSCODE if you are debugging with VSCode
+        idekey=PHPSTORM 
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=api-platform
@@ -100,9 +102,3 @@ PHP …
     with Xdebug v3.0.2, Copyright (c) 2002-2021, by Derick Rethans
     …
 ```
-
-
-
-
-
-

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -87,7 +87,8 @@ In VSCode, alongside the default PHP configuration in `launch.json`, you'll need
     ]
 }
 ```
-Note for Linux environments, the `client_host` setting of `host.docker.internal` will not work, you will need the actual local IP address of your computer.
+
+Note: For Linux environments, the `client_host` setting of `host.docker.internal` will not work, you will need the actual local IP address of your computer.
 
 ## Troubleshooting
 

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -71,7 +71,7 @@ Note for Mac environments use the following:
 ```
 
 In VSCode, alongside the default php config in `launch.json`, you'll need path mappings for a docker image.
-```
+```json
 {
     "version": "0.2.0",
     "configurations": [

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -43,12 +43,11 @@ services:
       # See https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
       # See https://github.com/docker/for-linux/issues/264
       # The `remote_host` below may optionally be replaced with `remote_connect_back`
+      XDEBUG_MODE: debug
       XDEBUG_CONFIG: >-
-        remote_enable=1
-        remote_host=host.docker.internal
-        remote_connect_back=1
-        remote_port=9000
-        idekey=PHPSTORM
+        client_host=host.docker.internal
+        client_port=9003 # default port for Xdebug 3
+        idekey=PHPSTORM # or VSCODE if you are debugging with VSCode
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
       PHP_IDE_CONFIG: serverName=api-platform
@@ -61,12 +60,32 @@ Note for Mac environments use the following:
         remote_enable=1
         remote_host=docker.for.mac.localhost
         remote_connect_back=0
-        remote_port=9000
+        remote_port=9003
         idekey=PHPSTORM
         remote_autostart=1
         remote_mode=req
         remote_handler=dbgp
 ```
+
+In VSCode, alongside the default php config in `launch.json`, you'll need path mappings.
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "log": true,
+            "pathMappings": {
+                "/srv/api": "${workspaceFolder}/api"
+            },
+        },
+    ]
+}
+```
+Note for Linux environments, the `client_host` setting of `host.docker.internal` will not work, you will need the actual local IP address of your computer
 
 ## Troubleshooting
 
@@ -81,3 +100,9 @@ PHP …
     with Xdebug v3.0.2, Copyright (c) 2002-2021, by Derick Rethans
     …
 ```
+
+
+
+
+
+

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -88,7 +88,7 @@ In VSCode, alongside the default php config in `launch.json`, you'll need path m
     ]
 }
 ```
-Note for Linux environments, the `client_host` setting of `host.docker.internal` will not work, you will need the actual local IP address of your computer
+Note for Linux environments, the `client_host` setting of `host.docker.internal` will not work, you will need the actual local IP address of your computer.
 
 ## Troubleshooting
 

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -43,12 +43,13 @@ services:
       # See https://docs.docker.com/docker-for-mac/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
       # See https://github.com/docker/for-linux/issues/264
       # The `remote_host` below may optionally be replaced with `remote_connect_back`
+      # XDEBUG_MODE required for step debugging
       XDEBUG_MODE: debug
+      # default port for Xdebug 3 is 9003
+      # idekey=VSCODE if you are debugging with VSCode
       XDEBUG_CONFIG: >-
         client_host=host.docker.internal
-        # default port for Xdebug 3
         client_port=9003 
-        # or VSCODE if you are debugging with VSCode
         idekey=PHPSTORM 
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings
@@ -69,7 +70,7 @@ Note for Mac environments use the following:
         remote_handler=dbgp
 ```
 
-In VSCode, alongside the default php config in `launch.json`, you'll need path mappings.
+In VSCode, alongside the default php config in `launch.json`, you'll need path mappings for a docker image.
 ```
 {
     "version": "0.2.0",

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -49,7 +49,6 @@ services:
       # idekey=VSCODE if you are debugging with VSCode
       XDEBUG_CONFIG: >-
         client_host=host.docker.internal
-        client_port=9003 
         idekey=PHPSTORM 
       # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
       # Then PHPStorm will use the corresponding path mappings


### PR DESCRIPTION
Xdebug 3 no longer uses the remote_ convention, they have been removed in Xdebug 3. 
Need XDEBUG_MODE: debug for step debugging

Added sample launch.json for .vscode

These changes are all for Ubuntu 20.04, so maybe the different configs could be separated out?

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
