### PR TITLE
Add tag to JWT Token Operation

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -249,6 +249,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
             ref: 'JWT Token',
             post: new Model\Operation(
                 operationId: 'postCredentialsItem',
+                tags: ['Token'],
                 responses: [
                     '200' => [
                         'description' => 'Get JWT token',


### PR DESCRIPTION
I add `tag` to JWT Token Operation in `JwtDecorator`, because before adding a tag to operation it looks likes:

![Screenshot from 2021-03-26 11-44-41](https://user-images.githubusercontent.com/10156301/112615289-f9769180-8e2a-11eb-9deb-44edf980d363.png)

After adding a tag to the operation it looks  likes this:

![Screenshot from 2021-03-26 12-02-51](https://user-images.githubusercontent.com/10156301/112615558-49edef00-8e2b-11eb-957b-7d07300e0a18.png)

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
