### PR TITLE
docs(security): fix security definition for properties

### DIFF
--- a/core/security.md
+++ b/core/security.md
@@ -102,7 +102,8 @@ class Book
 App\Entity\Book:
     properties:
         adminOnlyProperty:
-            security: 'is_granted("ROLE_ADMIN")'
+            attributes:
+                security: 'is_granted("ROLE_ADMIN")'
 ```
 
 [/codeSelector]


### PR DESCRIPTION
The definition of the `security` attribute for an object property is currently wrong (only in YAML documentation).

The working configuration is the following:
```yaml
# api/config/api_platform/resources/Book.yaml
App\Entity\Book:
    properties:
        adminOnlyProperty:
            attributes:
                security: 'is_granted("ROLE_ADMIN")'
```

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
