### PR TITLE
Adds  argument to service JWTDecorator

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -291,6 +291,7 @@ services:
 
     App\OpenApi\JwtDecorator:
         decorates: 'api_platform.openapi.factory'
+        arguments: [ '@App\OpenApi\OpenApiFactory.inner' ]
         autoconfigure: false
 ```
 


### PR DESCRIPTION
Like in  https://api-platform.com/docs/core/openapi/ its now (Symfony 5.3.7) necessary to add this argument. Otherwise it  will produce circular reference for `App\OpenApi\JwtDecorator`.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
