### PR TITLE
docs: Update Expo CLI link

### DIFF
--- a/client-generator/react-native.md
+++ b/client-generator/react-native.md
@@ -7,7 +7,7 @@
 To use this generator you need [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/) (or [npm](https://www.npmjs.com/)) installed.
 To run the command line tool, we also recommend using [npx](https://www.npmjs.com/package/npx).
 
-Create a React Native application using [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli).
+Create a React Native application using [Expo CLI](https://docs.expo.io/workflow/expo-cli/).
 
 ```console
 yarn global add expo-cli


### PR DESCRIPTION
Hello! 

The Expo CLI installation link change, a redirection was created but using the next link should be better and avoid a 404 link on API Platform documentation. 
