### PR TITLE
Add empty security option to remove security of authentication endpoint

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -273,6 +273,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
                         ],
                     ]),
                 ),
+                security: [],
             ),
         );
         $openApi->getPaths()->addPath('/authentication_token', $pathItem);


### PR DESCRIPTION
This PR adds a empty security array to authentication_token route. With this parameter set this route won't require authentication in openapi anymore.
