### PR TITLE
docs: Improve jwt features

### DIFF
--- a/client-generator/react.md
+++ b/client-generator/react.md
@@ -61,7 +61,7 @@ Omit the resource flag to generate files for all resource types exposed by the A
 If you don't use the standalone installation, run the following command instead:
 
 ```console
-npx @api-platform/client-generator https://demo.api-platform.com src/ --resource book
+npx @api-platform/client-generator https://demo.api-platform.com src/ --resource book -g react
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.

--- a/client-generator/troubleshooting.md
+++ b/client-generator/troubleshooting.md
@@ -55,3 +55,7 @@ cause: null } }
 Check access to the specified URL, in this case `https://demo.api-platform.com/contexts/Entrypoint`, use curl to check
 access and the response `curl https://demo.api-platform.com/contexts/Entrypoint`. In the above case an "Access Denied"
 message in JSON format was being returned.  
+
+## Docker distribution on Windows and hot-reloading
+
+Due to [a long-time known Docker for Windows issue](https://forums.docker.com/t/file-system-watch-does-not-work-with-mounted-volumes/12038), the files changes on the host are not notified on the `pwa` container. It causes the hot-reloading feature to not working properly for Windows users.

--- a/client-generator/vuetify.md
+++ b/client-generator/vuetify.md
@@ -2,7 +2,7 @@
 
 ## Install with Docker
 
-If you use the API Platform distribution with docker, first you have to add the [Vue CLI](https://cli.vuejs.org/guide/) to the `yarn global add` command in `client/Dockerfile`:
+If you use the API Platform distribution with docker, first you have to add the [Vue CLI](https://cli.vuejs.org/guide/) to the `yarn global add` command in `pwa/Dockerfile`:
 
 ```dockerfile
 RUN yarn global add @api-platform/client-generator @vue/cli @vue/cli-service-global

--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -150,7 +150,7 @@ services:
 
 ## Calling multiple DataPersisters
 
-Our DataPersisters are called in chain, once a data persister is supported the chain breaks and API Platform assumes your data is persisted. You can call mutliple data persisters by implementing the `ResumableDataPersisterInterface`:
+Our DataPersisters are called in chain, once a data persister is supported the chain breaks and API Platform assumes your data is persisted. You can call multiple data persisters by implementing the `ResumableDataPersisterInterface`:
 
 ```php
 namespace App\DataPersister;

--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -184,4 +184,53 @@ final class BlogPostDataPersister implements ContextAwareDataPersisterInterface,
 }
 ```
 
-This is very useful when using [`Messenger` with API Platform](messenger.md) as you may want to do something asynchronously with the data but still call the default Doctrine data persister.
+This is very useful when using [`Messenger` with API Platform](messenger.md) as you may want to do something asynchronously with the data but still call the default Doctrine data persister, for example:
+```php
+namespace App\DataPersister;
+
+use ApiPlatform\Core\DataPersister\ContextAwareDataPersisterInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\BlogPost;
+
+final class BlogPostDataPersister implements ContextAwareDataPersisterInterface, ResumableDataPersisterInterface 
+{
+    private $entityManager;
+    
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+    
+    public function supports($data, array $context = []): bool
+    {
+        return $data instanceof BlogPost;
+    }
+
+    public function persist($data, array $context = [])
+    {
+        $this->entityManager->persist($data);
+        $this->entityManager->flush();
+    }
+
+    public function remove($data, array $context = [])
+    {
+        $this->entityManager->remove($data);
+        $this->entityManager->flush();
+    }
+
+    // Once called this data persister will resume to the next one
+    public function resumable(array $context = []): bool 
+    {
+        return true;
+    }
+}
+```
+```yaml
+# api/config/services.yaml
+services:
+    # ...
+    App\DataPersister\BlogPostDataPersister: ~
+        # Uncomment only if autoconfiguration is disabled
+        #arguments: ['@App\DataPersister\BlogPostDataPersister.inner']
+        #tags: [ 'api_platform.data_persister' ]
+```

--- a/core/filters.md
+++ b/core/filters.md
@@ -280,7 +280,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
 
 #[ApiResource]
-#[ApiFilter(BooleanFilter::class, properties: ['isAvailableGenericallyInMyCountry']]
+#[ApiFilter(BooleanFilter::class, properties: ['isAvailableGenericallyInMyCountry'])]
 class Offer
 {
     // ...
@@ -310,7 +310,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter;
 
 #[ApiResource]
-#[ApiFilter(NumericFilter::class, properties: ['sold']]
+#[ApiFilter(NumericFilter::class, properties: ['sold'])]
 class Offer
 {
     // ...
@@ -340,7 +340,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter;
 
 #[ApiResource]
-#[ApiFilter(RangeFilter::class, properties: ['price']]
+#[ApiFilter(RangeFilter::class, properties: ['price'])]
 class Offer
 {
     // ...
@@ -375,7 +375,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
 
 #[ApiResource]
-#[ApiFilter(ExistsFilter::class, properties: ['transportFees']]
+#[ApiFilter(ExistsFilter::class, properties: ['transportFees'])]
 class Offer
 {
     // ...
@@ -417,7 +417,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['id', 'name'], arguments: ['orderParameterName' => 'order']]
+#[ApiFilter(OrderFilter::class, properties: ['id', 'name'], arguments: ['orderParameterName' => 'order'])]
 class Offer
 {
     // ...
@@ -441,7 +441,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['id' => 'ASC', 'name' => 'DESC']]
+#[ApiFilter(OrderFilter::class, properties: ['id' => 'ASC', 'name' => 'DESC'])]
 class Offer
 {
     // ...
@@ -472,7 +472,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['validFrom' => ['nulls_comparison' => OrderFilter::NULLS_SMALLEST, 'default_direction' => 'DESC']]]
+#[ApiFilter(OrderFilter::class, properties: ['validFrom' => ['nulls_comparison' => OrderFilter::NULLS_SMALLEST, 'default_direction' => 'DESC']])]
 class Offer
 {
     // ...
@@ -508,8 +508,8 @@ use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['product.releaseDate']]
-#[ApiFilter(SearchFilter::class, properties: ['product.color' => 'exact']]
+#[ApiFilter(OrderFilter::class, properties: ['product.releaseDate'])]
+#[ApiFilter(SearchFilter::class, properties: ['product.color' => 'exact'])]
 class Offer
 {
     // ...
@@ -578,7 +578,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['id', 'date'], arguments: ['orderParameterName' => 'order']]
+#[ApiFilter(OrderFilter::class, properties: ['id', 'date'], arguments: ['orderParameterName' => 'order'])]
 class Tweet
 {
     // ...
@@ -602,7 +602,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['id' => 'asc', 'date' => 'desc']]
+#[ApiFilter(OrderFilter::class, properties: ['id' => 'asc', 'date' => 'desc'])]
 class Tweet
 {
     // ...
@@ -641,7 +641,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\MatchFilter;
 
 #[ApiResource]
-#[ApiFilter(MatchFilter::class, properties: ['message']]
+#[ApiFilter(MatchFilter::class, properties: ['message'])]
 class Tweet
 {
     // ...
@@ -672,7 +672,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 
 #[ApiResource]
-#[ApiFilter(TermFilter::class, properties: ['gender', 'age']]
+#[ApiFilter(TermFilter::class, properties: ['gender', 'age'])]
 class User
 {
     // ...
@@ -703,8 +703,8 @@ use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 
 #[ApiResource]
-#[ApiFilter(OrderFilter::class, properties: ['author.firstName']]
-#[ApiFilter(TermFilter::class, properties: ['author.gender']]
+#[ApiFilter(OrderFilter::class, properties: ['author.firstName'])]
+#[ApiFilter(TermFilter::class, properties: ['author.gender'])]
 class Tweet
 {
     // ...
@@ -776,7 +776,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Serializer\Filter\PropertyFilter;
 
 #[ApiResource]
-#[ApiFilter(PropertyFilter::class, arguments: ['parameterName' => 'properties', 'overrideDefaultProperties' => false, 'whitelist' => ['allowed_property']]]
+#[ApiFilter(PropertyFilter::class, arguments: ['parameterName' => 'properties', 'overrideDefaultProperties' => false, 'whitelist' => ['allowed_property']])]
 class Book
 {
     // ...

--- a/core/filters.md
+++ b/core/filters.md
@@ -1262,7 +1262,7 @@ class DummyCar
     /**
      * @ORM\OneToMany(targetEntity="DummyCarColor", mappedBy="car")
      */
-    #[ApiFilter(SearchFilter::class, properties: {'colors.prop' => 'ipartial'])]
+    #[ApiFilter(SearchFilter::class, properties: ['colors.prop' => 'ipartial'])]
     public $colors;
 
     // ...

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -158,11 +158,9 @@ For instance, in the following example, only the query of an item and the create
 
 namespace App\Entity;
 
- * @ApiResource(graphql={
- *     "item_query",
- *     "create"
- * })
- */
+#[ApiResource(
+    graphql: ['item_query', 'create']
+)]
 class Book
 {
     // ...
@@ -289,32 +287,32 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use App\Resolver\BookCollectionResolver;
 use App\Resolver\BookResolver;
 
-/**
- * @ApiResource(graphql={
- *     "retrievedQuery"={
- *         "item_query"=BookResolver::class
- *     },
- *     "notRetrievedQuery"={
- *         "item_query"=BookResolver::class,
- *         "args"={}
- *     },
- *     "withDefaultArgsNotRetrievedQuery"={
- *         "item_query"=BookResolver::class,
- *         "read"=false
- *     },
- *     "withCustomArgsQuery"={
- *         "item_query"=BookResolver::class,
- *         "args"={
- *             "id"={"type"="ID!"},
- *             "log"={"type"="Boolean!", "description"="Is logging activated?"},
- *             "logDate"={"type"="DateTime"}
- *         }
- *     },
- *     "collectionQuery"={
- *         "collection_query"=BookCollectionResolver::class
- *     }
- * })
- */
+#[ApiResource(
+    graphql: [
+      'retrievedQuery' => [
+          'item_query' => BookResolver::class
+      ],
+      'notRetrievedQuery' => [
+          'item_query' => BookResolver::class,
+          'args' => []
+      ],
+      'withDefaultArgsNotRetrievedQuery' => [
+          'item_query' => BookResolver::class,
+          'read' => false
+      ],
+      'withCustomArgsQuery' => [
+          'item_query' => BookResolver::class,
+          'args' => [
+              'id' => ['type' => 'ID!'],
+              'log' => ['type' => 'Boolean!', 'description' => 'Is logging activated?'],
+              'logDate' => ['type' => 'DateTime']
+          ]
+      ],
+      'collectionQuery' => [
+          'collection_query' => BookCollectionResolver::class
+      ]
+    ]
+)]
 class Book
 {
     // ...
@@ -446,24 +444,24 @@ namespace App\Model;
 use ApiPlatform\Core\Annotation\ApiResource;
 use App\Resolver\BookMutationResolver;
 
-/**
- * @ApiResource(graphql={
- *     "mutation"={
- *         "mutation"=BookMutationResolver::class
- *     },
- *     "withCustomArgsMutation"={
- *         "mutation"=BookMutationResolver::class,
- *         "args"={
- *             "sendMail"={"type"="Boolean!", "description"="Send a mail?"}
- *         }
- *     },
- *     "disabledStagesMutation"={
- *         "mutation"=BookMutationResolver::class,
- *         "deserialize"=false,
- *         "write"=false
- *     }
- * })
- */
+#[ApiResource(
+    graphql: [
+        'mutation' => [
+            'mutation' => BookMutationResolver::class
+        ],
+        'withCustomArgsMutation' => [
+            'mutation' => BookMutationResolver::class,
+            'args' => [
+                'sendMail' => ['type' => 'Boolean!', 'description'=> 'Send a mail?' ]
+            ]
+        ],
+        'disabledStagesMutation' => [
+            'mutation' => BookMutationResolver::class,
+            'deserialize' => false,
+            'write' => false
+        ]
+    ]
+)]
 class Book
 {
     // ...
@@ -530,16 +528,14 @@ namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     graphql={
- *         ...
- *         "update",
- *         ...
- *     },
- *     mercure=true
- * )
- */
+ #[ApiResource(
+      graphql: [
+          ...
+          'update',
+          ...
+      ],
+      mercure: true
+)]
 class Book
 {
     // ...
@@ -681,13 +677,13 @@ namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(graphql={
- *     "mutation"={
- *         "write"=false
- *     }
- * })
- */
+#[ApiResource(
+    graphql: [
+        'mutation' => [
+            'write' => false
+        ]
+    ]
+)]
 class Book
 {
     // ...
@@ -703,14 +699,12 @@ namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     graphql={...},
- *     attributes={
- *         "write"=false
- *     }
- * })
- */
+#[ApiResource(
+    graphql: [...],
+    attributes: [
+        'write' => false
+    ]
+)]
 class Book
 {
     // ...
@@ -743,22 +737,20 @@ namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     attributes={
- *         "filters"={"offer.search_filter"}
- *     },
- *     graphql={
- *         "item_query",
- *         "collection_query"={
- *              "filters"={"offer.date_filter"}
- *          },
- *          "delete",
- *          "update",
- *          "create"
- *     }
- * )
- */
+#[ApiResource(
+    attributes: [
+        'filters' => ['offer.search_filter']
+    ],
+    graphql: [
+        'item_query',
+        'collection_query' => [
+            'filters' => ['offer.date_filter']
+        ],
+        'delete',
+        'update',
+        'create'
+    ]
+)]
 class Offer
 {
     // ...
@@ -819,11 +811,9 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
-/**
- * @ApiResource
- * @ApiFilter(OrderFilter::class, properties={"product.releaseDate"})
- * @ApiFilter(SearchFilter::class, properties={"product.color": "exact"})
- */
+#[ApiResource]
+#[ApiFilter(OrderFilter::class, properties: ['product.releaseDate'])]
+#[ApiFilter(SearchFilter::class, properties: ['product.color' => 'exact'])]
 class Offer
 {
     // ...
@@ -966,19 +956,17 @@ namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     graphql={
- *          "item_query",
- *          "collection_query"={
- *              "pagination_type"="page"
- *          },
- *          "delete",
- *          "update",
- *          "create"
- *     }
- * )
- */
+#[ApiResource(
+    graphql: [
+        'item_query',
+         'collection_query' => [
+            'pagination_type' => 'page'
+         ],
+         'delete',
+         'update',
+         'create'
+    ]
+)]
 class Offer
 {
     // ...
@@ -995,13 +983,11 @@ namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     attributes={
- *          "pagination_type"="page"
- *     }
- * )
- */
+#[ApiResource(
+    attributes: [
+        'pagination_type' => 'page'
+    ]
+)]
 class Offer
 {
     // ...
@@ -1062,9 +1048,7 @@ It can also be disabled for a specific resource (REST and GraphQL):
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_enabled"=false})
- */
+#[ApiResource(attributes: ['pagination_enabled' => false])]
 class Book
 {
     // ...
@@ -1081,9 +1065,7 @@ You can also disable the pagination for a specific collection operation:
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(graphql={"collection_query"={"pagination_enabled"=false}})
- */
+#[ApiResource(graphql: ['collection_query' => ['pagination_enabled' => false]])]
 class Book
 {
     // ...
@@ -1109,23 +1091,21 @@ namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(
- *     attributes={"security"="is_granted('ROLE_USER')"},
- *     collectionOperations={
- *         "post"={"security"="is_granted('ROLE_ADMIN')", "security_message"="Only admins can add books."}
- *     },
- *     itemOperations={
- *         "get"={"security"="is_granted('ROLE_USER') and object.owner == user", "security_message"="Sorry, but you are not the book owner."}
- *     },
- *     graphql={
- *         "item_query"={"security"="is_granted('ROLE_USER') and object.owner == user"},
- *         "collection_query"={"security"="is_granted('ROLE_ADMIN')"},
- *         "delete"={"security"="is_granted('ROLE_ADMIN')"},
- *         "create"={"security"="is_granted('ROLE_ADMIN')"}
- *     }
- * )
- */
+#[ApiResource(
+    attributes: ['security' => "is_granted('ROLE_USER')"],
+    collectionOperations: [
+        'post' => ['security' => "is_granted('ROLE_ADMIN')", 'security_message' => 'Only admins can add books.']
+    ],
+    itemOperations: [
+        'get' => ['security' => "is_granted('ROLE_USER') and object.owner == user", 'security_message' => 'Sorry, but you are not the book owner.']
+    ],
+    graphql: [
+        'item_query' => ['security' => "is_granted('ROLE_USER') and object.owner == user"],
+        'collection_query' => ['security' => "is_granted('ROLE_ADMIN')"],
+        'delete' => ['security' => "is_granted('ROLE_ADMIN')"],
+        'create' => ['security' => "is_granted('ROLE_ADMIN')"]
+    ]
+)]
 class Book
 {
     // ...
@@ -1156,20 +1136,18 @@ namespace App\Entity;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
-/**
- * @ApiResource(
- *     normalizationContext={"groups"={"read"}},
- *     denormalizationContext={"groups"={"write"}},
- *     graphql={
- *         "item_query"={"normalization_context"={"groups"={"item_query"}}},
- *         "collection_query"={"normalization_context"={"groups"={"collection_query"}}},
- *         "create"={
- *             "normalization_context"={"groups"={"collection_query"}},
- *             "denormalization_context"={"groups"={"mutation"}}
- *         }
- *     }
- * )
- */
+#[ApiResource(
+    normalizationContext: ['groups' => ['read']],
+    denormalizationContext: ['groups' => ['write']],
+    graphql: [
+        'item_query' => ['normalization_context' => ['groups' => ['item_query']]],
+        'collection_query' => ['normalization_context' => ['groups' => ['collection_query']]],
+        'create' => [
+            'normalization_context' => ['groups' => ['collection_query']],
+            'denormalization_context' => ['groups' => ['mutation']]
+        ]
+    }
+)]
 class Book
 {
     // ...
@@ -1386,10 +1364,8 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
-/**
- * @ApiResource
- * @ApiFilter(SearchFilter::class, properties={"publicationDate": "partial"})
- */
+#[ApiResource]
+#[ApiFilter(SearchFilter::class, properties: ['publicationDate' => 'partial'])]
 class Book
 {
     // ...
@@ -1444,10 +1420,8 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
-/**
- * @ApiResource
- * @ApiFilter(SearchFilter::class, properties={"relatedBooks.name": "exact"})
- */
+#[ApiResource]
+#[ApiFilter(SearchFilter::class, properties: ['relatedBooks.name' => 'exact'])]
 class Book
 {
     // ...
@@ -1775,23 +1749,23 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 /**
  * @ORM\Entity
- * @ApiResource(
- *     iri="http://schema.org/MediaObject",
- *     normalizationContext={
- *         "groups"={"media_object_read"}
- *     },
- *     graphql={
- *         "upload"={
- *             "mutation"=CreateMediaObjectResolver::class,
- *             "deserialize"=false,
- *             "args"={
- *                 "file"={"type"="Upload!", "description"="The file to upload"}
- *             }
- *         }
- *     }
- * )
  * @Vich\Uploadable
  */
+#[ApiResource(
+    iri: 'http://schema.org/MediaObject',
+    normalizationContext: [
+        'groups' => ['media_object_read']
+    ],
+    graphql: [
+        'upload' => [
+            'mutation' => CreateMediaObjectResolver::class,
+            'deserialize' => false,
+            'args' => [
+                'file' => ['type' => 'Upload!', 'description' => 'The file to upload']
+            ]
+        ]
+    ]
+)]
 class MediaObject
 {
     /**
@@ -1806,9 +1780,9 @@ class MediaObject
     /**
      * @var string|null
      *
-     * @ApiProperty(iri="http://schema.org/contentUrl")
      * @Groups({"media_object_read"})
      */
+    #[ApiProperty(iri: 'http://schema.org/contentUrl)]
     public $contentUrl;
 
     /**
@@ -1916,13 +1890,13 @@ namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiResource;
 
-/**
- * @ApiResource(graphql={
- *     "create"={
- *         "description"="My custom description."
- *     }
- * })
- */
+#[ApiResource(
+    graphql: [
+        'create' => [
+            'description' => 'My custom description.'
+        ]
+    ]
+)]
 class Book
 {
     // ...

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -1072,6 +1072,12 @@ class Book
 }
 ```
 
+### Partial Pagination
+
+[Partial pagination](pagination.md#partial-pagination) is possible with GraphQL.
+
+When enabled, backwards pagination will not be possible, and the `hasNextPage` information will be always `false`.
+
 ## Security
 
 To add a security layer to your queries and mutations, follow the [security](security.md) documentation.

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -21,8 +21,7 @@ docker-compose exec php sh -c '
 
 You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 
-*Note:* If you used [Symfony Flex to install API Platform](../distribution/index.md#using-symfony-flex-and-composer-advanced-users),
-the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
+*Note:* If you used [Symfony Flex to install API Platform](../distribution/index.md#using-symfony-flex-and-composer-advanced-users), URLs will be prefixed with `/api` by default. For example, the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
 
 ## Changing Location of the GraphQL Endpoint
 
@@ -174,7 +173,7 @@ If you don't know what queries are yet, please [read the documentation about the
 For each resource, two queries are available: one for retrieving an item and the other one for the collection.
 For example, if you have a `Book` resource, the queries `book` and `books` can be used.
 
-### Global Object Identifier
+### Global Object Identifier
 
 When querying an item, you need to pass an identifier as argument. Following the [GraphQL Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm),
 the identifier needs to be globally unique. In API Platform, this argument is represented as an [IRI (Internationalized Resource Identifier)](https://www.w3.org/TR/ld-glossary/#internationalized-resource-identifier).

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -264,7 +264,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
                 summary: 'Get JWT token to login.',
                 requestBody: new Model\RequestBody(
                     description: 'Generate new JWT Token',
-                    content: new ArrayObject([
+                    content: new \ArrayObject([
                         'application/json' => [
                             'schema' => [
                                 '$ref' => '#/components/schemas/Credentials',

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -66,7 +66,7 @@ Then update the security configuration:
 security:
     encoders:
         App\Entity\User:
-            algorithm: argon2i
+            algorithm: auto
 
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
@@ -222,7 +222,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
         $openApi = ($this->decorated)($context);
         $schemas = $openApi->getComponents()->getSchemas();
 
-        $schemas['Token'] = new ArrayObject([
+        $schemas['Token'] = new \ArrayObject([
             'type' => 'object',
             'properties' => [
                 'token' => [
@@ -231,7 +231,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
                 ],
             ],
         ]);
-        $schemas['Credentials'] = new ArrayObject([
+        $schemas['Credentials'] = new \ArrayObject([
             'type' => 'object',
             'properties' => [
                 'email' => [

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -171,8 +171,8 @@ Want to test the routes of your JWT-authentication-protected API?
 # api/config/packages/api_platform.yaml
 api_platform:
     swagger:
-         api_keys:
-             apiKey:
+        api_keys:
+            apiKey:
                 name: Authorization
                 type: header
 ```
@@ -292,6 +292,83 @@ services:
         decorates: 'api_platform.openapi.factory'
         autoconfigure: false
 ```
+
+### Improve return values of the JWT-Token Endpoint
+
+Per Default, only the `Token` is in the Response from the `POST /authentication_token` endpoint.
+If you want to make an auto renewal, after the old token expires, you need to know how long the token is valid.
+This value is stored in the parameter `token_ttl` in the file `api/config/packages/lexik_jwt_authentication.yaml`
+(or overwritten in the Environment).
+
+Here is an example how to add this info and the roles of the user, into the response.
+See [Data-Customization with LexikJWTAuthenticationBundle](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/2-data-customization.md#eventsauthentication_success---adding-public-data-to-the-jwt-response) for details.
+All additional attributes are under the "data"-path in the response.
+
+Create a new File `api\EventListener\AuthenticationSuccessListener`
+
+```php
+<?php
+
+namespace App\EventListener;
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class AuthenticationSuccessListener
+{
+    private ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Add User Role and Expiration-Infos of Token
+     * @param AuthenticationSuccessEvent $event
+     * @throws \Exception
+     */
+    public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $event): void
+    {
+        $data = $event->getData();
+        $user = $event->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return;
+        }
+
+        $token_ttl = $this->container->getParameter('lexik_jwt_authentication.token_ttl');
+
+        $data['data'] = array(
+            'token_ttl' => $token_ttl,
+            'roles' => $user->getRoles(),
+        );
+
+        $event->setData($data);
+    }
+}
+```
+
+And register this service in `config/services.yaml`:
+
+```yaml
+# api/config/services.yaml
+services:
+    # ...   
+
+    acme_api.event.authentication_success_listener:
+        class: App\EventListener\AuthenticationSuccessListener
+        tags:
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccessResponse }
+
+```
+
+With the help of `token_ttl` you can now automate the token renewal.
+[Example for a token renewal with Postman for easy testing](../core/testing-postman.md)
+
+This is just one of many solutions for this problem.
+See section [About token expiration](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/index.md#about-token-expiration) from LexikJWTAuthenticationBundle.
 
 ## Testing
 

--- a/core/subresources.md
+++ b/core/subresources.md
@@ -141,7 +141,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 
  #[ApiResource(
     subresourceOperations: [
-        'api_questions_answer_get_subresource': [
+        'api_questions_answer_get_subresource' => [
             'method' => 'GET',
             'normalization_context': [
                 'groups': ['foobar'],
@@ -206,7 +206,7 @@ You can control the path of subresources with the `path` option of the `subresou
 
 #[ApiResource(
     subresourceOperations: [
-        'api_questions_answer_get_subresource': [
+        'api_questions_answer_get_subresource' => [
             'method' => 'GET',
             'path' => '/questions/{id}/all-answers',
         ],
@@ -227,7 +227,7 @@ The `subresourceOperations` attribute also allows you to add an access control o
 
  #[ApiResource(
     subresourceOperations: [
-        'api_questions_answer_get_subresource': [
+        'api_questions_answer_get_subresource' => [
             'security' => "has_role('ROLE_AUTHENTICATED')",
         ],
     ],

--- a/core/testing-postman.md
+++ b/core/testing-postman.md
@@ -1,0 +1,105 @@
+# Testing with Postman
+
+As mentioned in the [Testing Utilities](../core/testing.md) Postman is an option for automated tests and much more.
+
+## Problem with manual testing
+
+If you just use Swagger UI with JWT and Bearer as Auth-Mode, you have todo a lot of repetitive work.
+Let us take the following example with manual testing.
+You make a change at the code and add an attribute to an entity.
+
+- [x] First you load/reload the Swagger UI
+- [x] Send your Credentials to the authentication Endpoint (/authentication_token).
+- [x] Copy the token from the response (maybe save it in a temporary file).
+- [x] Now you click on "Authorize" in Swagger and enter "Bearer [TOKEN]" and submit the form.
+- [x] **Finally search the correct route, enter the params and check if everything is fine**
+
+Make a new change and start all tasks from the beginning. Boring, isn't it?
+
+## Solution: Postman with automatic authentication
+
+The solution is to automate authentication and testing. One Option is Postman with automatic authentication.
+The following steps are necessary for authentication with JWT in Postman.
+
+1. Follow this guide to [add the TTL of the JWT-Tokens to the authentication Endpoint](../core/jwt.md#improve-return-values-of-the-jwt-token-endpoint).
+
+2. Export OpenApi-Schemata from API-Platform
+
+        symfony console api:openapi:export -o "openapi.json"
+
+3. [Import Data in Postman](https://learning.postman.com/docs/getting-started/importing-and-exporting-data/)
+
+4. Set Auth Type of the Collection to `Bearer Token` and the Token value to `{{AuthTokenVar}}`
+
+5. Add Pre-Request Scripts. See section below.
+
+6. Add/Set Collection Variables according to your settings.
+
+   | Variable            | InitialValue                                  |
+   | ------------------- |---------------------------------------------- |
+   | baseUrl             | <https://localhost/>                          |
+   | AuthUrl             | <https://localhost/authentication_token>      |
+   | AuthTokenVar        |                                               |
+   | AuthToken_CreatedAt |                                               |
+   | AuthToken_ExpiresIn |                                               |
+   | AuthEmail           |                                               |
+   | AuthPassword        |                                               |
+
+### Pre-Request Scripts for authentication with JWT
+
+[Pre-Request Scripts](https://learning.postman.com/docs/writing-scripts/pre-request-scripts/), do exactly what the name says. The run before every request.
+With that help the Auth Token is generated and renewed automatically.
+
+There are different [variable scopes](https://learning.postman.com/docs/sending-requests/variables/#variable-scopes) in Postman.
+In this code only collectionVariables are used for simplicity.
+
+```js
+var tokenCreatedAt = pm.collectionVariables.get("AuthToken_CreatedAt");
+
+// ensure correct initial setup (yesterday)
+if (!tokenCreatedAt) {
+    tokenCreatedAt = new Date(new Date().setDate(new Date().getDate() - 1))
+}
+
+var tokenExpiresIn = pm.collectionVariables.get("AuthToken_ExpiresIn");
+
+if (!tokenExpiresIn) {
+    tokenExpiresIn = 3600; // Default: 1 hour
+}
+
+var tokenCreatedTime = (new Date() - Date.parse(tokenCreatedAt))
+
+if (tokenCreatedTime >= (tokenExpiresIn*1000)) {
+
+    console.log("The token has expired. Attempting to request a new token.");
+
+    pm.sendRequest({
+        url: pm.collectionVariables.get("AuthUrl"),
+        method: 'POST',
+        header: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        body: {
+            mode: 'raw',
+            raw: JSON.stringify(
+                {
+                    "email": pm.collectionVariables.get("AuthEmail"),
+                    "password": pm.collectionVariables.get("AuthPassword")
+                }
+            )
+        }
+    }, function(error, response) {
+
+        var token = response.json().token;
+        var tokenExpiresIn = response.json().data.token_ttl; // in seconds
+
+        if(token)
+        {
+            pm.collectionVariables.set("AuthToken_CreatedAt", new Date());
+            pm.collectionVariables.set("AuthTokenVar", response.json().token);
+            pm.collectionVariables.set("AuthToken_ExpiresIn", tokenExpiresIn);
+        }
+    });
+}
+```

--- a/core/validation.md
+++ b/core/validation.md
@@ -26,9 +26,9 @@ use Symfony\Component\Validator\Constraints as Assert; // Symfony's built-in con
 /**
  * A product.
  *
- * @ApiResource
  * @ORM\Entity
  */
+#[ApiResource]
 class Product
 {
     /**
@@ -138,10 +138,7 @@ You can configure the groups you want to use when the validation occurs directly
 use ApiPlatform\Core\Annotation\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource(attributes={"validation_groups"={"a", "b"}})
- * ...
- */
+#[ApiResource(attributes: ['validation_groups' => ['a', 'b']])]
 class Book
 {
     /**
@@ -179,20 +176,17 @@ You can have different validation for each [operation](operations.md) related to
 use ApiPlatform\Core\Annotation\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource(
- *     collectionOperations={
- *         "get",
- *         "post"={"validation_groups"={"Default", "postValidation"}}
- *     },
- *     itemOperations={
- *         "delete",
- *         "get",
- *         "put"={"validation_groups"={"Default", "putValidation"}}
- *     }
- * )
- * ...
- */
+#[ApiResource(
+    collectionOperations: [
+        'get',
+        'post' => ['validation_groups' => ['Default', 'postValidation']]
+    ],
+    itemOperations: [
+        'delete',
+        'get',
+        'put' => ['validation_groups' => ['Default', 'putValidation']]
+    ]
+)]
 class Book
 {
     /**
@@ -247,11 +241,9 @@ In the following example, we use a static method to return the validation groups
 use ApiPlatform\Core\Annotation\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource(
- *     attributes={"validation_groups"={Book::class, "validationGroups"}}
- * )
- */
+#[ApiResource(
+    attributes: ['validation_groups' => [Book::class, 'validationGroups']]
+)]
 class Book
 {
     /**
@@ -329,9 +321,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use App\Validator\AdminGroupsGenerator;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource(attributes={"validation_groups"=AdminGroupsGenerator::class})
- */
+#[ApiResource(attributes: ['validation_groups' => AdminGroupsGenerator::class])
 class Book
 {
     /**
@@ -394,15 +384,15 @@ use App\Validator\MySequencedGroup; // the sequence group to use
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ApiResource(
- *     collectionOperations={
- *          "post" = {
- *              "validation_groups" = MySequencedGroup::class
- *          }
- *     }
- * )
  * @ORM\Entity
  */
+#[ApiResource(
+    collectionOperations: [
+      'post' => [
+        'validation_groups' => MySequencedGroup::class
+      ]
+    ]
+)]
 class Greeting
 {
     /**


### PR DESCRIPTION
docs: add infos how to add ttl of JWT-tokens in response of the authentication endpoint. add automated authentication with JWT in postman.

I am not sure if it is ok to generate a new page for postman. But later there could be added an example with OAuth2 or other postman related infos. The JWT page is allready very big.

I guess markdown linter will fail because the jwt page use non valid data before.