### PR TITLE
docs: add missing yaml documentation in the default order section

### DIFF
--- a/core/default-order.md
+++ b/core/default-order.md
@@ -5,6 +5,8 @@ API Platform Core provides an easy way to override the default order of items in
 By default, items in the collection are ordered in ascending (ASC) order by their resource identifier(s). If you want to
 customize this order, you must add an `order` attribute on your ApiResource annotation:
 
+[codeSelector]
+
 ```php
 <?php
 // api/src/Entity/Book.php
@@ -28,8 +30,20 @@ class Book
 }
 ```
 
+```yaml
+# config/api/resources/Book.yaml
+App\Entity\Book:
+    attributes:
+        order:
+            foo: ASC
+```
+
+[/codeSelector]
+
 This `order` attribute is used as an array: the key defines the order field, the values defines the direction.
 If you only specify the key, `ASC` direction will be used as default. For example, to order by `foo` & `bar`:
+
+[codeSelector]
 
 ```php
 <?php
@@ -59,7 +73,18 @@ class Book
 }
 ```
 
+```yaml
+# config/api/resources/Book.yaml
+App\Entity\Book:
+    attributes:
+        order: ['foo', 'bar']
+```
+
+[/codeSelector]
+
 It's also possible to configure the default order on an association property:
+
+[codeSelector]
 
 ```php
 <?php
@@ -84,7 +109,18 @@ class Book
 }
 ```
 
+```yaml
+# config/api/resources/Book.yaml
+App\Entity\Book:
+    attributes:
+        order: ['author.username']
+```
+
+[/codeSelector]
+
 Another possibility is to apply the default order for a specific collection operation, which will override the global default order configuration.
+
+[codeSelector]
 
 ```php
 /**
@@ -106,3 +142,21 @@ class Book
     // ...
 }
 ```
+
+```yaml
+# config/api/resources/Book.yaml
+App\Entity\Book:
+    get: ~
+    get_desc_custom:
+        method: get
+        path: custom_collection_desc_foos
+        order:
+            name: DESC
+    get_asc_custom:
+        method: get
+        path: custom_collection_asc_foos
+        order:
+            name: ASC
+```
+
+[/codeSelector]


### PR DESCRIPTION
Add missing yaml documentation in the default order section