### PR TITLE
Update serialization.md : Remove unused import in BookAttributeNormalizer

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -877,7 +877,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class BookAttributeNormalizer implements ContextAwareNormalizerInterface, NormalizerAwareInterface
 {


### PR DESCRIPTION
`use Symfony\Component\Serializer\Normalizer\NormalizerInterface;` is not used anymore in `BookAttributeNormalizer`

https://api-platform.com/docs/core/serialization/#changing-the-serialization-context-on-a-per-item-basis
