### PR TITLE
docs: 2.7 update

### DIFF
--- a/admin/handling-relations.md
+++ b/admin/handling-relations.md
@@ -150,10 +150,9 @@ This API uses the following PHP code:
 ```php
 <?php
 // api/src/Entity/Review.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -179,11 +178,10 @@ class Review
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;

--- a/admin/performance.md
+++ b/admin/performance.md
@@ -17,12 +17,11 @@ you can make sure the authors are retrieved in one go by writing:
 ```php
 <?php
 // api/src/Entity/Author.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -35,8 +34,8 @@ class Author
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue
      * @ORM\Id
-     * @ApiFilter(SearchFilter::class, strategy="exact")
      */
+    #[ApiFilter(SearchFilter::class, strategy: "exact")]
     public $id;
 
     /**

--- a/admin/schema.org.md
+++ b/admin/schema.org.md
@@ -16,11 +16,12 @@ To configure which property should be shown to represent your entity, map the pr
 
 ```php
 // api/src/Entity/Person.php
+...
 
-/**
- * @ApiProperty(iri="http://schema.org/name")
- */
+#[ApiProperty(types: ["http://schema.org/name"])]
 private $name;
+
+...
 ```
 
 ## Emails, URLs and Identifiers

--- a/admin/validation.md
+++ b/admin/validation.md
@@ -12,13 +12,12 @@ For instance, with API Platform Core as backend, if you write the following:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 class Book
 {
     /**
@@ -47,13 +46,12 @@ For example if you have this code:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 class Book
 {
     /**

--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -102,12 +102,11 @@ The `format` attribute can be used as a shortcut, it sets both the `input_format
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
- #[ApiResource(formats: ['xml', 'jsonld', 'csv' => ['text/csv']])]
+#[ApiResource(formats: ['xml', 'jsonld', 'csv' => ['text/csv']])]
 class Book
 {
     // ...
@@ -127,21 +126,17 @@ You can specify different accepted formats at operation level too, it's especial
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 
-#[ApiResource(
-    formats: ['jsonld', 'csv' => ['text/csv']],
-    itemOperations: [
-        'patch' => [
-            'input_formats' => [
-                'json' => ['application/merge-patch+json'],
-            ],
-        ],
-    ],
-)]
+#[ApiResource(formats: ['jsonld', 'csv' => ['text/csv']])]
+#[Patch(inputFormats: ['json' => ['application/merge-patch+json']])]
+#[GetCollection]
+#[Post]
 class Book
 {
     // ...
@@ -227,7 +222,6 @@ services:
 ```php
 <?php
 // api/src/Serializer/CustomItemNormalizer.php
-
 namespace App\Serializer;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -274,7 +268,6 @@ flatten or remove overly complex relations:
 ```php
 <?php
 // api/src/Serializer/CustomItemNormalizer.php
-
 namespace App\Serializer;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;

--- a/core/controllers.md
+++ b/core/controllers.md
@@ -31,7 +31,6 @@ First, let's create your custom operation:
 ```php
 <?php
 // api/src/Controller/CreateBookPublication.php
-
 namespace App\Controller;
 
 use App\Entity\Book;
@@ -90,18 +89,20 @@ The routing has not been configured yet because we will add it at the resource c
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 use App\Controller\CreateBookPublication;
 
-#[ApiResource(itemOperations: [
-    'get',
-    'post_publication' => [
-        'method' => 'POST',
-        'path' => '/books/{id}/publication',
-        'controller' => CreateBookPublication::class,
-    ],
-])]
+#[ApiResource]
+#[Get]
+#[Post(
+    name: 'publication', 
+    uriTemplate: '/books/{id}/publication', 
+    controller: CreateBookPublication::class
+)]
 class Book
 {
     // ...
@@ -155,20 +156,22 @@ You may want different serialization groups for your custom operations. Just con
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 use App\Controller\CreateBookPublication;
 use Symfony\Component\Serializer\Annotation\Groups;
 
-#[ApiResource(itemOperations: [
-    'get',
-    'post_publication' => [
-        'method' => 'POST',
-        'path' => '/books/{id}/publication',
-        'controller' => CreateBookPublication::class,
-        'normalization_context' => ['groups' => 'publication'],
-    ],
-])]
+#[ApiResource]
+#[Get]
+#[Post(
+    name: 'publication', 
+    uriTemplate: '/books/{id}/publication', 
+    controller: CreateBookPublication::class, 
+    normalizationContext: ['groups' => 'publication']
+)]
 class Book
 {
     // ...
@@ -231,19 +234,21 @@ operation attribute:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 use App\Controller\CreateBookPublication;
 
-#[ApiResource(itemOperations: [
-    'get',
-    'post_publication' => [
-        'method' => 'POST',
-        'path' => '/books/{id}/publication',
-        'controller' => CreateBookPublication::class,
-        'read' => false,
-    ],
-])]
+#[ApiResource]
+#[Get]
+#[Post(
+    name: 'publication', 
+    uriTemplate: '/books/{id}/publication', 
+    controller: CreateBookPublication::class, 
+    read: false
+)]
 class Book
 {
     // ...
@@ -309,14 +314,16 @@ First, let's create your resource configuration:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 
-#[ApiResource(itemOperations: [
-    'get',
-    'post_publication' => ['route_name' => 'book_post_publication'],
-    'book_post_discontinuation',
-])]
+#[ApiResource]
+#[Get]
+#[Post(name: 'publication', routeName: 'book_post_publication')]
+#[Post(name: 'book_post_discontinuation')]
 class Book
 {
     // ...
@@ -361,7 +368,6 @@ and its related route using annotations:
 ```php
 <?php
 // api/src/Controller/CreateBookPublication.php
-
 namespace App\Controller;
 
 use App\Entity\Book;
@@ -406,7 +412,6 @@ the same thing as the previous example:
 ```php
 <?php
 // api/src/Controller/BookController.php
-
 namespace App\Controller;
 
 use App\Entity\Book;

--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -23,6 +23,7 @@ persist data for a given resource will be used.
 ## Creating a Custom Data Persister
 
 If the [Symfony MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle) is installed in your project, you can use the following command to generate a custom data persister easily:
+
 ```console
 bin/console make:data-persister
 ```
@@ -190,6 +191,7 @@ final class BlogPostDataPersister implements ContextAwareDataPersisterInterface,
 ```
 
 This is very useful when using [`Messenger` with API Platform](messenger.md) as you may want to do something asynchronously with the data but still call the default Doctrine data persister, for example:
+
 ```php
 namespace App\DataPersister;
 
@@ -230,6 +232,7 @@ final class BlogPostDataPersister implements ContextAwareDataPersisterInterface,
     }
 }
 ```
+
 ```yaml
 # api/config/services.yaml
 services:

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -23,7 +23,7 @@ Both implementations can also implement a third, optional, interface called
 if you want to limit their effects to a single resource or operation.
 
 In the following examples we will create custom data providers for an entity class called `App\Entity\BlogPost`.
-Note, that if your entity is not Doctrine-related, you need to flag the identifier property by using `@ApiProperty(identifier=true)` for things to work properly (see also [Entity Identifier Case](serialization.md#entity-identifier-case)).
+Note, that if your entity is not Doctrine-related, you need to flag the identifier property by using `#[ApiProperty(identifier: true)]` for things to work properly (see also [Entity Identifier Case](serialization.md#entity-identifier-case)).
 
 ## Custom Collection Data Provider
 
@@ -265,8 +265,6 @@ using it within your data provider.
 ```php
 <?php
 // api/src/DataProvider/CustomCollectionDataProvider.php
-
-declare(strict_types=1);
 
 namespace App\DataProvider;
 

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -28,6 +28,7 @@ Note, that if your entity is not Doctrine-related, you need to flag the identifi
 ## Custom Collection Data Provider
 
 If the [Symfony MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle) is installed in your project, you can use the following command to generate a custom collection data provider easily:
+
 ```console
 bin/console make:data-provider --collection-only
 ```
@@ -85,6 +86,7 @@ You can find a full working example in the [API Platform's demo application](htt
 ## Custom Item Data Provider
 
 If the [Symfony MakerBundle](https://symfony.com/doc/current/bundles/SymfonyMakerBundle) is installed in your project, you can use the following command to generate a custom item data provider easily:
+
 ```console
 bin/console make:data-provider --item-only
 ```

--- a/core/default-order.md
+++ b/core/default-order.md
@@ -12,11 +12,9 @@ customize this order, you must add an `order` attribute on your ApiResource anno
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"order"={"foo": "ASC"}})
- */
+#[ApiResource(order: ['foo' => 'ASC'])]
 class Book
 {
     // ...
@@ -50,11 +48,9 @@ If you only specify the key, `ASC` direction will be used as default. For exampl
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"order"={"foo", "bar"}})
- */
+#[ApiResource(order: ['foo' => 'bar'])]
 class Book
 {
     // ...
@@ -91,11 +87,9 @@ It's also possible to configure the default order on an association property:
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"order"={"author.username"}})
- */
+#[ApiResource(order: ['author.username'])]
 class Book
 {
     // ...
@@ -123,13 +117,17 @@ Another possibility is to apply the default order for a specific collection oper
 [codeSelector]
 
 ```php
-/**
- *     collectionOperations={
- *         "get",
- *         "get_desc_custom"={"method"="GET", "path"="custom_collection_desc_foos", "order"={"name"="DESC"}},
- *         "get_asc_custom"={"method"="GET", "path"="custom_collection_asc_foos", "order"={ "name"="ASC"}},
- *     }
- */
+<?php
+// api/src/Entity/Book.php
+namespace App\Entity;
+
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+#[GetCollection]
+#[GetCollection(name: 'desc_custom', uriTemplate: 'custom_collection_desc_foos', order: ['name' => 'DESC'])]
+#[GetCollection(name: 'asc_custom', uriTemplate: 'custom_collection_asc_foos', order: ['name' => 'ASC'])]
 class Book
 {
     // ...

--- a/core/deprecations.md
+++ b/core/deprecations.md
@@ -22,14 +22,11 @@ To deprecate a resource class, use the `deprecationReason` attribute:
 ```php
 <?php
 // api/src/Entity/Parchment.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(deprecationReason="Create a Book instead")
- */
+#[ApiResource(deprecationReason: "Create a Book instead")]
 class Parchment
 {
     // ...
@@ -55,16 +52,13 @@ You can also use this new `deprecationReason` attribute to deprecate specific [o
 ```php
 <?php
 // api/src/Entity/Parchment.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 
-/**
- * @ApiResource(itemOperations={
- *     "get"={"deprecation_reason"="Retrieve a Book instead"}
- * })
- */
+#[ApiResource]
+#[Get(deprecationReason: 'Retrieve a Book instead')]
 class Parchment
 {
     // ...
@@ -78,22 +72,17 @@ It's also possible to deprecate a single property:
 ```php
 <?php
 // api/src/Entity/Review.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 class Review
 {
     // ...
 
-    /**
-     * @ApiProperty(deprecationReason="Use the rating property instead")
-     */
+    #[ApiProperty(deprecationReason: "Use the rating property instead")]
     public $letter;
     
     // ...
@@ -128,17 +117,11 @@ Thanks to the `sunset` attribute, API Platform makes it easy to set this header 
 ```php
 <?php
 // api/src/Entity/Parchment.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(
- *   deprecationReason="Create a Book instead",
- *   sunset="01/01/2020"
- * )
- */
+#[ApiResource(deprecationReason:"Create a Book instead", sunset: "01/01/2020")]
 class Parchment
 {
     // ...
@@ -153,19 +136,13 @@ It's also possible to set the `Sunset` header only for a specific [operation](op
 ```php
 <?php
 // api/src/Entity/Parchment.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 
-/**
- * @ApiResource(itemOperations={
- *     "get"={
- *         "deprecation_reason"="Retrieve a Book instead",
- *         "sunset"="01/01/2020"
- *     }
- * })
- */
+#[ApiResource]
+#[Get(sunset: '01/01/2020', deprecationReason: 'Retrieve a Book instead')]
 class Parchment
 {
     // ...

--- a/core/dto.md
+++ b/core/dto.md
@@ -1,6 +1,6 @@
 # Using Data Transfer Objects (DTOs)
 
- As stated in [the general design considerations](design.md), in most cases [the DTO pattern](https://en.wikipedia.org/wiki/Data_transfer_object) should be implemented using an API Resource class representing the public data model exposed through the API and [a custom data provider](data-providers.md). In such cases, the class marked with `@ApiResource` will act as a DTO.
+ As stated in [the general design considerations](design.md), in most cases [the DTO pattern](https://en.wikipedia.org/wiki/Data_transfer_object) should be implemented using an API Resource class representing the public data model exposed through the API and [a custom data provider](data-providers.md). In such cases, the class marked with `#[ApiResource]` will act as a DTO.
 
 However, it's sometimes useful to use a specific class to represent the input or output data structure related to an operation.
 
@@ -14,19 +14,13 @@ To do so, a resource can take an input and/or an output class:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Dto\BookInput;
 use App\Dto\BookOutput;
 
-/**
- * @ApiResource(
- *   input=BookInput::class,
- *   output=BookOutput::class
- * )
- */
+#[ApiResource(input: BookInput::class, output: BookOutput::class)]
 final class Book
 {
     public $id;
@@ -64,7 +58,7 @@ Similarly, the `output` attribute is used during [the serialization process](ser
 
 The `input` and `output` attributes are taken into account by all the documentation generators (GraphQL and OpenAPI, Hydra).
 
-Note that `Book` entity needs an id property. The simplest way is adding a public property called `$id`, as in the example. However, as in any other entity, you can use a private property, with getter and setter functions, and/or named it as you wish, provided you annotate it with `@ApiProperty(identifier=true)`. For instance, you could have a property called `$code`.
+Note that `Book` entity needs an id property. The simplest way is adding a public property called `$id`, as in the example. However, as in any other entity, you can use a private property, with getter and setter functions, and/or named it as you wish, provided you annotate it with `#[ApiProperty(identifier: true)]`. For instance, you could have a property called `$code`.
 So the `InputDataTransformer` actually transforms the isbn into a code. And then in the `OutputDataTransformer`, from this code into the name.
 
 To create a `Book`, we `POST` a data structure corresponding to the `BookInput` class and get back in the response a data structure corresponding to the `BookOutput` class:
@@ -288,32 +282,16 @@ will be skipped. If `output` is `false`, the serialization process will be skipp
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Dto\BookOutput;
 use App\Dto\CreateBook;
 use App\Dto\UpdateBook;
 
-/**
- * @ApiResource(
- *     collectionOperations={
- *         "create"={
- *             "method"="POST",
- *             "input"=CreateBook::class,
- *             "output"=BookOutput::class
- *         }
- *     },
- *     itemOperations={
- *         "update"={
- *             "method"="PUT",
- *             "input"=UpdateBook::class,
- *             "output"=BookOutput::class
- *         }
- *     }
- * )
- */
+#[ApiResource]
+#[Put(name: 'update', input: UpdateBook::class, output: BookOutput::class)]
+#[Post(name: 'create', input: CreateBook::class, output: BookOutput::class)]
 final class Book
 {
 }
@@ -379,15 +357,12 @@ Because API Platform can (de)normalize anything in the supported formats (`jsonl
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Model\Attribute;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 final class Book
 {
   /**

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -146,8 +146,8 @@ Here is an example of mappings for 2 resources, `User` and `Tweet`, and their mo
 // api/src/Model/User.php
 namespace App\Model;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource]
 class User
@@ -175,8 +175,8 @@ class User
 // api/src/Model/Tweet.php
 namespace App\Model;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 
  #[ApiResource]
 class Tweet

--- a/core/errors.md
+++ b/core/errors.md
@@ -17,18 +17,17 @@ configure API Platform to convert it to a `404 Not Found` error:
 ```php
 <?php
 // api/src/Exception/ProductNotFoundException.php
-
 namespace App\Exception;
 
 final class ProductNotFoundException extends \Exception
 {
+    // ...
 }
 ```
 
 ```php
 <?php
 // api/src/EventSubscriber/ProductManager.php
-
 namespace App\EventSubscriber;
 
 use ApiPlatform\Core\EventListener\EventPriorities;
@@ -118,22 +117,17 @@ The `exception_to_status` configuration can be set on resources and operations:
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 use App\Exception\ProductWasRemovedException;
 use App\Exception\ProductNotFoundException;
 
-#[ApiResource(
-    itemOperations: [
-        'get' => [
-            'exception_to_status' => [
-                ProductWasRemovedException::class => 410,
-            ],
-        ],
-    ],
-    exceptionToStatus: [
-        ProductNotFoundException::class => 404,
-    ]
-)]
+#[ApiResource(exceptionToStatus: ['ProductNotFoundException::class' => 404])]
+#[Get(exceptionToStatus: ['ProductWasRemovedException::class' => 410])]
+#[GetCollection]
+#[Post]
 class Book
 {
     // ...

--- a/core/extending-jsonld-context.md
+++ b/core/extending-jsonld-context.md
@@ -11,35 +11,27 @@ within the following annotation will be passed to the context. This provides a g
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(iri="http://schema.org/Book")
- */
+#[ApiResource(types: ["http://schema.org/Book"])]
 class Book
 {
     // ...
 
-    /**
-     * ...
-     * @ApiProperty(
-     *     iri="http://schema.org/name",
-     *     attributes={
-     *         "jsonld_context"={
-     *             "@id"="http://yourcustomid.com",
-     *             "@type"="http://www.w3.org/2001/XMLSchema#string",
-     *             "someProperty"={
-     *                 "a"="textA",
-     *                 "b"="textB"
-     *             }
-     *         }
-     *     }
-     * )
-     */
+    #[ApiProperty(
+        types: ['http://schema.org/name'],
+        jsonldContext: [
+            "@id" => "http://yourcustomid.com",
+            "@type" => "http://www.w3.org/2001/XMLSchema#string",
+            "someProperty" => [
+                "a" => "textA",
+                "b" => "textB"
+            ]
+        ]        
+    )]
     public $name;
     
     // ...
@@ -80,15 +72,12 @@ It's also possible to replace the Hydra context used by the documentation genera
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * ...
- * @ApiResource(itemOperations={
- *     "get"={"hydra_context"={"foo"="bar"}}
- * })
- */
+#[ApiResource]
+#[Get(hydraContext: ['foo' => 'bar'])]
 class Book
 {
     //...

--- a/core/extensions.md
+++ b/core/extensions.md
@@ -23,14 +23,11 @@ Given these two entities:
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 class User
 {
     // ...
@@ -40,14 +37,11 @@ class User
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 class Offer
 {
    /**

--- a/core/external-vocabularies.md
+++ b/core/external-vocabularies.md
@@ -8,23 +8,17 @@ API Platform Core provides annotations usable on PHP classes and properties for 
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(iri="http://schema.org/Book")
- */
+#[ApiResource(types: ["http://schema.org/Book"])]
 class Book
 {
     // ...
 
-    /**
-     * ...
-     * @ApiProperty(iri="http://schema.org/name")
-     */
+    #[ApiProperty(types: ["http://schema.org/name"])]
     public $name;
     
     // ...
@@ -58,7 +52,7 @@ The generated JSON for products and the related context document will now use ex
 
 An extended list of existing open vocabularies is available on [the Linked Open Vocabularies (LOV) database](http://lov.okfn.org/dataset/lov/).
 
-By default, when using [validations](validation.md) API Platform Core will try to define known [Schema.org](https://schema.org) types as IRIs for your properties if you did not provide any in your `@ApiProperty` annotations.
+By default, when using [validations](validation.md) API Platform Core will try to define known [Schema.org](https://schema.org) types as IRIs for your properties if you did not provide any in your `#[ApiProperty]` annotations.
 Built-in mapping is:
 
 Constraints                                          | Schema.org type                   |

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -51,8 +51,11 @@ The `MediaObject` resource is implemented like this:
 // api/src/Entity/MediaObject.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 use App\Controller\CreateMediaObjectAction;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
@@ -65,33 +68,31 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  * @Vich\Uploadable
  */
 #[ApiResource(
-    iri: 'http://schema.org/MediaObject',
-    normalizationContext: ['groups' => ['media_object:read']],
-    itemOperations: ['get'],
-    collectionOperations: [
-        'get',
-        'post' => [
-            'controller' => CreateMediaObjectAction::class,
-            'deserialize' => false,
-            'validation_groups' => ['Default', 'media_object_create'],
-            'openapi_context' => [
-                'requestBody' => [
-                    'content' => [
-                        'multipart/form-data' => [
-                            'schema' => [
-                                'type' => 'object',
-                                'properties' => [
-                                    'file' => [
-                                        'type' => 'string',
-                                        'format' => 'binary',
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
+    normalizationContext: ['groups' => ['media_object:read']], 
+    types: ['http://schema.org/MediaObject']
+)]
+#[Get]
+#[GetCollection]
+#[Post(
+    controller: CreateMediaObjectAction::class, 
+    deserialize: false, 
+    validationContext: ['groups' => ['Default', 'media_object_create']], 
+    openapiContext: [
+        'requestBody' => [
+            'content' => [
+                'multipart/form-data' => [
+                    'schema' => [
+                        'type' => 'object', 
+                        'properties' => [
+                            'file' => [
+                                'type' => 'string', 
+                                'format' => 'binary'
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
     ]
 )]
 class MediaObject
@@ -103,7 +104,7 @@ class MediaObject
      */
     private ?int $id = null;
 
-    #[ApiProperty(iri: 'http://schema.org/contentUrl')]
+    #[ApiProperty(types: ['http://schema.org/contentUrl'])]
     #[Groups(['media_object:read'])]
     public ?string $contentUrl = null;
 
@@ -249,8 +250,8 @@ We first need to edit our Book resource, and add a new property called `image`.
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
@@ -258,7 +259,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
 /**
  * @ORM\Entity
  */
-#[ApiResource(iri: 'http://schema.org/Book')]
+#[ApiResource(types: ['http://schema.org/Book'])]
 class Book
 {
     // ...
@@ -267,7 +268,7 @@ class Book
      * @ORM\ManyToOne(targetEntity=MediaObject::class)
      * @ORM\JoinColumn(nullable=true)
      */
-    #[ApiProperty(iri: 'http://schema.org/image')]
+    #[ApiProperty(types: ['http://schema.org/image'])]
     public ?MediaObject $image = null;
     
     // ...
@@ -350,8 +351,10 @@ The `Book` resource needs to be modified like this:
 // api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -362,23 +365,17 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  * @Vich\Uploadable
  */
 #[ApiResource(
-    iri: 'http://schema.org/Book',
-    normalizationContext: ['groups' => ['book:read']],
-    denormalizationContext: ['groups' => ['book:write']],
-    collectionOperations: [
-        'get',
-        'post' => [
-            'input_formats' => [
-                'multipart' => ['multipart/form-data'],
-            ],
-        ],
-    ],
+    normalizationContext: ['groups' => ['book:read']], 
+    denormalizationContext: ['groups' => ['book:write']], 
+    types: ['http://schema.org/Book']
 )]
+#[GetCollection]
+#[Post(inputFormats: ['multipart' => ['multipart/form-data']])]
 class Book
 {
     // ...
 
-    #[ApiProperty(iri: 'http://schema.org/contentUrl')]
+    #[ApiProperty(types: ['http://schema.org/contentUrl'])]
     #[Groups(['book:read'])]
     public ?string $contentUrl = null;
 

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -228,6 +228,7 @@ your data, you will get a response looking like this:
 ### Accessing Your Media Objects Directly
 
 You will need to modify your Caddyfile to allow the above `contentUrl` to be accessed directly. If you followed the above configuration for the VichUploaderBundle, that will be in `api/public/media`. Add your folder to the list of path matches, e.g. `|^/media/|`:
+
 ```caddyfile
 ...
 # Matches requests for HTML documents, for static files and for Next.js files,

--- a/core/filters.md
+++ b/core/filters.md
@@ -253,6 +253,7 @@ The `after` and `before` filters will filter including the value whereas `strict
 Like others filters, the date filter must be explicitly enabled:
 
 [codeSelector]
+
 ```php
 <?php
 // api/src/Entity/Offer.php

--- a/core/filters.md
+++ b/core/filters.md
@@ -47,12 +47,11 @@ to a Resource in two ways:
     ```php
     <?php
     // api/src/Entity/Offer.php
-
     namespace App\Entity;
 
-    use ApiPlatform\Core\Annotation\ApiResource;
+    use ApiPlatform\Metadata\ApiResource;
 
-    #[ApiResource(attributes: ['filters' => ['offer.date_filter']])]
+    #[ApiResource(filters: ['offer.date_filter'])]
     class Offer
     {
         // ...
@@ -98,11 +97,10 @@ to a Resource in two ways:
     ```php
     <?php
     // api/src/Entity/Offer.php
-
     namespace App\Entity;
 
     use ApiPlatform\Core\Annotation\ApiFilter;
-    use ApiPlatform\Core\Annotation\ApiResource;
+    use ApiPlatform\Metadata\ApiResource;
     use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 
     #[ApiResource]
@@ -150,10 +148,9 @@ In the following example, we will see how to allow the filtering of a list of e-
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -200,10 +197,9 @@ It is possible to filter on relations too, if `Offer` has a `Product` relation:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -260,11 +256,10 @@ Like others filters, the date filter must be explicitly enabled:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 
 #[ApiResource]
@@ -322,11 +317,10 @@ For instance, exclude entries with a property value of `null` with the following
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 
 #[ApiResource]
@@ -373,11 +367,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
 
 #[ApiResource]
@@ -428,11 +421,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\NumericFilter;
 
 #[ApiResource]
@@ -483,11 +475,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\RangeFilter;
 
 #[ApiResource]
@@ -543,11 +534,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
 
 #[ApiResource]
@@ -610,11 +600,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
@@ -661,11 +650,10 @@ will not be applied unless you configure a default order direction to use:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
@@ -719,11 +707,10 @@ For instance, treat entries with a property value of `null` as the smallest, wit
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
@@ -788,11 +775,10 @@ built-in filters support nested properties using the dot (`.`) syntax, e.g.:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -851,11 +837,10 @@ for all properties:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
@@ -922,7 +907,7 @@ Enable the filter:
 namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 
 #[ApiResource]
@@ -969,7 +954,7 @@ will not be applied unless you configure a default order direction to use:
 namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 
 #[ApiResource]
@@ -1008,7 +993,7 @@ Enable the filter:
 namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\MatchFilter;
 
 #[ApiResource]
@@ -1039,7 +1024,7 @@ Enable the filter:
 namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 
 #[ApiResource]
@@ -1069,7 +1054,7 @@ All built-in filters support nested properties using the (`.`) syntax.
 namespace App\Model;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Filter\TermFilter;
 
@@ -1100,11 +1085,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Serializer\Filter\GroupFilter;
 
 #[ApiResource]
@@ -1139,11 +1123,10 @@ Enable the filter:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Serializer\Filter\PropertyFilter;
 
 #[ApiResource]
@@ -1245,11 +1228,10 @@ Finally, add this filter to resources you want to be filtered by using the `ApiF
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Filter\RegexpFilter;
 
 #[ApiResource]
@@ -1268,11 +1250,10 @@ In the previous example, the filter can be applied on any property. You can also
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Filter\RegexpFilter;
 
 #[ApiResource]
@@ -1318,16 +1299,13 @@ Finally, if you don't want to use the `#[ApiFilter]` annotation, you can registe
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Filter\RegexpFilter;
 
 #[ApiResource(
-    attributes => [
-        'filters' => [RegexpFilter::class],
-    ],
+    filters: [RegexpFilter::class]
 )]
 class Offer
 {
@@ -1394,10 +1372,9 @@ Suppose we have a `User` entity and an `Order` entity related to the `User` one.
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource]
 class User
@@ -1409,10 +1386,9 @@ class User
 ```php
 <?php
 // api/src/Entity/Order.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ApiResource]
@@ -1457,7 +1433,6 @@ Then, let's mark the `Order` entity as a "user aware" entity.
 ```php
 <?php
 // api/src/Entity/Order.php
-
 namespace App\Entity;
 
 use App\Annotation\UserAware;
@@ -1608,9 +1583,11 @@ If the annotation is given over a property, the filter will be configured on the
 
 ```php
 <?php
+// api/src/Entity/DummyCar.php
+namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -1660,11 +1637,10 @@ For example, let's define three data filters (`DateFilter`, `SearchFilter` and `
 ```php
 <?php
 // api/src/Entity/DummyCar.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\BooleanFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;

--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -54,10 +54,9 @@ Create your User entity with serialization groups:
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use FOS\UserBundle\Model\User as BaseUser;
 use FOS\UserBundle\Model\UserInterface;
@@ -66,11 +65,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
 /**
  * @ORM\Entity
  * @ORM\Table(name="fos_user")
- * @ApiResource(
- *     normalizationContext={"groups"={"user", "user:read"}},
- *     denormalizationContext={"groups"={"user", "user:write"}}
- * )
  */
+ #[ApiResource(
+    normalizationContext: ['groups' => ['user', 'user:read']],
+    denormalizationContext: ['groups' => ['user', 'user:write']],
+ )]
 class User extends BaseUser
 {
     /**

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -35,10 +35,9 @@ Here is an example of entities mapped using annotations which will be exposed th
 ```php
 <?php
 // api/src/Entity/Product.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -103,10 +102,9 @@ class Product // The class name will be used to name exposed resources
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -115,7 +113,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @ORM\Entity
  */
-#[ApiResource(iri: 'http://schema.org/Offer')]
+#[ApiResource(types: ['http://schema.org/Offer'])]
 class Offer
 {
     /**

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -133,13 +133,13 @@ api_platform:
 
 To understand what an operation is, please refer to the [operations documentation](operations.md).
 
-For GraphQL, the operations are defined under the `graphql` attribute.
+For GraphQL, the operations are defined under the `Query`, `QueryCollection` and `Mutation` attributes.
 By default, all operations are enabled.
 
 For the queries, the operations are:
 
-* `item_query`
-* `collection_query`
+* `Query`
+* `QueryCollection`
 
 For the mutations, the operations are:
 
@@ -154,12 +154,15 @@ For instance, in the following example, only the query of an item and the create
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-#[ApiResource(
-    graphql: ['item_query', 'create']
-)]
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+#[Query]
+#[Mutation(name: 'create')]
 class Book
 {
     // ...
@@ -199,11 +202,11 @@ If you want a custom query for a collection, create a class like this:
 
 ```php
 <?php
-
+// api/src/Resolver/BookCollectionResolver.php
 namespace App\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryCollectionResolverInterface;
-use App\Model\Book;
+use App\Entity\Book;
 
 final class BookCollectionResolver implements QueryCollectionResolverInterface
 {
@@ -242,11 +245,11 @@ The resolver for an item is very similar:
 
 ```php
 <?php
-
+// api/src/Resolver/BookResolver.php
 namespace App\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\QueryItemResolverInterface;
-use App\Model\Book;
+use App\Entity\Book;
 
 final class BookResolver implements QueryItemResolverInterface
 {
@@ -279,46 +282,39 @@ In your resource, add the following:
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
-
-use ApiPlatform\Core\Annotation\ApiResource;
 use App\Resolver\BookCollectionResolver;
 use App\Resolver\BookResolver;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\ApiResource;
 
-#[ApiResource(
-    graphql: [
-        // Auto-generated queries and mutations
-        'item_query',
-        'collection_query',
-        'create',
-        'update',
-        'delete',
-
-        'retrievedQuery' => [
-            'item_query' => BookResolver::class
-        ],
-        'notRetrievedQuery' => [
-            'item_query' => BookResolver::class,
-            'args' => []
-        ],
-        'withDefaultArgsNotRetrievedQuery' => [
-            'item_query' => BookResolver::class,
-            'read' => false
-        ],
-        'withCustomArgsQuery' => [
-            'item_query' => BookResolver::class,
-            'args' => [
-                'id' => ['type' => 'ID!'],
-                'log' => ['type' => 'Boolean!', 'description' => 'Is logging activated?'],
-                'logDate' => ['type' => 'DateTime']
-            ]
-        ],
-        'collectionQuery' => [
-            'collection_query' => BookCollectionResolver::class
-        ]
+#[ApiResource]
+/** Auto generated graphql operations and mutations */
+#[Query]
+#[QueryCollection]
+#[Mutation(name: 'create')]
+#[Mutation(name: 'update')]
+#[Mutation(name: 'delete')]
+/** Custom graphql operations */ 
+#[Query(name: 'retrievedQuery', resolver: BookResolver::class)]
+#[Query(name: 'notRetrievedQuery', resolver: BookResolver::class, 
+    args: []
+)]
+#[Query(name: 'withDefaultArgsNotRetrievedQuery', resolver: BookResolver::class, 
+    read: false
+)]
+#[Query(name: 'withCustomArgsQuery', resolver: BookResolver::class,
+    args: [
+        'id' => ['type' => 'ID!'], 
+        'log' => ['type' => 'Boolean!', 'description' => 'Is logging activated?'], 
+        'logDate' => ['type' => 'DateTime']
     ]
 )]
+#[QueryCollection(name: 'collectionQuery', resolver: BookCollectionResolver::class)]
 class Book
 {
     // ...
@@ -405,11 +401,11 @@ Create your resolver:
 
 ```php
 <?php
-
+// api/src/Resolver/BookMutationResolver.php
 namespace App\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
-use App\Model\Book;
+use App\Entity\Book;
 
 final class BookMutationResolver implements MutationResolverInterface
 {
@@ -446,36 +442,35 @@ Now in your resource:
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
-
-use ApiPlatform\Core\Annotation\ApiResource;
 use App\Resolver\BookMutationResolver;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\ApiResource;
 
-#[ApiResource(
-    graphql: [
-        // Auto-generated queries and mutations
-        'item_query',
-        'collection_query',
-        'create',
-        'update',
-        'delete',
-
-        'mutation' => [
-            'mutation' => BookMutationResolver::class
-        ],
-        'withCustomArgsMutation' => [
-            'mutation' => BookMutationResolver::class,
-            'args' => [
-                'sendMail' => ['type' => 'Boolean!', 'description'=> 'Send a mail?' ]
-            ]
-        ],
-        'disabledStagesMutation' => [
-            'mutation' => BookMutationResolver::class,
-            'deserialize' => false,
-            'write' => false
+#[ApiResource]
+/** Auto generated graphql operations and mutations */
+#[Query]
+#[QueryCollection]
+#[Mutation(name: 'create')]
+#[Mutation(name: 'update')]
+#[Mutation(name: 'delete')]
+/** Custom graphql operations */ 
+#[Mutation(name: 'mutation', resolver: BookMutationResolver::class)]
+#[Mutation(name: 'withCustomArgsMutation', resolver: BookMutationResolver::class, 
+    args: [
+        'sendMail' => [
+            'type' => 'Boolean!', 
+            'description' => 'Send a mail?'
         ]
     ]
+)]
+#[Mutation(name: 'disabledStagesMutation', resolver: BookMutationResolver::class, 
+    deserialize: false, 
+    write: false
 )]
 class Book
 {
@@ -540,19 +535,14 @@ For instance, your resource should look like this:
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-
- #[ApiResource(
-      graphql: [
-          ...
-          'update',
-          ...
-      ],
-      mercure: true
-)]
+#[ApiResource(mercure: true)]
+#[Mutation(name: 'update')]
 class Book
 {
     // ...
@@ -630,7 +620,6 @@ Create your *WriteStage*:
 
 ```php
 <?php
-
 namespace App\Stage;
 
 use ApiPlatform\Core\GraphQl\Resolver\Stage\WriteStageInterface;
@@ -689,18 +678,18 @@ A stage can be disabled at the operation level:
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-
-#[ApiResource(
-    graphql: [
-        'mutation' => [
-            'write' => false
-        ]
-    ]
-)]
+#[ApiResource]
+#[Query]
+#[QueryCollection]
+#[Mutation(write: false)]
 class Book
 {
     // ...
@@ -711,17 +700,18 @@ Or at the resource attributes level (will be also applied in REST and for all op
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-
-#[ApiResource(
-    graphql: [...],
-    attributes: [
-        'write' => false
-    ]
-)]
+#[ApiResource(write: false)]
+#[Query(...)]
+#[QueryCollection(...)]
+#[Mutation(...)]
 class Book
 {
     // ...
@@ -741,33 +731,27 @@ Filters are supported out-of-the-box. Follow the [filters](filters.md) documenta
 
 However you don't necessarily have the same needs for your GraphQL endpoint as for your REST one.
 
-In the `ApiResource` declaration, you can choose to decorrelate the GraphQL filters in `collection_query` of the `graphql` attribute.
-In order to keep the default behavior (possibility to fetch, delete, update or create), define all the operations (`item_query` ,`collection_query` , `delete`, `update` and `create`).
+In the `QueryCollection` declaration, you can choose to decorrelate the GraphQL filters.
+In order to keep the default behavior (possibility to fetch, delete, update or create), define all the operations and mutations (`Query` ,`QueryCollection` , `delete`, `update` and `create`).
 
 For example, this entity will have a search filter for REST and a date filter for GraphQL:
 
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-#[ApiResource(
-    attributes: [
-        'filters' => ['offer.search_filter']
-    ],
-    graphql: [
-        'item_query',
-        'collection_query' => [
-            'filters' => ['offer.date_filter']
-        ],
-        'delete',
-        'update',
-        'create'
-    ]
-)]
+#[ApiResource(filters: ['offer.search_filter'])]
+#[Query]
+#[QueryCollection(filters: ['offer.date_filter'])]
+#[Mutation(name: 'delete')]
+#[Mutation(name: 'update')]
+#[Mutation(name: 'create')]
 class Offer
 {
     // ...
@@ -820,11 +804,10 @@ Unlike for REST, all built-in filters support nested properties using the unders
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -968,22 +951,19 @@ For instance at the operation level:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-#[ApiResource(
-    graphql: [
-        'item_query',
-         'collection_query' => [
-            'pagination_type' => 'page'
-         ],
-         'delete',
-         'update',
-         'create'
-    ]
-)]
+#[ApiResource]
+#[Query]
+#[QueryCollection(paginationType: 'page')]
+#[Mutation(name: 'delete')]
+#[Mutation(name: 'update')]
+#[Mutation(name: 'create')]
 class Offer
 {
     // ...
@@ -995,15 +975,12 @@ Or if you want to do it at the resource level:
 ```php
 <?php
 // api/src/Entity/Offer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource(
-    attributes: [
-        'pagination_type' => 'page'
-    ]
+    paginationType: 'page'
 )]
 class Offer
 {
@@ -1062,10 +1039,11 @@ It can also be disabled for a specific resource (REST and GraphQL):
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-#[ApiResource(attributes: ['pagination_enabled' => false])]
+#[ApiResource(paginationEnabled: false)]
 class Book
 {
     // ...
@@ -1079,10 +1057,13 @@ You can also disable the pagination for a specific collection operation:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 
-#[ApiResource(graphql: ['collection_query' => ['pagination_enabled' => false]])]
+#[ApiResource]
+#[QueryCollection(paginationEnabled: false)]
 class Book
 {
     // ...
@@ -1109,26 +1090,22 @@ Please note that, it's not possible to update a book in GraphQL because the `upd
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\Post;
 
-#[ApiResource(
-    attributes: ['security' => "is_granted('ROLE_USER')"],
-    collectionOperations: [
-        'post' => ['security' => "is_granted('ROLE_ADMIN')", 'security_message' => 'Only admins can add books.']
-    ],
-    itemOperations: [
-        'get' => ['security' => "is_granted('ROLE_USER') and object.owner == user", 'security_message' => 'Sorry, but you are not the book owner.']
-    ],
-    graphql: [
-        'item_query' => ['security' => "is_granted('ROLE_USER') and object.owner == user"],
-        'collection_query' => ['security' => "is_granted('ROLE_ADMIN')"],
-        'delete' => ['security' => "is_granted('ROLE_ADMIN')"],
-        'create' => ['security' => "is_granted('ROLE_ADMIN')"]
-    ]
-)]
+#[ApiResource(security: "is_granted('ROLE_USER')")]
+#[Get(security: "is_granted('ROLE_USER') and object.owner == user", securityMessage: 'Sorry, but you are not the book owner.')]
+#[Post(security: "is_granted('ROLE_ADMIN')", securityMessage: 'Only admins can add books.')]
+#[Query(security: "is_granted('ROLE_USER') and object.owner == user")]
+#[QueryCollection(security: "is_granted('ROLE_ADMIN')")]
+#[Mutation(name: 'delete', security: "is_granted('ROLE_ADMIN')")]
+#[Mutation(name: 'create', security: "is_granted('ROLE_ADMIN')")]
 class Book
 {
     // ...
@@ -1160,22 +1137,20 @@ The following example shows how associations can be secured:
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
-#[ApiResource(
-    graphql: [
-        'item_query' => ['security' => 'is_granted("VIEW", object)'],
-        'collection_query' => ['security' => 'is_granted("ROLE_ADMIN")'],
-    ],
-)]
+#[ApiResource]
+#[Query(security: 'is_granted("VIEW", object)')]
+#[QueryCollection(security: 'is_granted("ROLE_ADMIN")')]
 class User
 {
     // ...
@@ -1197,22 +1172,20 @@ class User
 ```php
 <?php
 // api/src/Entity/Document.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
-#[ApiResource(
-    graphql: [
-        'item_query' => ['security' => 'is_granted("VIEW", object)'],
-        'collection_query' => ['security' => 'is_granted("ROLE_ADMIN")'],
-    ],
-)]
+#[ApiResource]
+#[Query(security: 'is_granted("VIEW", object)')]
+#[QueryCollection(security: 'is_granted("ROLE_ADMIN")')]
 class Document
 {
     // ...
@@ -1231,10 +1204,10 @@ class Document
 }
 ```
 
-The above example only allows admins to see the full collection of each resource (`collection_query`).
-Users must be granted the `VIEW` attribute on a resource to be able to query it directly (`item_query`) - which would use a `Voter` to make this decision.
+The above example only allows admins to see the full collection of each resource (`QueryCollection`).
+Users must be granted the `VIEW` attribute on a resource to be able to query it directly (`Query`) - which would use a `Voter` to make this decision.
 
-Similar to `item_query`, all associations are secured, requiring `VIEW` access on the parent object (*not* on the association).
+Similar to `Query`, all associations are secured, requiring `VIEW` access on the parent object (*not* on the association).
 This means that a user with `VIEW` access to a `Document` is able to see all users who are in the `viewers` collection, as well as the `createdBy` association.
 This may be a little too open, so you could instead do a role check here to only allow admins to access these fields, or check for a different attribute that could be implemented in the voter (e.g. `VIEW_CREATED_BY`.)
 Alternatively, you could still expose the users, but limit the visible fields by limiting access with `ApiProperty` `security` (such as the `User::$email` property above) or with [dynamic serializer groups](serialization.md#changing-the-serialization-context-dynamically).
@@ -1257,35 +1230,40 @@ The following example shows you what can be done:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
-    normalizationContext: ['groups' => ['read']],
-    denormalizationContext: ['groups' => ['write']],
-    graphql: [
-        'item_query' => ['normalization_context' => ['groups' => ['item_query']]],
-        'collection_query' => ['normalization_context' => ['groups' => ['collection_query']]],
-        'create' => [
-            'normalization_context' => ['groups' => ['collection_query']],
-            'denormalization_context' => ['groups' => ['mutation']]
-        ]
-    }
+    normalizationContext: ['groups' => ['read']], 
+    denormalizationContext: ['groups' => ['write']]
+)]
+#[Query(
+    normalizationContext: ['groups' => ['Query']]
+)]
+#[QueryCollection(
+    normalizationContext: ['groups' => ['QueryCollection']]
+)]
+#[Mutation(
+    name: 'create', 
+    normalizationContext: ['groups' => ['QueryCollection']], 
+    denormalizationContext: ['groups' => ['mutation']]
 )]
 class Book
 {
     // ...
 
     /**
-     * @Groups({"read", "write", "item_query", "collection_query"})
+     * @Groups({"read", "write", "Query", "QueryCollection"})
      */
     public $name;
 
     /**
-     * @Groups({"read", "mutation", "item_query"})
+     * @Groups({"read", "mutation", "Query"})
      */
     public $author;
 
@@ -1308,8 +1286,8 @@ Make sure you understand the implications when doing this: having different type
 
 For instance:
 
-* If you use a different `normalization_context` for a mutation, a `MyResourcePayloadData` type with the restricted fields will be generated and used instead of `MyResource` (the query type).
-* If you use a different `normalization_context` for the query of an item (`item_query` operation) and for the query of a collection (`collection_query` operation), two types `MyResourceItem` and `MyResourceCollection` with the restricted fields will be generated and used instead of `MyResource` (the query type).
+* If you use a different `normalizationContext` for a mutation, a `MyResourcePayloadData` type with the restricted fields will be generated and used instead of `MyResource` (the query type).
+* If you use a different `normalizationContext` for the query of an item (`Query` operation) and for the query of a collection (`QueryCollection` operation), two types `MyResourceItem` and `MyResourceCollection` with the restricted fields will be generated and used instead of `MyResource` (the query type).
 
 ## Exception and Error
 
@@ -1325,7 +1303,6 @@ For instance, create a class like this:
 ```php
 <?php
 // api/src/Error/ErrorHandler.php
-
 namespace App\Error;
 
 use ApiPlatform\Core\GraphQl\Error\ErrorHandlerInterface;
@@ -1381,7 +1358,6 @@ services:
 ```php
 <?php
 // api/config/services.php
-
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use App\Error\ErrorHandler;
@@ -1424,7 +1400,6 @@ The code should look like this:
 ```php
 <?php
 // api/src/Serializer/Exception/MyExceptionNormalizer.php
-
 namespace App\Serializer\Exception;
 
 use App\Exception\MyException;
@@ -1484,10 +1459,9 @@ For instance, your resource can have properties in camelCase:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -1540,10 +1514,9 @@ For instance if you have this resource:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\SearchFilter;
 
@@ -1616,7 +1589,6 @@ For instance, to create a custom `DateType`:
 
 ```php
 <?php
-
 namespace App\Type\Definition;
 
 use ApiPlatform\Core\GraphQl\Type\Definition\TypeInterface;
@@ -1730,11 +1702,10 @@ Your class needs to look like this:
 
 ```php
 <?php
-
 namespace App\Type;
 
 use ApiPlatform\Core\GraphQl\Type\TypeConverterInterface;
-use App\Model\Book;
+use App\Entity\Book;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -1797,7 +1768,6 @@ The decorator could be like this:
 
 ```php
 <?php
-
 namespace App\Serializer;
 
 use ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface;
@@ -1862,12 +1832,11 @@ Configure the entity by adding a [custom mutation resolver](#custom-mutations):
 ```php
 <?php
 // api/src/Entity/MediaObject.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
-use App\Resolver\CreateMediaObjectResolver;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;use App\Resolver\CreateMediaObjectResolver;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -1879,17 +1848,17 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  * @Vich\Uploadable
  */
 #[ApiResource(
-    iri: 'http://schema.org/MediaObject',
-    normalizationContext: [
-        'groups' => ['media_object_read']
-    ],
-    graphql: [
-        'upload' => [
-            'mutation' => CreateMediaObjectResolver::class,
-            'deserialize' => false,
-            'args' => [
-                'file' => ['type' => 'Upload!', 'description' => 'The file to upload']
-            ]
+    normalizationContext: ['groups' => ['media_object_read']], 
+    types: ['http://schema.org/MediaObject']
+)]
+#[Mutation(
+    name: 'upload', 
+    resolver: CreateMediaObjectResolver::class, 
+    deserialize: false, 
+    args: [
+        'file' => [
+            'type' => 'Upload!', 
+            'description' => 'The file to upload'
         ]
     ]
 )]
@@ -1909,7 +1878,7 @@ class MediaObject
      *
      * @Groups({"media_object_read"})
      */
-    #[ApiProperty(iri: 'http://schema.org/contentUrl)]
+    #[ApiProperty(types: ['http://schema.org/contentUrl'])]
     public $contentUrl;
 
     /**
@@ -1933,11 +1902,13 @@ class MediaObject
     }
 }
 ```
+'file' => ['type' => 'Upload!','description' => 'The file to upload']
+'files' => ['type' => '[Upload!]!','description' => 'Files to upload']
 
 As you can see, a dedicated type `Upload` is used in the argument of the `upload` mutation.
-
-If you need to upload multiple files, replace `"file"={"type"="Upload!", "description"="The file to upload"}`
-with `"files"={"type"="[Upload!]!", "description"="Files to upload"}`.
+If you need to upload multiple files, replace   
+`'file' => ['type' => 'Upload!','description' => 'The file to upload']`  
+with `'files' => ['type' => '[Upload!]!','description' => 'Files to upload']`.
 
 You don't need to create it, it's provided in API Platform.
 
@@ -1948,7 +1919,6 @@ The corresponding resolver you added in the resource configuration should be wri
 ```php
 <?php
 // api/src/Resolver/CreateMediaObjectResolver.php
-
 namespace App\Resolver;
 
 use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
@@ -2012,18 +1982,14 @@ For instance, if you want to change the description of the `create` mutation:
 
 ```php
 <?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-namespace App\Model;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-
-#[ApiResource(
-    graphql: [
-        'create' => [
-            'description' => 'My custom description.'
-        ]
-    ]
-)]
+#[ApiResource]
+#[Mutation(name: 'create', description: 'My custom description.')]
 class Book
 {
     // ...

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -1902,11 +1902,12 @@ class MediaObject
     }
 }
 ```
+
 'file' => ['type' => 'Upload!','description' => 'The file to upload']
 'files' => ['type' => '[Upload!]!','description' => 'Files to upload']
 
 As you can see, a dedicated type `Upload` is used in the argument of the `upload` mutation.
-If you need to upload multiple files, replace   
+If you need to upload multiple files, replace
 `'file' => ['type' => 'Upload!','description' => 'The file to upload']`  
 with `'files' => ['type' => '[Upload!]!','description' => 'Files to upload']`.
 

--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -13,21 +13,20 @@ Let's say you have the following class, which is identified by a `UUID` type. In
 
 ```php
 <?php
+// api/src/Entity/Person.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 use App\Uuid;
 
-/**
- * @ApiResource
- */
+#[ApiResource]
 final class Person
 {
     /**
      * @var Uuid
-     * @ApiProperty(identifier=true)
      */
+    #[ApiProperty(identifier: true)]
     public $code;
     
     // ...
@@ -150,34 +149,35 @@ If your resource is also a Doctrine entity and you want to use another identifie
 
 ```php
 <?php
+// api/src/Entity/Person.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 use App\Uuid;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ApiResource
  */
+#[ApiResource]
 final class Person
 {
     /**
      * @var int
-     * @ApiProperty(identifier=false)
      *
      * @ORM\Id()
      * @ORM\GeneratedValue()
      * @ORM\Column(type="integer")
      */
+    #[ApiProperty(identifier: false)]
     private $id;
     
     /**
      * @var Uuid
-     * @ApiProperty(identifier=true)
      * @ORM\Column(type="uuid", unique=true)
-     */
+     */     
+    #[ApiProperty(identifier: true)]
     public $code;
     
     // ...

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -203,8 +203,6 @@ To do it, we need to create a decorator:
 <?php
 // api/src/OpenApi/JwtDecorator.php
 
-declare(strict_types=1);
-
 namespace App\OpenApi;
 
 use ApiPlatform\Core\OpenApi\Factory\OpenApiFactoryInterface;

--- a/core/mercure.md
+++ b/core/mercure.md
@@ -44,14 +44,11 @@ Use the `mercure` attribute to hint API Platform that it must dispatch the updat
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(mercure=true)
- */
+#[ApiResource(mercure: true)]
 class Book
 {
     // ...
@@ -82,14 +79,11 @@ Then, use options to mark the published updates as privates:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(mercure={"private": true})
- */
+#[ApiResource(mercure: ['private' => true])]
 class Book
 {
     // ...
@@ -101,14 +95,11 @@ It's also possible to execute an *expression* (using the [Symfony Expression Lan
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(mercure="object.mercureOptions")
- */
+#[ApiResource(mercure: 'object.mercureOptions')]
 class Book
 {
     public $mercureOptions = ['private' => true];
@@ -146,10 +137,9 @@ Below is an example using the `topics` option:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 use App\Entity\User;
 
@@ -181,10 +171,9 @@ Using an *expression* function:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Entity\User;
 
 #[ApiResource(

--- a/core/messenger.md
+++ b/core/messenger.md
@@ -25,19 +25,18 @@ Set the `messenger` attribute to `true`, and API Platform will automatically dis
 ```php
 <?php
 // api/src/Entity/Person.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 use Symfony\Component\Validator\Constraints as Assert;
 use ApiPlatform\Core\Action\NotFoundAction;
 
-#[ApiResource(collectionOperations: [
-        "post" => ["messenger" => true, "output" => false, "status" => 202]
-    ], itemOperations: [
-        "get" => ["controller" => NotFoundAction::class, "read" => false, "status" => 404]
-    ]
-)]
+#[ApiResource]
+#[Get(controller: NotFoundAction::class, read: false, status: 404)]
+#[Post(messenger: true, output: false, status: 202)]
 final class Person
 {
     #[ApiProperty(identifier: true)]
@@ -124,19 +123,27 @@ Set the `messenger` attribute to `input`, and API Platform will automatically di
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\GetCollection;
 use App\Dto\ResetPasswordRequest;
 
-#[ApiResource(collectionOperations: [
-        "post", "get",
-        "reset_password" => ["status" => 202, "messenger" => "input", "input" => ResetPasswordRequest::class, "output" => false, "method" => "POST", "path" => "/users/reset_password"]
-    ]
+#[ApiResource]
+#[GetCollection]
+#[Post]
+#[Post(
+    name: 'reset_password', 
+    status: 202, 
+    messenger: 'input', 
+    input: ResetPasswordRequest::class, 
+    output: false, 
+    uriTemplate: '/users/reset_password'
 )]
 final class User
 {
+    // ...
 }
 ```
 

--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -236,7 +236,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
  * @ODM\Document
  */
 #[ApiResource]
-#[GetCollection(doctrineMongodb: ['execute_options' => ['allowDiskUse' => true]])]
+#[GetCollection(extraProperties: ['doctrineMongodb' => ['execute_options' => ['allowDiskUse' => true]]])]
 class Offer
 {
     // ...
@@ -257,7 +257,7 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 /**
  * @ODM\Document
  */
-#[ApiResource(doctrineMongodb: ['execute_options' => ['allowDiskUse' => true]])]
+#[ApiResource(extraProperties: ['doctrineMongodb' => ['execute_options' => ['allowDiskUse' => true]]])]
 class Offer
 {
     // ...

--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -103,16 +103,15 @@ Creating resources mapped to MongoDB documents is as simple as creating entities
 
 namespace App\Document;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * @ApiResource
- *
  * @ODM\Document
  */
+#[ApiResource]
 class Product
 {
     /**
@@ -163,15 +162,14 @@ class Product
 
 namespace App\Document;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * @ApiResource(iri="http://schema.org/Offer")
- *
  * @ODM\Document
  */
+#[ApiResource(types: ['http://schema.org/Offer'])]
 class Offer
 {
     /**
@@ -230,24 +228,15 @@ For instance at the operation level:
 
 namespace App\Document;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
- * @ApiResource(attributes={
- *     collectionOperations={
- *         "get"={
- *             "method"="GET",
- *             "doctrine_mongodb"={
- *                 "execute_options"={
- *                     "allowDiskUse"=true
- *                 }
- *             }
- *         }
- *     }
- * })
  * @ODM\Document
  */
+#[ApiResource]
+#[GetCollection(doctrineMongodb: ['execute_options' => ['allowDiskUse' => true]])]
 class Offer
 {
     // ...
@@ -262,19 +251,13 @@ Or at the resource level:
 
 namespace App\Document;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /**
- * @ApiResource(attributes={
- *     "doctrine_mongodb"={
- *         "execute_options"={
- *             "allowDiskUse"=true
- *         }
- *     }
- * })
  * @ODM\Document
  */
+#[ApiResource(doctrineMongodb: ['execute_options' => ['allowDiskUse' => true]])]
 class Offer
 {
     // ...

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -114,18 +114,17 @@ The following configuration will give you total control over your OpenAPI defini
 ```php
 <?php
 // api/src/Entity/Product.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Annotation\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * @ApiResource
  * @ORM\Entity
  */
