### PR TITLE
fix: Clarify PUT operation

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -44,7 +44,7 @@ Note: the `PATCH` method must be enabled explicitly in the configuration, refer 
 
 Note: with JSON Merge Patch, the [null values will be skipped](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) in the response.
 
-Note: Current `PUT` implementation behaves more or less like a PATCH. The standard `PUT` behavior will be implemented API-Platfor 3.0. See [#4344] (https://github.com/api-platform/core/issues/4344) 
+Note: Current `PUT` implementation behaves more or less like the `PATCH` method. Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (https://github.com/api-platform/core/issues/4344) to track the progress.
 
 ## Enabling and Disabling Operations
 

--- a/core/operations.md
+++ b/core/operations.md
@@ -36,7 +36,7 @@ Item operations:
 Method   | Mandatory | Description
 ---------|-----------|-------------------------------------------
 `GET`    | yes       | Retrieve an element
-`PUT`    | no        | Replace an element.  
+`PUT`    | no        | Replace an element
 `PATCH`  | no        | Apply a partial modification to an element
 `DELETE` | no        | Delete an element
 

--- a/core/operations.md
+++ b/core/operations.md
@@ -36,13 +36,15 @@ Item operations:
 Method   | Mandatory | Description
 ---------|-----------|-------------------------------------------
 `GET`    | yes       | Retrieve an element
-`PUT`    | no        | Replace an element
+`PUT`    | no        | Replace an element.  
 `PATCH`  | no        | Apply a partial modification to an element
 `DELETE` | no        | Delete an element
 
 Note: the `PATCH` method must be enabled explicitly in the configuration, refer to the [Content Negotiation](content-negotiation.md) section for more information.
 
 Note: with JSON Merge Patch, the [null values will be skipped](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) in the response.
+
+Note: Current `PUT` implementation behaves more or less like a PATCH. The standard `PUT` behavior will be implemented API-Platfor 3.0. See [#4344] (https://github.com/api-platform/core/issues/4344) 
 
 ## Enabling and Disabling Operations
 


### PR DESCRIPTION
This PR clarifies PUT operation (or the fact that it acts more like a patch). Related issue: https://github.com/api-platform/core/issues/4344. Is it possible to see the future roadmap? It needs to be linked in the documentation. 