### PR TITLE
docs(errors): document the different behaviour depending on status code

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -105,5 +105,6 @@ the error will be returned in this format as well:
 ## Message Scope
 
 Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted information.
-- If your status code is >= 500 and < 600, the exception message will only be displayed in debug mode (dev and test). In production, a generic message matching the status code provided will be shown instead. If you are using an unofficial HTTP code, a general message will be displayed.
-- in any other cases, your exception message will be sent to end users
+If your status code is >= 500 and < 600, the exception message will only be displayed in debug mode (dev and test). In production, a generic message matching the status code provided will be shown instead. If you are using an unofficial HTTP code, a general message will be displayed.
+
+In any other cases, your exception message will be sent to end users.

--- a/core/errors.md
+++ b/core/errors.md
@@ -101,3 +101,7 @@ the error will be returned in this format as well:
   "hydra:description": "The product \"1234\" does not exist."
 }
 ```
+### Message scope
+Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted informations.
+- If your status code is >= 500 and < 600, it will be only thrown in debug environments (dev and test). In production, a message matching the status code provided will be thrown. If you are using an unofficial HTTP code, a generic message will be thrown instead.
+- in any other cases, your exception message will be sent to end users

--- a/core/errors.md
+++ b/core/errors.md
@@ -104,6 +104,6 @@ the error will be returned in this format as well:
 
 ## Message Scope
 
-Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted informations.
+Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted information.
 - If your status code is >= 500 and < 600, it will be only thrown in debug environments (dev and test). In production, a message matching the status code provided will be thrown. If you are using an unofficial HTTP code, a generic message will be thrown instead.
 - in any other cases, your exception message will be sent to end users

--- a/core/errors.md
+++ b/core/errors.md
@@ -101,7 +101,9 @@ the error will be returned in this format as well:
   "hydra:description": "The product \"1234\" does not exist."
 }
 ```
-### Message scope
+
+## Message Scope
+
 Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted informations.
 - If your status code is >= 500 and < 600, it will be only thrown in debug environments (dev and test). In production, a message matching the status code provided will be thrown. If you are using an unofficial HTTP code, a generic message will be thrown instead.
 - in any other cases, your exception message will be sent to end users

--- a/core/errors.md
+++ b/core/errors.md
@@ -105,5 +105,5 @@ the error will be returned in this format as well:
 ## Message Scope
 
 Depending on the status code you use, the message may be replaced with a generic one in production to avoid leaking unwanted information.
-- If your status code is >= 500 and < 600, it will be only thrown in debug environments (dev and test). In production, a message matching the status code provided will be thrown. If you are using an unofficial HTTP code, a generic message will be thrown instead.
+- If your status code is >= 500 and < 600, the exception message will only be displayed in debug mode (dev and test). In production, a generic message matching the status code provided will be shown instead. If you are using an unofficial HTTP code, a general message will be displayed.
 - in any other cases, your exception message will be sent to end users


### PR DESCRIPTION
See https://github.com/api-platform/core/issues/4275

It was not clear that the HTTP status code chosen had an impact on whether the exception message will be sent to end users or not.
This PR adds a little explanation.