+#[ApiResource]
 class Product // The class name will be used to name exposed resources
 {
     /**
@@ -140,29 +139,26 @@ class Product // The class name will be used to name exposed resources
      *
      * @ORM\Column
      * @Assert\NotBlank
-     *
-     * @ApiProperty(
-     *     attributes={
-     *         "openapi_context"={
-     *             "type"="string",
-     *             "enum"={"one", "two"},
-     *             "example"="one"
-     *         }
-     *     }
-     * )
      */
+    #[ApiProperty(
+        openapiContext: [
+            "type" => "string",
+            "enum" => ["one", "two"],
+            "example" => "one"
+        ]
+    )]
     public $name;
 
     /**
      * @ORM\Column
      * @Assert\DateTime
-     *
-     * @ApiProperty(
-     *     attributes={
-     *         "openapi_context"={"type"="string", "format"="date-time"}
-     *     }
-     * )
      */
+    #[ApiProperty(
+        openapiContext: [
+            "type" => "string", 
+            "format" => "date-time"
+        ]
+    )]
     public $timestamp;
 
     // ...
@@ -267,35 +263,25 @@ in the (`de`)`normalization_context`. It's possible to override the name
 thanks to the `swagger_definition_name` option:
 
 ```php
-/**
- * @ApiResource(
- *      collectionOperations={
- *          "post"={
- *              "denormalization_context"={
- *                  "groups"={"user:read"},
- *                  "swagger_definition_name": "Read",
- *              },
- *          },
- *      },
- * )
- */
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+
+#[ApiResource]
+#[Post(denormalizationContext: ['groups' => ['user:read'], 'swagger_definition_name' => 'Read'])]
 class User
 {
+    // ...
 }
 ```
 
