### PR TITLE
Fixes to Content Negotiation / Serialization docs

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -2,7 +2,7 @@
 
 The API system has built-in [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation) capabilities.
 
-By default, only the [JSON-LD](https://json-ld.org) format is enabled. However API Platform Core supports many more formats and can be extended.
+By default, only the [JSON-LD](https://json-ld.org) and JSON formats are enabled. However API Platform Core supports many more formats and can be extended.
 
 The framework natively supports JSON-LD (and Hydra), GraphQL, JSON:API, HAL, YAML, CSV, HTML (API docs), raw JSON and raw XML.
 Using the raw JSON or raw XML formats is discouraged, prefer using JSON-LD instead, which provides more feature and is as easy to use.
@@ -52,6 +52,7 @@ api_platform:
         yaml:     ['application/x-yaml']
         csv:      ['text/csv']
         html:     ['text/html']
+        myformat: ['application/vnd.myformat']
 ```
 
 To enable GraphQL support, [read the dedicated chapter](graphql.md).

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -694,7 +694,9 @@ services:
 Note: this normalizer will work only for JSON-LD format, if you want to process JSON data too, you have to decorate another service:
 
 ```yaml
-    App\Serializer\ApiNormalizer:
+    # Need a different name to avoid duplicate YAML key
+    'app.serializer.normalizer.item.json':
+        class: 'App\Serializer\ApiNormalizer'
         decorates: 'api_platform.serializer.normalizer.item'
 ```
 


### PR DESCRIPTION
- Docs state that only JSON-LD is enabled by default, which isn't the case: https://github.com/api-platform/core/blob/de5988dacc871a7c1565aa8dea8c30102984cff9/src/Bridge/Symfony/Bundle/DependencyInjection/Configuration.php#L216...L218
  - While JSON may only enabled for the sake of Swagger, it still means that someone can use content negotiation anywhere on the API to request data in an unexpected format... perhaps bypassing a custom normalizer.  Important for security considerations developers are aware that more formats exist.
  - (HTML is enabled by default too, but from what I see this doesn't provide a way to actually interact with the main API - so probably doesn't need to be mentioned?)
- Added the missing `myformat` example which is talked about but not shown.
- In the Serialization section, the approach recommended for adding a custom serializer to multiple content types won't work due to duplicate YAML key.