### PR TITLE
correction in PHP code

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -143,8 +143,8 @@ use ApiPlatform\Core\Annotation\ApiResource;
     subresourceOperations: [
         'api_questions_answer_get_subresource' => [
             'method' => 'GET',
-            'normalization_context': [
-                'groups': ['foobar'],
+            'normalization_context' => [
+                'groups' => ['foobar'],
             ],
         ],
     ],


### PR DESCRIPTION
corrected code sample that still used DocBlock notations in PHP8 Attributes

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
