### PR TITLE
docs: change fakerPHP repository link

### DIFF
--- a/distribution/testing.md
+++ b/distribution/testing.md
@@ -65,7 +65,7 @@ docker-compose exec php \
 
 To learn more about fixtures, take a look at the documentation of [Alice](https://github.com/nelmio/alice)
 and [AliceBundle](https://github.com/hautelook/AliceBundle).
-The list of available generators as well as a cookbook explaining how to create custom generators can be found in the documentation of [Faker](https://github.com/fzaninotto/Faker), the library used by Alice under the hood.
+The list of available generators as well as a cookbook explaining how to create custom generators can be found in the documentation of [Faker](https://github.com/fakerphp/faker), the library used by Alice under the hood.
 
 ## Writing Functional Tests
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
The core [```nelmio/alice```](https://github.com/nelmio/alice) changed the Faker dependency from [```fzaninotto/faker```](https://github.com/fzaninotto/faker) to [```fakerphp/faker```](https://github.com/fakerphp/faker).

https://github.com/nelmio/alice/pull/1059