### PR TITLE
Improve helm for Version 3 (WIP)

### DIFF
--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -39,24 +39,6 @@ Working-Dir: Your local installation of api-platform. Default /api-platform/
     docker push gcr.io/test-api-platform/caddy
     docker push gcr.io/test-api-platform/pwa
 
-#### Example with a local registry for develop
-
-Run a local registry with the [official image from Docker](https://hub.docker.com/_/registry)
-
-    docker run -d -p 5000:5000 --restart always --name registry registry:latest
-
-#### 1. Build the images and tag them:
-
-    docker build -t localhost:5000/api-platform/php -t localhost:5000/api-platform/php:latest api --target api_platform_php
-    docker build -t localhost:5000/api-platform/caddy -t localhost:5000/api-platform/caddy:latest api --target api_platform_caddy
-    docker build -t localhost:5000/api-platform/pwa -t localhost:5000/api-platform/pwa:latest pwa --target api_platform_pwa_prod
-
-#### 2. Push your images to your Docker registry
-
-    docker push localhost:5000/api-platform/php
-    docker push localhost:5000/api-platform/caddy
-    docker push localhost:5000/api-platform/pwa
-
 ## Deploying with Helm 3
 
 ### 1. Check the Helm-Version. 

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -87,8 +87,7 @@ The result should look similar to *Downloading postgresql from repo https://char
         --set php.appSecret='!ChangeMe!' \
         --set postgresql.postgresqlPassword='!ChangeMe!' \
         --set postgresql.persistence.enabled=true \
-        --set corsAllowOrigin='^https?://[a-z\]*\.mywebsite.com$' \
-        --set serviceAccount.create=false
+        --set corsAllowOrigin='^https?://[a-z\]*\.mywebsite.com$'
 
 You can add the parameter `--dry-run` to check upfront if anything is correct.
 Replace the values with the image-parameters from the stage above.


### PR DESCRIPTION
Improve helm for Version 3 (WIP)

There are some points to discuss in my point of view.

- I removed the notice for < 18.04 (18.04 is released on 2018-04-10)
  https://docs.docker.com/engine/release-notes/18.04/
- These lines do exactly the same, so they could be changed, or not?
  actual: docker build -t gcr.io/test-api-platform/php -t gcr.io/test-api-platform/php:latest api --target api_platform_php
  new: docker build -t gcr.io/test-api-platform/php:latest api --target api_platform_php
- Can i remove the part of "Tiller RBAC Issue" and concentrate on Helm v.3 ?
- Can i remove the Sentence "Finally, build the `pwa` (client and admin) JavaScript apps and [deploy them on a static
website hosting service](https://create-react-app.dev/docs/deployment/)." ?
  The PWA is now a Pod in Kubernetes.
- Needs more testing

The **ServiceAccount** default works in minikube. But it has errors in kubernetes for me.
I will open an issue after further investigation.
--set serviceAccount.create=false
