### PR TITLE
Update jwt.md for Symfony 5.3 compatibility

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -64,9 +64,9 @@ Then update the security configuration:
 ```yaml
 # api/config/packages/security.yaml
 security:
+    # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
-        App\Entity\User:
-            algorithm: auto
+        App\Entity\User: 'auto'
 
     # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
@@ -95,8 +95,8 @@ security:
             jwt: ~
 
     access_control:
-        - { path: ^/docs, roles: IS_AUTHENTICATED_ANONYMOUSLY } # Allows accessing the Swagger UI
-        - { path: ^/authentication_token, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/docs, roles: PUBLIC_ACCESS } # Allows accessing the Swagger UI
+        - { path: ^/authentication_token, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
 ```
 
@@ -122,9 +122,9 @@ If your API uses a [path prefix](https://symfony.com/doc/current/routing/externa
 ```yaml
 # api/config/packages/security.yaml
 security:
+    # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
-        App\Entity\User:
-            algorithm: auto
+        App\Entity\User: 'auto'
     
     # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
@@ -156,8 +156,8 @@ security:
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
 
     access_control:
-        - { path: ^/docs, roles: IS_AUTHENTICATED_ANONYMOUSLY } # Allows accessing API documentations and Swagger UI
-        - { path: ^/authentication_token, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/docs, roles: PUBLIC_ACCESS } # Allows accessing API documentations and Swagger UI
+        - { path: ^/authentication_token, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
 ```
 

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -68,7 +68,7 @@ security:
         App\Entity\User:
             algorithm: auto
 
-    https://symfony.com/doc/current/security/experimental_authenticators.html
+    # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
@@ -126,7 +126,7 @@ security:
         App\Entity\User:
             algorithm: auto
     
-    https://symfony.com/doc/current/security/experimental_authenticators.html
+    # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
@@ -307,7 +307,6 @@ namespace App\Tests;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\User;
 use Hautelook\AliceBundle\PhpUnit\ReloadDatabaseTrait;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class AuthenticationTest extends ApiTestCase
 {

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -64,10 +64,12 @@ Then update the security configuration:
 ```yaml
 # api/config/packages/security.yaml
 security:
-    encoders:
+    password_hashers:
         App\Entity\User:
             algorithm: auto
 
+    https://symfony.com/doc/current/security/experimental_authenticators.html
+    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         # used to reload user from session & other features (e.g. switch_user)
@@ -90,9 +92,7 @@ security:
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: ~
 
     access_control:
         - { path: ^/docs, roles: IS_AUTHENTICATED_ANONYMOUSLY } # Allows accessing the Swagger UI
@@ -122,10 +122,12 @@ If your API uses a [path prefix](https://symfony.com/doc/current/routing/externa
 ```yaml
 # api/config/packages/security.yaml
 security:
-    encoders:
+    password_hashers:
         App\Entity\User:
             algorithm: auto
-
+    
+    https://symfony.com/doc/current/security/experimental_authenticators.html
+    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         # used to reload user from session & other features (e.g. switch_user)
@@ -143,9 +145,7 @@ security:
             stateless: true
             anonymous: true
             provider: app_user_provider
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: ~
         main:
             anonymous: true
             json_login:
@@ -307,6 +307,7 @@ namespace App\Tests;
 use ApiPlatform\Core\Bridge\Symfony\Bundle\Test\ApiTestCase;
 use App\Entity\User;
 use Hautelook\AliceBundle\PhpUnit\ReloadDatabaseTrait;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class AuthenticationTest extends ApiTestCase
 {
@@ -319,7 +320,7 @@ class AuthenticationTest extends ApiTestCase
         $user = new User();
         $user->setEmail('test@example.com');
         $user->setPassword(
-            self::$container->get('security.password_encoder')->encodePassword($user, '$3CR3T')
+            self::$container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')
         );
 
         $manager = self::$container->get('doctrine')->getManager();


### PR DESCRIPTION
update doc for Symfony 5.3 compatibility, due to use deprecated code app does not work and return warnings

- New in version 5.3: The password_hashers option was introduced in Symfony 5.3. In previous versions it was called encoders.
- Deprecated since version 5.3: Guard authenticators are deprecated since Symfony 5.3 in favor of the new authenticator-based system.

Reference: 
https://symfony.com/doc/current/security.html#c-hashing-passwords
https://symfony.com/doc/current/security.html#guard-authenticators

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
