### PR TITLE
fix: remove 'anonymous' security in JWT config

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -84,7 +84,6 @@ security:
             security: false
         main:
             stateless: true
-            anonymous: true
             provider: app_user_provider
             json_login:
                 check_path: /authentication_token


### PR DESCRIPTION
The anonymous option for the firewall config was removed in symfony 5.1
as explained here: https://github.com/symfony/symfony/pull/36574

Using the option caused an error but it can be skipped. "[A] user that
is not authenticated is similar to an "unknown" user: They both have no
rights at all."

Resolves #1445

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
