### PR TITLE
Remove empty string defaults from entities

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -260,13 +260,13 @@ class Book
     public ?string $isbn = null;
 
     /** The title of this book. */
-    public string $title = '';
+    public string $title;
 
     /** The description of this book. */
-    public string $description = '';
+    public string $description;
 
     /** The author of this book. */
-    public string $author = '';
+    public string $author;
 
     /** The publication date of this book. */
     public ?\DateTimeInterface $publicationDate = null;
@@ -305,10 +305,10 @@ class Review
     public int $rating = 0;
 
     /** The body of the review. */
-    public string $body = '';
+    public string $body;
 
     /** The author of the review. */
-    public string $author = '';
+    public string $author;
 
     /** The date of publication of this review.*/
     public ?\DateTimeInterface $publicationDate = null;


### PR DESCRIPTION
I'm not getting the SQL exception in 'Validating Data' section; empty strings are being stored instead of null being attempted.

The simplest fix is to remove the default empty strings from the entities.

This is using the Symfony and Composer install.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