-It's also possible to re-use the (`de`)`normalization_context`:
+It's also possible to re-use the (`de`)`normalizationContext`:
 
 ```php
-/**
- * @ApiResource(
- *      collectionOperations={
- *          "post"={
- *              "denormalization_context"=User::API_WRITE,
- *          },
- *      },
- * )
- */
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+
+#[ApiResource]
+#[Post(denormalizationContext: [User::API_WRITE])]
 class User
 {
     const API_WRITE = [
@@ -314,43 +300,43 @@ You also have full control over both built-in and custom operations documentatio
 ```php
 <?php
 // api/src/Entity/Rabbit.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
 use App\Controller\RandomRabbit;
 
-#[ApiResource(collectionOperations: [
-        'create_rabbit' => [
-            'method'          => 'post',
-            'path'            => '/rabbit/create',
-            'controller'      => RandomRabbit::class,
-            'openapi_context' => [
-                'summary'     => 'Create a rabbit picture',
-                'description' => "# Pop a great rabbit picture by color!\n\n![A great rabbit](https://rabbit.org/graphics/fun/netbunnies/jellybean1-brennan1.jpg)",
-                'requestBody' => [
-                    'content' => [
-                        'application/json' => [
-                            'schema'  => [
-                                'type'       => 'object',
-                                'properties' =>
-                                    [
-                                        'name'        => ['type' => 'string'],
-                                        'description' => ['type' => 'string'],
-                                    ],
-                            ],
-                            'example' => [
-                                'name'        => 'Mr. Rabbit',
-                                'description' => 'Pink Rabbit',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ],
+#[ApiResource]
+#[Post(
+    name: 'create_rabbit', 
+    uriTemplate: '/rabbit/create', 
+    controller: RandomRabbit::class, 
+    openapiContext: [
+        'summary' => 'Create a rabbit picture', 
+        'description' => '# Pop a great rabbit picture by color!\n\n![A great rabbit](https://rabbit.org/graphics/fun/netbunnies/jellybean1-brennan1.jpg)', 
+        'requestBody' => [
+            'content' => [
+                'application/json' => [
+                    'schema' => [
+                        'type' => 'object', 
+                        'properties' => [
+                            'name' => ['type' => 'string'], 
+                            'description' => ['type' => 'string']
+                        ]
+                    ], 
+                    'example' => [
+                        'name' => 'Mr. Rabbit', 
+                        'description' => 'Pink Rabbit'
+                    ]
+                ]
+            ]
+        ]
     ]
 )]
 class Rabbit
-{}
+{
+    // ...
+}
 ```
 
 ```yaml

--- a/core/operation-path-naming.md
+++ b/core/operation-path-naming.md
@@ -31,9 +31,7 @@ Make sure the custom segment generator implements [`ApiPlatform\Core\Operation\P
 
 ```php
 <?php
-
 // api/src/Operation/SingularPathSegmentNameGenerator.php
-
 namespace App\Operation;
 
 use ApiPlatform\Core\Operation\PathSegmentNameGeneratorInterface;

--- a/core/operations.md
+++ b/core/operations.md
@@ -21,7 +21,7 @@ Collection operations act on a collection of resources. By default two routes ar
 operations act on an individual resource. Three default routes are defined: `GET`, `PUT` and `DELETE` (`PATCH` is also supported
 when [using the JSON:API format](content-negotiation.md), as required by the specification).
 
-When the `ApiPlatform\Core\Annotation\ApiResource` annotation is applied to an entity class, the following built-in CRUD
+When the `ApiPlatform\Metadata\ApiResource` annotation is applied to an entity class, the following built-in CRUD
 operations are automatically enabled:
 
 Collection operations:
@@ -70,15 +70,15 @@ will be automatically added.
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 
-#[ApiResource(
-    collectionOperations: ['get'],
-    itemOperations: ['get'],
-)]
+#[ApiResource]
+#[Get]
+#[GetCollection]
 class Book
 {
     // ...
@@ -122,19 +122,15 @@ The previous example can also be written with an explicit method definition:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
 
-#[ApiResource(
-    collectionOperations: [
-        'get' => ['method' => 'get'],
-    ],
-    itemOperations: [
-        'get' => ['method' => 'get'],
-    ],
-)]
+#[ApiResource]
+#[Get]
+#[GetCollection]
 class Book
 {
     // ...
@@ -185,26 +181,23 @@ If you do not want to allow access to the resource item (i.e. you don't want a `
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
 use ApiPlatform\Core\Action\NotFoundAction;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\ApiResource;
 
-#[ApiResource(
-    collectionOperations: [
-        'get' => ['method' => 'get'],
-    ],
-    itemOperations: [
-        'get' => [
-            'controller' => NotFoundAction::class,
-            'read' => false,
-            'output' => false,
-        ],
-    ],
+#[ApiResource]
+#[Get(
+    controller: NotFoundAction::class, 
+    read: false, 
+    output: false
 )]
+#[GetCollection]
 class Book
 {
+    // ...
 }
 ```
 
@@ -257,28 +250,24 @@ In addition to that, we require the `id` parameter in the URL of the `GET` opera
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
 
-#[ApiResource(
-    collectionOperations: [
-        'post' => [
-            'path' => '/grimoire',
-            'status' => 301,
-        ],
-    ],
-    itemOperations: [
-        'get' => [
-            'path' => '/grimoire/{id}',
-            'requirements' => ['id' => '\d+'],
-            'defaults' => ['color' => 'brown'],
-            'options' => ['my_option' => 'my_option_value'],
-            'schemes' => ['https'],
-            'host' => '{subdomain}.api-platform.com',
-        ],
-    ],
+#[ApiResource]
+#[Get(
+    uriTemplate: '/grimoire/{id}', 
+    requirements: ['id' => '\d+'], 
+    defaults: ['color' => 'brown'], 
+    options: ['my_option' => 'my_option_value'], 
+    schemes: ['https'], 
+    host: '{subdomain}.api-platform.com'
+)]
+#[Post(
+    uriTemplate: '/grimoire', 
+    status: 301
 )]
 class Book
 {
@@ -359,10 +348,9 @@ you don't need to override all the operations to set the path but configure the 
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource(routePrefix: '/library')]
 class Book
@@ -405,7 +393,7 @@ App\Entity\Book:
 
 [/codeSelector]
 
-Alternatively, the more verbose attribute syntax can be used: `@ApiResource(attributes={"route_prefix"="/library"})`.
+Alternatively, the more verbose attribute syntax can be used: `#[ApiResource(routePrefix: "/library")]`.
 
 API Platform will automatically map this `post_publication` operation to the route `book_post_publication`. Let's create a custom action
 and its related route using annotations:
@@ -493,8 +481,7 @@ Let's say you have the following entities in your project:
 
 ```php
 <?php
-// src/Entity/Place.php
-
+// api/src/Entity/Place.php
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
@@ -532,8 +519,7 @@ class Place
 
 ```php
 <?php
-// src/Entity/Weather.php
-
+// api/src/Entity/Weather.php
 namespace App\Entity;
 
 class Weather
@@ -551,33 +537,28 @@ Because we want to get the weather for a known place, it is more reasonable to q
 
 ```php
 <?php
-// src/Entity/Place.php
-
+// api/src/Entity/Place.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\ApiResource;
 use App\Controller\GetWeather;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
  */
-#[ApiResource(
-    collectionOperations: [
-        'get',
-        'post',
-    ],
-    itemOperations: [
-        'get',
-        'put',
-        'delete',
-        'get_weather' => [
-            'method' => 'GET',
-            'path' => '/places/{id}/weather',
-            'controller' => GetWeather::class,
-        ],
-    ],
-)]
+#[ApiResource]
+#[Get]
+#[Put]
+#[Delete]
+#[Get(name: 'weather', uriTemplate: '/places/{id}/weather', controller: GetWeather::class)]
+#[GetCollection]
+#[Post]
 class Place
 {
     // ...
@@ -588,11 +569,10 @@ This implies that API Platform has to know about this entity, so we will need to
 
 ```php
 <?php
-// src/Entity/Weather.php
-
+// api/src/Entity/Weather.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource]
 class Weather
@@ -605,23 +585,18 @@ Since we are required to expose at least one route, let's expose just one:
 
 ```php
 <?php
-// src/Entity/Weather.php
-
+// api/src/Entity/Weather.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 
-#[ApiResource(
-    itemOperations: [
-        'get' => [
-            'method' => 'GET',
-            'controller' => SomeRandomController::class,
-        ],
-    ],
-)]
+#[ApiResource]
+#[Get(controller: SomeRandomController::class)]
 class Weather
 {
     // ...
+}
 ```
 
 This way, we expose a route that will do… nothing. Note that the controller does not even need to exist.

--- a/core/operations.md
+++ b/core/operations.md
@@ -44,7 +44,7 @@ Note: the `PATCH` method must be enabled explicitly in the configuration, refer 
 
 Note: with JSON Merge Patch, the [null values will be skipped](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) in the response.
 
-Note: Current `PUT` implementation behaves more or less like the `PATCH` method. Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (https://github.com/api-platform/core/issues/4344) to track the progress.
+Note: Current `PUT` implementation behaves more or less like the `PATCH` method. Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (<https://github.com/api-platform/core/issues/4344>) to track the progress.
 
 ## Enabling and Disabling Operations
 

--- a/core/operations.md
+++ b/core/operations.md
@@ -44,7 +44,8 @@ Note: the `PATCH` method must be enabled explicitly in the configuration, refer 
 
 Note: with JSON Merge Patch, the [null values will be skipped](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) in the response.
 
-Note: Current `PUT` implementation behaves more or less like the `PATCH` method. Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (<https://github.com/api-platform/core/issues/4344>) to track the progress.
+Note: Current `PUT` implementation behaves more or less like the `PATCH` method. 
+Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (<https://github.com/api-platform/core/issues/4344>) to track the progress.
 
 ## Enabling and Disabling Operations
 

--- a/core/operations.md
+++ b/core/operations.md
@@ -44,7 +44,7 @@ Note: the `PATCH` method must be enabled explicitly in the configuration, refer 
 
 Note: with JSON Merge Patch, the [null values will be skipped](https://symfony.com/doc/current/components/serializer.html#skipping-null-values) in the response.
 
-Note: Current `PUT` implementation behaves more or less like the `PATCH` method. 
+Note: Current `PUT` implementation behaves more or less like the `PATCH` method.
 Existing properties not included in the payload are **not** removed, their current values are preserved. To remove an existing property, its value must be explicitly set to `null`. Implementing [the standard `PUT` behavior](https://httpwg.org/specs/rfc7231.html#PUT) is on the roadmap, follow [issue #4344] (<https://github.com/api-platform/core/issues/4344>) to track the progress.
 
 ## Enabling and Disabling Operations

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -519,5 +519,6 @@ and if you want your results to be paginated, you will need to return an instanc
 `ApiPlatform\Core\DataProvider\PartialPaginatorInterface` or
 `ApiPlatform\Core\DataProvider\PaginatorInterface`.
 A few existing classes are provided to make it easier to paginate the results:
+
 * `ApiPlatform\Core\DataProvider\ArrayPaginator`
 * `ApiPlatform\Core\DataProvider\TraversablePaginator`

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -75,12 +75,11 @@ It can also be disabled for a specific resource:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_enabled"=false})
- */
+#[ApiResource(paginationEnabled: false)]
 class Book
 {
     // ...
@@ -119,12 +118,11 @@ The client ability to disable the pagination can also be set in the resource con
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_client_enabled"=true})
- */
+#[ApiResource(paginationClientEnabled: true)]
 class Book
 {
     // ...
@@ -151,12 +149,11 @@ api_platform:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_items_per_page"=30})
- */
+#[ApiResource(paginationItemsPerPage: 30)]
 class Book
 {
     // ...
@@ -186,12 +183,11 @@ Changing the number of items per page can be enabled (or disabled) for a specifi
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_client_items_per_page"=true})
- */
+#[ApiResource(paginationClientItemsPerPage: true)]
 class Book
 {
     // ...
@@ -216,14 +212,11 @@ api_platform:
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(
- *     attributes={"pagination_maximum_items_per_page"=50}
- * )
- */
+#[ApiResource(paginationMaximumItemsPerPage: 50)]
 class Book
 {
     // ...
@@ -235,16 +228,13 @@ class Book
 ```php
 <?php
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 
-/**
- * @ApiResource(
- *     collectionOperations={
- *         "get"={"pagination_maximum_items_per_page"=50}
- *     }
- * )
- */
+#[ApiResource]
+#[GetCollection(paginationMaximumItemsPerPage: 50)]
 class Book
 {
     // ...
@@ -272,14 +262,12 @@ api_platform:
 
 ```php
 <?php
-
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_partial"=true})
- */
+#[ApiResource(paginationPartial: true)]
 class Book
 {
     // ...
@@ -307,14 +295,12 @@ The partial pagination retrieval can now be changed by toggling a query paramete
 
 ```php
 <?php
-
 // api/src/Entity/Book.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(attributes={"pagination_client_partial"=true})
- */
+#[ApiResource(paginationClientPartial: true)]
 class Book
 {
     // ...
@@ -330,24 +316,22 @@ The following configuration also works on a specific operation:
 
 ```php
 <?php
-
 // api/src/Entity/Book.php
+namespace App\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\OrderFilter;
 use ApiPlatform\Core\Bridge\Doctrine\MongoDbOdm\Filter\RangeFilter;
 
-/**
- * @ApiResource(attributes={
- *     "pagination_partial"=true,
- *     "pagination_via_cursor"={
- *         {"field"="id", "direction"="DESC"},
- *     },
- * )
- * @ApiFilter(RangeFilter::class, properties={"id"})
- * @ApiFilter(OrderFilter::class, properties={"id"="DESC"})
- */
+#[ApiResource(
+    paginationPartial: true, 
+    paginationViaCursor: [
+        ['field' => 'id', 'direction' => 'DESC']
+    ]
+)]
+#[ApiFilter(RangeFilter::class, properties: ["id"])]
+#[ApiFilter(OrderFilter::class, properties: ["id" => "DESC"])]
 class Book
 {
     // ...
@@ -362,26 +346,19 @@ The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Bri
 
 * `$fetchJoinCollection` argument: Whether there is a join to a collection-valued association. When set to `true`, the Doctrine ORM Paginator will perform an additional query, in order to get the correct number of results.
 
-    You can configure this using the `pagination_fetch_join_collection` attribute on a resource or on a per-operation basis:
+    You can configure this using the `paginationFetchJoinCollection` attribute on a resource or on a per-operation basis:
 
     ```php
     <?php
     // api/src/Entity/Book.php
+    namespace App\Entity;
 
-    use ApiPlatform\Core\Annotation\ApiResource;
+    use ApiPlatform\Metadata\ApiResource;
+    use ApiPlatform\Metadata\GetCollection;
 
-    /**
-    * @ApiResource(
-    *     attributes={"pagination_fetch_join_collection"=false},
-    *     collectionOperations={
-    *         "get",
-    *         "get_custom"={
-    *             ...
-    *             "pagination_fetch_join_collection"=true,
-    *         },
-    *     },
-    * )
-    */
+    #[ApiResource(paginationFetchJoinCollection: false)]
+    #[GetCollection]
+    #[GetCollection(name: 'custom', paginationFetchJoinCollection: true)]
     class Book
     {
         // ...
@@ -390,26 +367,19 @@ The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Bri
 
 * `setUseOutputWalkers` setter: Whether to use output walkers. When set to `true`, the Doctrine ORM Paginator will use output walkers, which are compulsory for some types of queries.
 
-    You can configure this using the `pagination_use_output_walkers` attribute on a resource or on a per-operation basis:
+    You can configure this using the `paginationUseOutputWalkers` attribute on a resource or on a per-operation basis:
 
     ```php
     <?php
     // api/src/Entity/Book.php
+    namespace App\Entity;
 
-    use ApiPlatform\Core\Annotation\ApiResource;
+    use ApiPlatform\Metadata\ApiResource;
+    use ApiPlatform\Metadata\GetCollection;
 
-    /**
-    * @ApiResource(
-    *     attributes={"pagination_use_output_walkers"=false},
-    *     collectionOperations={
-    *         "get",
-    *         "get_custom"={
-    *             ...
-    *             "pagination_use_output_walkers"=true,
-    *         },
-    *     },
-    * )
-    */
+    #[ApiResource(paginationUseOutputWalkers: false)]
+    #[GetCollection]
+    #[GetCollection(name: 'custom', paginationUseOutputWalkers: true)]
     class Book
     {
         // ...
@@ -427,9 +397,7 @@ First example:
 
 ```php
 <?php
-
 // api/src/Repository/BookRepository.php
-
 namespace App\Repository;
 
 use App\Entity\Book;
@@ -484,9 +452,7 @@ The Controller would look like this:
 
 ```php
 <?php
-
 // api/src/Controller/Book/GetBooksByFavoriteAuthorAction.php
-
 namespace App\Controller\Book;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Paginator;

--- a/core/performance.md
+++ b/core/performance.md
@@ -52,9 +52,7 @@ augmented with these resources. Here is an example of how this can be done:
 
 ```php
 <?php
-
-declare(strict_types=1);
-
+// api/src/EventSubscriber/UserResourcesSubscriber.php
 namespace App\EventSubscriber;
 
 use ApiPlatform\Core\EventListener\EventPriorities;
@@ -93,11 +91,15 @@ final class UserResourcesSubscriber implements EventSubscriberInterface
 The `cache_headers` attribute can be used to set custom HTTP cache headers:
 
 ```php
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(cacheHeaders={"max_age"=60, "shared_max_age"=120, "vary"={"Authorization", "Accept-Language"}})
- */
+#[ApiResource(
+    cacheHeaders: [
+        'max_age' => 60, 
+        'shared_max_age' => 120, 
+        'vary' => ['Authorization', 'Accept-Language']
+    ]
+)]
 class Book
 {
     // ...
@@ -114,15 +116,15 @@ Vary: Authorization, Accept-Language
 It's also possible to set different cache headers per operation:
 
 ```php
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource(
- *     itemOperations={
- *         "get"={"cache_headers"={"max_age"=60, "shared_max_age"=120}}
- *     }
- * )
- */
+#[ApiResource]
+#[Get(
+    cacheHeaders: [
+        'max_age' => 60, 
+        'shared_max_age' => 120
+    ]
+)]
 class Book
 {
     // ...
@@ -169,10 +171,12 @@ readable association according to the serialization context. If you want to fetc
 you have to bypass `readable` and `readableLink` by using the `fetchEager` attribute on the property declaration, for example:
 
 ```php
-/**
- * @ApiProperty(attributes={"fetchEager": true})
- */
+...
+
+ #[ApiProperty(fetchEager: true)]
  public $foo;
+
+...
 ```
 
 #### Max Joins
@@ -225,16 +229,15 @@ from the configuration of each resource. You can do this at the resource level, 
 ```php
 <?php
 // api/src/Entity/Address.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ApiResource
  * @ORM\Entity
  */
+#[ApiResource]
 class Address
 {
     // ...
@@ -244,16 +247,15 @@ class Address
 ```php
 <?php
 // api/src/Entity/User.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ApiResource(attributes={"force_eager"=false})
  * @ORM\Entity
  */
+#[ApiResource(forceEager: false)]
 class User
 {
     /**
@@ -278,26 +280,21 @@ class User
 ```php
 <?php
 // api/src/Entity/Group.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\GetCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * @ApiResource(
- *     attributes={"force_eager"=false},
- *     itemOperations={
- *         "get"={"force_eager"=true},
- *         "post"
- *     },
- *     collectionOperations={
- *         "get"={"force_eager"=true},
- *         "post"
- *     }
- * )
  * @ORM\Entity
  */
+#[ApiResource(forceEager: false)]
+#[Get(forceEager: true)]
+#[Post]
+#[GetCollection(forceEager: true)]
 class Group
 {
     /**

--- a/core/push-relations.md
+++ b/core/push-relations.md
@@ -11,21 +11,19 @@ Vulcain is faster, cleaner, more flexible, and is supported out of the box in th
 
 ```php
 <?php
-
+// api/src/Entity/Book.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 
-/**
- * @ApiResource
- */
+#[ApiResource] 
 class Book
 {
     /**
      * @var Author
-     * @ApiProperty(push=true)
      */
+     #[ApiProperty(push: true)]
     public $author;
     
     // ...

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -79,10 +79,9 @@ It is simple to specify what groups to use in the API system:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
@@ -126,24 +125,12 @@ App\Entity\Book:
 
 [/codeSelector]
 
-Alternatively, you can use the more verbose syntax:
-
-```php
-<?php
-// ...
-
-#[ApiResource(attributes: [
-    'normalization_context' => ['groups' => ['read']],
-    'denormalization_context' => ['groups' => ['write']],
-])]
-```
-
 In the previous example, the `name` property will be visible when reading (`GET`) the object, and it will also be available
 to write (`PUT` / `PATCH` / `POST`). The `author` property will be write-only; it will not be visible when serialized responses are
 returned by the API.
 
-Internally, API Platform passes the value of the `normalization_context` as the 3rd argument of [the `Serializer::serialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_serialize) during the normalization
-process. `denormalization_context` is passed as the 4th argument of [the `Serializer::deserialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_deserialize) during denormalization (writing).
+Internally, API Platform passes the value of the `normalizationContext` as the 3rd argument of [the `Serializer::serialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_serialize) during the normalization
+process. `denormalizationContext` is passed as the 4th argument of [the `Serializer::deserialize()` method](https://api.symfony.com/master/Symfony/Component/Serializer/SerializerInterface.html#method_deserialize) during denormalization (writing).
 
 To configure the serialization groups of classes's properties, you must use directly [the Symfony Serializer's configuration files or annotations](https://symfony.com/doc/current/components/serializer.html#attributes-groups).
 
@@ -167,21 +154,16 @@ In the following example we use different serialization groups for the `GET` and
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
 use Symfony\Component\Serializer\Annotation\Groups;
 
-#[ApiResource(
-    normalizationContext: ['groups' => ['get']],
-    itemOperations: [
-        'get',
-        'put' => [
-            'normalization_context' => ['groups' => ['put']],
-        ],
-    ],
-)]
+#[ApiResource(normalizationContext: ['groups' => ['get']])]
+#[Get]
+#[Put(normalizationContext: ['groups' => ['put']])]
 class Book
 {
     /**
@@ -260,10 +242,9 @@ the `book` group, the author will be embedded.
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(normalizationContext: ['groups' => ['book']])]
@@ -306,10 +287,9 @@ App\Entity\Book:
 ```php
 <?php
 // api/src/Entity/Person.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource]
@@ -367,10 +347,9 @@ the same way as normalization. For example:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource(denormalizationContext: ['groups' => ['book']])]
 class Book
@@ -406,19 +385,14 @@ It is a common problem to have entities that reference other entities of the sam
 ```php
 <?php
 // api/src/Entity/Person.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
-    normalizationContext: [
-        'groups' => ['person'],
-    ],
-    denormalizationContext: [
-        'groups' => ['person'],
-    ],
+    normalizationContext: ['groups' => ['person']],
+    denormalizationContext: ['groups' => ['person']]
 )]
 class Person
 {
@@ -467,19 +441,15 @@ To force the **$parent** property to be used as an IRI, add an **#[ApiProperty(r
 ```php
 <?php
 // api/src/Entity/Person.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
-    normalizationContext: [
-        'groups' => ['person'],
-    ],
-    denormalizationContext: [
-        'groups' => ['person'],
-    ],
+    normalizationContext: ['groups' => ['person']],
+    denormalizationContext: ['groups' => ['person']]
 )]
 class Person
 {
@@ -570,6 +540,8 @@ class PlainIdentifierDenormalizer implements ContextAwareDenormalizerInterface, 
     {
         return \in_array($format, ['json', 'jsonld'], true) && is_a($type, Dummy::class, true) && !empty($data['relatedDummy']) && !isset($context[__CLASS__]);
     }
+}
+```
 
 ## Property Normalization Context
 
@@ -581,12 +553,9 @@ For instance:
 ```php
 <?php
 // api/src/Entity/Book.php
-
-declare(strict_types=1);
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Context;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -621,12 +590,9 @@ It's also possible to only change the denormalization or normalization context:
 ```php
 <?php
 // api/src/Entity/Book.php
-
-declare(strict_types=1);
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Context;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -650,12 +616,9 @@ Groups are also supported:
 ```php
 <?php
 // api/src/Entity/Book.php
-
-declare(strict_types=1);
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Context;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -688,23 +651,19 @@ Sometimes you need to expose calculated fields. This can be done by leveraging t
 
 ```php
 <?php
-
-declare(strict_types=1);
-
+// api/src/Entity/Greeting.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity
  */
-#[ApiResource(
-    collectionOperations: [
-        'get' => ['normalization_context' => ['groups' => 'greeting:collection:get']],
-    ],
-)]
+#[ApiResource]
+#[GetCollection(normalizationContext: ['groups' => 'greeting:collection:get'])]
 class Greeting
 {
     /**
@@ -776,10 +735,9 @@ Let's imagine a resource where most fields can be managed by any user, but some 
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ApiResource(
@@ -852,7 +810,6 @@ services:
 ```php
 <?php
 // api/src/Serializer/BookContextBuilder.php
-
 namespace App\Serializer;
 
 use ApiPlatform\Core\Serializer\SerializerContextBuilderInterface;
@@ -916,7 +873,6 @@ Here is an example:
 ```php
 <?php
 // api/src/Serializer/BookAttributeNormalizer.php
-
 namespace App\Serializer;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -1020,7 +976,6 @@ Note: this normalizer will work only for JSON-LD format, if you want to process 
 ```php
 <?php
 // api/src/Serializer/ApiNormalizer
-
 namespace App\Serializer;
 
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -1081,9 +1036,16 @@ API Platform is able to guess the entity identifier using Doctrine metadata ([OR
 For ORM, it also supports [composite identifiers](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/composite-primary-keys.html).
 
 If you are not using the Doctrine ORM or MongoDB ODM Provider, you must explicitly mark the identifier using the `identifier` attribute of
-the `ApiPlatform\Core\Annotation\ApiProperty` annotation. For example:
+the `ApiPlatform\Metadata\ApiProperty` annotation. For example:
 
 ```php
+<?php
+// api/src/Entity/Book.php
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+
 #[ApiResource]
 class Book
 {
@@ -1152,10 +1114,9 @@ attribute to the `#[ApiResource]` annotation:
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 #[ApiResource(normalizationContext: ['jsonld_embed_context' => true])]
 class Book
@@ -1198,10 +1159,10 @@ Indeed, after an update on this relation, the collection looks wrong because `Ar
 
 ```php
 <?php
-
+// api/src/Entity/Brand.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 

--- a/core/subresources.md
+++ b/core/subresources.md
@@ -14,10 +14,9 @@ the answer to the question 42:
 ```php
 <?php
 // api/src/Entity/Answer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -52,10 +51,9 @@ class Answer
 }
 
 // api/src/Entity/Question.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiSubresource;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -134,10 +132,9 @@ You may want custom groups on subresources, you can set `normalization_context` 
 ```php
 <?php
 // api/src/Entity/Answer.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
  #[ApiResource(
     subresourceOperations: [
@@ -203,6 +200,9 @@ You can control the path of subresources with the `path` option of the `subresou
 ```php
 <?php
 // api/src/Entity/Question.php
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource
 
 #[ApiResource(
     subresourceOperations: [
@@ -214,6 +214,7 @@ You can control the path of subresources with the `path` option of the `subresou
 )]
 class Question
 {
+    // ...
 }
 ```
 
@@ -224,17 +225,21 @@ The `subresourceOperations` attribute also allows you to add an access control o
 ```php
 <?php
 // api/src/Entity/Answer.php
+namespace App\Entity;
 
- #[ApiResource(
+use ApiPlatform\Metadata\ApiResource
+
+#[ApiResource(
     subresourceOperations: [
         'api_questions_answer_get_subresource' => [
             'security' => "is_granted('ROLE_AUTHENTICATED')",
         ],
     ],
- )]
- class Answer
- {
- }
+)]
+class Answer
+{
+    // ...
+}
 ```
 
 ### Limiting Depth
@@ -245,9 +250,10 @@ such as `comments`and you don't want the route `api/questions/{id}/answers/{id}/
 ```php
 <?php
 // api/src/Entity/Question.php
+namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Annotation\ApiSubresource;
 
 #[ApiResource]

--- a/core/testing.md
+++ b/core/testing.md
@@ -47,7 +47,7 @@ Note that you can create your own test case class extending the ApiTestCase. For
 
 ```php
 <?php
-
+// api/tests/AbstractTest.php
 namespace App\Tests;
 
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;

--- a/core/url-generation-strategy.md
+++ b/core/url-generation-strategy.md
@@ -39,7 +39,7 @@ It can also be configured only for a specific resource:
 <?php
 // api/src/Entity/Book.php
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Core\Api\UrlGeneratorInterface;
 
 #[ApiResource(urlGenerationStrategy: UrlGeneratorInterface::ABS_URL)]

--- a/core/validation.md
+++ b/core/validation.md
@@ -10,15 +10,14 @@ for this task, but you can replace it with your preferred validation library suc
 
 Validating submitted data is as simple as adding [Symfony's built-in constraints](http://symfony.com/doc/current/reference/constraints.html)
 or [custom constraints](http://symfony.com/doc/current/validation/custom_constraint.html) directly in classes marked with
-the `@ApiResource` annotation:
+the `#[ApiResource]` annotation:
 
 ```php
 <?php
 // api/src/Entity/Product.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Validator\Constraints\MinimalProperties; // A custom constraint
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert; // Symfony's built-in constraints
@@ -135,10 +134,10 @@ You can configure the groups you want to use when the validation occurs directly
 <?php
 // api/src/Entity/Book.php
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ApiResource(attributes: ['validation_groups' => ['a', 'b']])]
+#[ApiResource(validationContext: ['groups' => ['a', 'b']])]
 class Book
 {
     /**
@@ -173,20 +172,21 @@ You can have different validation for each [operation](operations.md) related to
 <?php
 // api/src/Entity/Book.php
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ApiResource(
-    collectionOperations: [
-        'get',
-        'post' => ['validation_groups' => ['Default', 'postValidation']]
-    ],
-    itemOperations: [
-        'delete',
-        'get',
-        'put' => ['validation_groups' => ['Default', 'putValidation']]
-    ]
-)]
+#[ApiResource]
+#[Delete]
+#[Get]
+#[Put(validationContext: ['groups' => ['Default', 'putValidation']])]
+#[GetCollection]
+#[Post(validationContext: ['groups' => ['Default', 'postValidation']])]
 class Book
 {
     /**
@@ -238,11 +238,11 @@ In the following example, we use a static method to return the validation groups
 <?php
 // api/src/Entity/Book.php
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
-    attributes: ['validation_groups' => [Book::class, 'validationGroups']]
+    validationContext: ['groups' => [Book::class, 'validationGroups']
 )]
 class Book
 {
@@ -314,14 +314,13 @@ Then, configure the entity class to use this service to retrieve validation grou
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use App\Validator\AdminGroupsGenerator;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ApiResource(attributes: ['validation_groups' => AdminGroupsGenerator::class])
+#[ApiResource(validationContext: ['groups' => [AdminGroupsGenerator::class]])
 class Book
 {
     /**
@@ -345,9 +344,6 @@ First, you need to create your sequenced group.
 
 ```php
 <?php
-
-declare(strict_types=1);
-
 namespace App\Validator;
 
 use Symfony\Component\Validator\Constraints\GroupSequence;
@@ -374,10 +370,11 @@ And then, you need to use your class as a validation group.
 
 ```php
 <?php
-
+// api/src/Entity/Greeting.php
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
 use App\Validator\One; // classic custom constraint
 use App\Validator\Two; // classic custom constraint
 use App\Validator\MySequencedGroup; // the sequence group to use
@@ -386,13 +383,8 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * @ORM\Entity
  */
-#[ApiResource(
-    collectionOperations: [
-      'post' => [
-        'validation_groups' => MySequencedGroup::class
-      ]
-    ]
-)]
+#[ApiResource]
+#[Post(validationContext: ['groups' => MySequencedGroup::class])]
 class Greeting
 {
     /**
@@ -466,7 +458,7 @@ For example:
 
 ```php
 <?php
-
+// api/src/Entity/Brand.php
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -64,6 +64,7 @@ Note for Mac environments use the following:
 ```
 
 In VSCode, alongside the default PHP configuration in `launch.json`, you'll need path mappings for the Docker image.
+
 ```json
 {
     "version": "0.2.0",

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -243,10 +243,9 @@ Let's describe this data model as a set of Plain Old PHP Objects (POPO):
 ```php
 <?php
 // api/src/Entity/Book.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 
 /** A book. */
@@ -289,10 +288,9 @@ class Book
 ```php
 <?php
 // api/src/Entity/Review.php
-
 namespace App\Entity;
 
-use ApiPlatform\Core\Annotation\ApiResource;
+use ApiPlatform\Metadata\ApiResource;
 
 /** A review of a book. */
 #[ApiResource]
@@ -365,7 +363,7 @@ Modify these files as described in these patches:
 `api/src/Entity/Book.php`
 
 ```diff
- use ApiPlatform\Core\Annotation\ApiResource;
+ use ApiPlatform\Metadata\ApiResource;
  use Doctrine\Common\Collections\ArrayCollection;
 +use Doctrine\ORM\Mapping as ORM;
  
@@ -444,7 +442,7 @@ Modify these files as described in these patches:
 ```diff
  namespace App\Entity;
  
- use ApiPlatform\Core\Annotation\ApiResource;
+ use ApiPlatform\Metadata\ApiResource;
 +use Doctrine\ORM\Mapping as ORM;
  
 -/** A review of a book. */
@@ -609,7 +607,7 @@ To summarize, if you want to expose any entity you just have to:
 
 1. Put it under the `App\Entity\` namespace
 2. Write your data providers and persisters, or if you use Doctrine, map it with the database
-3. Mark it with the `#[ApiPlatform\Core\Annotation\ApiResource]` attribute
+3. Mark it with the `#[ApiPlatform\Metadata\ApiResourc]` attribute
 
 Could it be any easier?!
 
@@ -645,7 +643,7 @@ Modify the following files as described in these patches:
 `api/src/Entity/Book.php`
 
 ```diff
- use ApiPlatform\Core\Annotation\ApiResource;
+ use ApiPlatform\Metadata\ApiResource;
  use Doctrine\Common\Collections\ArrayCollection;
  use Doctrine\ORM\Mapping as ORM;
 +use Symfony\Component\Validator\Constraints as Assert;
@@ -674,7 +672,7 @@ Modify the following files as described in these patches:
 `api/src/Entity/Review.php`
 
 ```diff
- use ApiPlatform\Core\Annotation\ApiResource;
+ use ApiPlatform\Metadata\ApiResource;
  use Doctrine\ORM\Mapping as ORM;
 +use Symfony\Component\Validator\Constraints as Assert;
  

--- a/schema-generator/configuration.md
+++ b/schema-generator/configuration.md
@@ -132,6 +132,7 @@ The `@Assert\NotNull` constrain is automatically added.
 
 ```php
 <?php
+...
 
 /**
  * The name of the item.
@@ -140,6 +141,8 @@ The `@Assert\NotNull` constrain is automatically added.
  * @Assert\NotNull
  */
   private string $name;
+
+...
 ```
 
 ## Forcing a Unique Property
@@ -160,8 +163,11 @@ Output:
 
 ```php
 <?php
+// api/src/Entity/Person.php
+namespace App\Entity;
 
-...
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
@@ -182,6 +188,9 @@ class Person
      * @Assert\Email
      */
     private string $email;
+
+    // ...
+}
 ```
 
 ## Making a Property Read-Only
@@ -234,9 +243,12 @@ Output:
 
 ```php
 <?php
+// api/src/Entity/Person.php
+namespace App\Entity;
 
-...
+use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * A person (alive, dead, undead, or fictional).
@@ -259,7 +271,9 @@ class Person
      * @Groups({"public"})
      */
     private string $name;
-
+    
+    // ...
+}
 ```
 
 ## Forcing an Embeddable Class to be Embedded
@@ -288,9 +302,13 @@ Output:
 
 ```php
 <?php
+// api/src/Entity/Product.php
+namespace App\Entity;
 
-...
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 /**
  * Any offered product or service.
@@ -298,9 +316,9 @@ use Doctrine\ORM\Mapping as ORM;
  * @see http://schema.org/Product Documentation on Schema.org
  *
  * @ORM\Entity
- * @ApiResource(iri="http://schema.org/Product")
  * @UniqueEntity("gtin13s")
  */
+#[ApiResource(types: ["http://schema.org/Product"])]
 class Product
 {
     /**
@@ -309,10 +327,12 @@ class Product
      * @see http://schema.org/weight
      *
      * @ORM\Embedded(class="App\Entity\QuantitativeValue", columnPrefix="weight_")
-     * @ApiProperty(iri="http://schema.org/weight")
      */
+    #[ApiProperty(types: ['http://schema.org/weight'])]
     private ?QuantitativeValue $weight = null;
 
+    // ...
+}
 ```
 
 ## Author PHPDoc


### PR DESCRIPTION
· php8 attributes instead of annotations.
· Removes item & collection operations
· ApiPlatform\Core\Annotation\ to ApiPlatform\Metadata\
· forgotten file names
· adds "declare_strict" at the beginning of php  examples

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
