### PR TITLE
fix: [doc] Update URL to point to the existing page

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -337,7 +337,7 @@ To know more about cursor-based pagination take a look at [this blog post on med
 
 ## Controlling The Behavior of The Doctrine ORM Paginator
 
-The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php) of API Platform performs some checks on the `QueryBuilder` to guess, in most common cases, the correct values to use when configuring the Doctrine ORM Paginator:
+The [PaginationExtension](https://github.com/api-platform/core/blob/2.6/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php) of API Platform performs some checks on the `QueryBuilder` to guess, in most common cases, the correct values to use when configuring the Doctrine ORM Paginator:
 
 * `$fetchJoinCollection` argument: Whether there is a join to a collection-valued association. When set to `true`, the Doctrine ORM Paginator will perform an additional query, in order to get the correct number of results.
 


### PR DESCRIPTION
Previous URL leads to 404

* Previous (404): https://github.com/api-platform/core/blob/main/src/Bridge/Doctrine/Orm/Extension/PaginationExtension.php
* New (200): https://github.com/api-platform/core/blob/main/src/Core/Bridge/Doctrine/Orm/Extension/PaginationExtension.php