### PR TITLE
Explain how the default IRI normalization works

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -234,6 +234,31 @@ Refer to the [operations](operations.md) documentation to learn more.
 By default, the serializer provided with API Platform represents relations between objects using [dereferenceable IRIs](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier).
 They allow you to retrieve details for related objects by issuing extra HTTP requests. However, for performance reasons, it is sometimes preferable to avoid forcing the client to issue extra HTTP requests.
 
+**Note:** The serializer automatically creates the IRIs if it can determine that the target type is also an ApiResource. It does this based on the Doctrine configuration, the declared PHP type or the type annotation declared in the DocBlock. This means that if your ApiResource is also a Doctrine entity this will work automatically. However, **if your ApiResource is not a Doctrine entity, special care must be taken:** make sure to declare the type or add a type annotation in a DocBlock. For example:
+
+```PHP
+<?php
+#[ApiResource]
+class Bar {...}
+
+#[ApiResource]
+class Foo {
+  public $bars; // <- This will NOT work; $bars will return as an array of embedded Bar objects instead of an array of IRIs.
+}
+
+
+#[ApiResource]
+class Foo {
+  // This will work; $bars will return as an array of IRIs.
+  /**
+   * @var Bar[]
+   */
+  public $bars;
+}
+```
+
+
+
 **Note:** We strongly recommend using [Vulcain](https://vulcain.rocks) instead of this feature. Vulcain allows creating faster (better hit rate) and better designed APIs than relying on compound documents, and is supported out of the box in the API Platform distribution.
 
 ### Normalization


### PR DESCRIPTION
The serialiser can (and will) turn referenced ApiResources into IRIs - if it knows the referenced item is an ApiResource. It determines this based on the Doctrine annotation, declared type or DocBlock type annotation. If an ApiResource is not a Doctrine entity (which is the recommended approach for non-prototyping apps), it is very easy to not "get" this default behaviour if no type is declared.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
