### PR TITLE
docs: Remove empty string defaults from entities

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -647,6 +647,11 @@ Modify the following files as described in these patches:
       */
 +    #[Assert\Isbn]
      public ?string $isbn = null;
+     
+      * @ORM\Column
+      */
++    #[Assert\NotBlank]
+     public string $title = '';
  
       * @ORM\Column(type="text")
       */

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -260,13 +260,13 @@ class Book
     public ?string $isbn = null;
 
     /** The title of this book. */
-    public string $title = '';
+    public string $title;
 
     /** The description of this book. */
-    public string $description = '';
+    public string $description;
 
     /** The author of this book. */
-    public string $author = '';
+    public string $author;
 
     /** The publication date of this book. */
     public ?\DateTimeInterface $publicationDate = null;
@@ -305,10 +305,10 @@ class Review
     public int $rating = 0;
 
     /** The body of the review. */
-    public string $body = '';
+    public string $body;
 
     /** The author of the review. */
-    public string $author = '';
+    public string $author;
 
     /** The date of publication of this review.*/
     public ?\DateTimeInterface $publicationDate = null;

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -402,7 +402,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $title = '';
+     public string $title;
  
 -    /** The description of this book. */
 +    /**
@@ -410,7 +410,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column(type="text")
 +     */
-     public string $description = '';
+     public string $description;
  
 -    /** The author of this book. */
 +    /**
@@ -418,7 +418,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $author = '';
+     public string $author;
  
 -    /** The publication date of this book. */
 +    /**
@@ -480,7 +480,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column(type="text")
 +     */
-     public string $body = '';
+     public string $body;
  
 -    /** The author of the review. */
 +    /**
@@ -488,7 +488,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $author = '';
+     public string $author;
  
 -    /** The date of publication of this review.*/
 +    /**

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -260,13 +260,13 @@ class Book
     public ?string $isbn = null;
 
     /** The title of this book. */
-    public string $title;
+    public string $title = '';
 
     /** The description of this book. */
-    public string $description;
+    public string $description = '';
 
     /** The author of this book. */
-    public string $author;
+    public string $author = '';
 
     /** The publication date of this book. */
     public ?\DateTimeInterface $publicationDate = null;
@@ -305,10 +305,10 @@ class Review
     public int $rating = 0;
 
     /** The body of the review. */
-    public string $body;
+    public string $body = '';
 
     /** The author of the review. */
-    public string $author;
+    public string $author = '';
 
     /** The date of publication of this review.*/
     public ?\DateTimeInterface $publicationDate = null;
@@ -402,7 +402,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $title;
+     public string $title = '';
  
 -    /** The description of this book. */
 +    /**
@@ -410,7 +410,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column(type="text")
 +     */
-     public string $description;
+     public string $description = '';
  
 -    /** The author of this book. */
 +    /**
@@ -418,7 +418,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $author;
+     public string $author = '';
  
 -    /** The publication date of this book. */
 +    /**
@@ -480,7 +480,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column(type="text")
 +     */
-     public string $body;
+     public string $body = '';
  
 -    /** The author of the review. */
 +    /**
@@ -488,7 +488,7 @@ Modify these files as described in these patches:
 +     *
 +     * @ORM\Column
 +     */
-     public string $author;
+     public string $author = '';
  
 -    /** The date of publication of this review.*/
 +    /**
@@ -658,12 +658,12 @@ Modify the following files as described in these patches:
       * @ORM\Column(type="text")
       */
 +    #[Assert\NotBlank]
-     public string $description;
+     public string $description = '';
  
       * @ORM\Column
       */
 +    #[Assert\NotBlank]
-     public string $author;
+     public string $author = '';
  
       * @ORM\Column(type="datetime_immutable")
       */
@@ -686,12 +686,12 @@ Modify the following files as described in these patches:
       * @ORM\Column(type="text")
       */
 +    #[Assert\NotBlank]
-     public string $body;
+     public string $body = '';
  
       * @ORM\Column
       */
 +    #[Assert\NotBlank]
-     public string $author;
+     public string $author = '';
  
       * @ORM\Column(type="datetime_immutable")
       */

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -658,12 +658,12 @@ Modify the following files as described in these patches:
       * @ORM\Column(type="text")
       */
 +    #[Assert\NotBlank]
-     public string $description = '';
+     public string $description;
  
       * @ORM\Column
       */
 +    #[Assert\NotBlank]
-     public string $author = '';
+     public string $author;
  
       * @ORM\Column(type="datetime_immutable")
       */
@@ -686,12 +686,12 @@ Modify the following files as described in these patches:
       * @ORM\Column(type="text")
       */
 +    #[Assert\NotBlank]
-     public string $body = '';
+     public string $body;
  
       * @ORM\Column
       */
 +    #[Assert\NotBlank]
-     public string $author = '';
+     public string $author;
  
       * @ORM\Column(type="datetime_immutable")
       */

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -626,14 +626,7 @@ Now try to add another book by issuing a `POST` request to `/books` with the fol
 }
 ```
 
-Oops, we forgot to add the title. Submit the request anyway, you should get a 500 error with the following message:
-
-> An exception occurred while executing 'INSERT INTO book [...] VALUES [...]' with params [...]:
-> SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'title' cannot be null
-
-Did you notice that the error was automatically serialized in JSON-LD and respects the Hydra Core vocabulary for errors?
-It allows the client to easily extract useful information from the error. Anyway, it's bad to get a SQL error when submitting
-a request. It means that we didn't use a valid input, and [it's a bad and dangerous practice](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html).
+The book is successfully created but there is a problem; we did not give it a title. It makes no sense to create a book record without a title so we really should have some validation measures in place to prevent this from being possible.
 
 API Platform comes with a bridge with [the Symfony Validator Component](https://symfony.com/doc/current/validation.html).
 Adding some of [its numerous validation constraints](https://symfony.com/doc/current/validation.html#supported-constraints)


### PR DESCRIPTION
I'm not getting the SQL exception in 'Validating Data' section; empty strings are being stored instead of null being attempted.

The simplest fix is to remove the default empty strings from the entities.

This is using the Symfony and Composer install.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
