### PR TITLE
fix: schema.org: attribute syntax

### DIFF
--- a/admin/schema.org.md
+++ b/admin/schema.org.md
@@ -17,7 +17,7 @@ To configure which property should be shown to represent your entity, map the pr
 ```php
 // api/src/Entity/Person.php
 
-#[ApiProperty(iri="http://schema.org/name")]
+#[ApiProperty(iri: "http://schema.org/name")]
 private $name;
 ```
 


### PR DESCRIPTION
This seems to have slipped through in "Change annotations to attributes"
(#1428) when converting from annotations.