### PR TITLE
docs: always use the latest version of the images

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -73,10 +73,10 @@ Similarly, on Windows, only [Docker for Windows](https://docs.docker.com/docker-
 Open a terminal, and navigate to the directory containing your project skeleton. Run the following command to start all
 services using [Docker Compose](https://docs.docker.com/compose/):
 
-Download the latest versions of the pre-built images:
+Download and build the latest versions of the images:
 
 ```console
-docker-compose pull
+docker-compose build --pull --no-cache
 ```
 
 Start Docker Compose in detached mode:


### PR DESCRIPTION
Fix for issues such as https://github.com/api-platform/api-platform/pull/1937