### PR TITLE
fix(docs): add missing service configuration

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -623,6 +623,14 @@ It's almost done, we have just one final issue: our fake item operation is visib
 To remove it, we will need to [decorate the Swagger documentation](openapi.md#overriding-the-openapi-specification).
 Then, remove the route from the decorator:
 
+```yaml
+# api/config/services.yaml
+    App\OpenApi\OpenApiFactory:
+        decorates: 'api_platform.openapi.factory'
+        arguments: [ '@App\OpenApi\OpenApiFactory.inner' ]
+        autoconfigure: false
+```
+
 ```php
 <?php
 // src/OpenApi/OpenApiFactory.php


### PR DESCRIPTION
Hi there,

I followed [this documentation](https://api-platform.com/docs/core/operations/#expose-a-model-without-any-routes) and noticed that decorator was never called. Comparing with [this chapter](https://api-platform.com/docs/core/openapi/#overriding-the-openapi-specification), I noticed the service configuration part was missing.

Here it is.

Regards,

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
