### PR TITLE
Fix sintax error missing ]

### DIFF
--- a/core/controllers.md
+++ b/core/controllers.md
@@ -95,7 +95,7 @@ use App\Controller\CreateBookPublication;
         'path' => '/books/{id}/publication',
         'controller' => CreateBookPublication::class,
     ],
-])
+])]
 class Book
 {
     //...


### PR DESCRIPTION
There was a missing ] in the documentation causing `Uncaught Error: syntax error, unexpected token "class", expecting "]"` , this pull request fixes that
