### PR TITLE
Update filters.md

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1182,6 +1182,7 @@ namespace App\Filter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\PropertyInfo\Type;
 
 final class RegexpFilter extends AbstractContextAwareFilter
 {
@@ -1212,7 +1213,7 @@ final class RegexpFilter extends AbstractContextAwareFilter
         foreach ($this->properties as $property => $strategy) {
             $description["regexp_$property"] = [
                 'property' => $property,
-                'type' => 'string',
+                'type' => Type::BUILTIN_TYPE_STRING,
                 'required' => false,
                 'swagger' => [
                     'description' => 'Filter using a regex. This will appear in the Swagger documentation!',


### PR DESCRIPTION
It is better to use `Type::BUILTIN_TYPE_STRING` in the documentation. 
The reasons for it are: 
- It's a Symfony thing
- By using Symfony Property Info Type the manual conveys the right thinking direction. The custom filter wont work if you use `'boolean'` as the type, the valid value for boolean is `'bool'` which is the value of the constant `Type::BUILTIN_TYPE_BOOL`, 
- By using `Type::BUILTIN_TYPE_STRING` in the documentation, developers will be pushed to the right thinking direction when building a custom filter

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
