### PR TITLE
docs: Update the environment variables used for Mercure

### DIFF
--- a/core/mercure.md
+++ b/core/mercure.md
@@ -25,13 +25,11 @@ Then, install the Symfony bundle:
 composer require symfony/mercure-bundle
 ```
 
-Finally, 3 environment variables [must be set](See configuring Symfony with environment variables https://symfony.com/doc/current/configuration.html):
+Finally, 3 environment variables [must be set](https://symfony.com/doc/current/configuration.html#configuration-based-on-environment-variables):
 
 * `MERCURE_URL`: the URL that must be used by API Platform to publish updates to your Mercure hub (can be an internal or a public URL)
 * `MERCURE_PUBLIC_URL`: the **public** URL of the Mercure hub that clients will use to subscribe to updates
 * `MERCURE_JWT_SECRET`: a valid Mercure [JSON Web Token (JWT)](https://jwt.io/) allowing API Platform to publish updates to the hub
-
-Api Platform uses the Symfony Mercure component. For more information, see https://symfony.com/doc/current/mercure.html
 
 The JWT **must** contain a `mercure.publish` property containing an array of topic selectors.
 This array can be empty to allow publishing anonymous updates only. It can also be `["*"]` to allow publishing on every topics.

--- a/core/mercure.md
+++ b/core/mercure.md
@@ -25,11 +25,13 @@ Then, install the Symfony bundle:
 composer require symfony/mercure-bundle
 ```
 
-Finally, 3 environment variables [must be set](https://symfony.com/doc/current/configuration/external_parameters.html):
+Finally, 3 environment variables [must be set](See configuring Symfony with environment variables https://symfony.com/doc/current/configuration.html):
 
-* `MERCURE_PUBLISH_URL`: the URL that must be used by API Platform to publish updates to your Mercure hub (can be an internal or a public URL)
-* `MERCURE_SUBSCRIBE_URL`: the **public** URL of the Mercure hub that clients will use to subscribe to updates
-* `MERCURE_JWT_TOKEN`: a valid Mercure [JSON Web Token (JWT)](https://jwt.io/) allowing API Platform to publish updates to the hub
+* `MERCURE_URL`: the URL that must be used by API Platform to publish updates to your Mercure hub (can be an internal or a public URL)
+* `MERCURE_PUBLIC_URL`: the **public** URL of the Mercure hub that clients will use to subscribe to updates
+* `MERCURE_JWT_SECRET`: a valid Mercure [JSON Web Token (JWT)](https://jwt.io/) allowing API Platform to publish updates to the hub
+
+Api Platform uses the Symfony Mercure component. For more information, see https://symfony.com/doc/current/mercure.html
 
 The JWT **must** contain a `mercure.publish` property containing an array of topic selectors.
 This array can be empty to allow publishing anonymous updates only. It can also be `["*"]` to allow publishing on every topics.


### PR DESCRIPTION
Since API Platform 2.6.5 the `mercure.hub_url` configuration is ignored if the Mercure bundle used is version ^0.3 and includes the `Discovery` class

The environment variables for the Mercure component are different so I have updated this documentation. I have not mentioned there is an option to use the `hub_url` configuration option. It may be worth mentioning in a comment on the configuration that the option is deprecated.

also see: https://github.com/api-platform/core/issues/4451

The link to the Symfony external parameter configuration was also broken.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
