### PR TITLE
add: [DOC] Custom Subresources Data Provider examples

### DIFF
--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -239,6 +239,49 @@ final class BlogPostItemDataProvider implements ItemDataProviderInterface, Restr
     }
 }
 ```
+## Custom Subresources Data Provider
+
+You can add custom logic or update subresources data provider with the SubresourceDataProviderInterface .
+
+```php
+<?php
+// api/src/DataProvider/BlogPostCollectionDataProvider.php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\BlogPost;
+
+final class BlogPostCollectionDataProvider implements SubresourceDataProviderInterface, RestrictedDataProviderInterface
+{
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return BlogPost::class === $resourceClass;
+    }
+
+    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null): iterable
+    {
+        // Retrieve the blog post collection from somewhere
+        $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
+		
+		// write your own logic
+		
+		return blogPosts;
+    }
+}
+```
+
+Declare the service in your service.
+
+```yaml
+# api/config/services.yaml
+services:
+    # ...
+    'App\DataProvider\BlogPostCollectionDataProvider':
+        bind:
+            $subresourceDataProvider: '@api_platform.doctrine.orm.default.subresource_data_provider'
+```
 
 ## Community Data Providers
 

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -17,6 +17,8 @@ For a given resource, you can implement two kinds of interface:
   is used when fetching a collection.
 * the [`ItemDataProviderInterface`](https://github.com/api-platform/core/blob/main/src/Core/DataProvider/ItemDataProviderInterface.php)
   is used when fetching items.
+* the [`SubresourceDataProviderInterface`](https://github.com/api-platform/core/blob/main/src/Core/DataProvider/SubresourceDataProviderInterface.php)
+  is used when fetching items.
 
 Both implementations can also implement a third, optional, interface called
 ['RestrictedDataProviderInterface'](https://github.com/api-platform/core/blob/main/src/Core/DataProvider/RestrictedDataProviderInterface.php)

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -126,6 +126,50 @@ services:
 
 You can find a full working example in the [API Platform's demo application](https://github.com/api-platform/demo/blob/main/api/src/DataProvider/TopBookItemDataProvider.php).
 
+## Custom Subresources Data Provider
+
+You can add custom logic or update subresources data provider with the SubresourceDataProviderInterface .
+
+```php
+<?php
+// api/src/DataProvider/BlogPostCollectionDataProvider.php
+
+namespace App\DataProvider;
+
+use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
+use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
+use App\Entity\BlogPost;
+
+final class BlogPostSubresourceDataProvider implements SubresourceDataProviderInterface, RestrictedDataProviderInterface
+{
+    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
+    {
+        return BlogPost::class === $resourceClass;
+    }
+
+    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null): iterable
+    {
+        // Retrieve the blog post collection from somewhere
+        $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
+		
+        // write your own logic
+		
+		return blogPosts;
+    }
+}
+```
+
+Declare the service in your services configuration:
+
+```yaml
+# api/config/services.yaml
+services:
+    # ...
+    'App\DataProvider\BlogPostSubresourceDataProvider':
+        arguments:
+            - '@api_platform.doctrine.orm.default.subresource_data_provider'
+```
+
 ## Injecting the Serializer in an `ItemDataProvider`
 
 In some cases, you may need to inject the `Serializer` in your `DataProvider`. There are no issues with the
@@ -238,49 +282,6 @@ final class BlogPostItemDataProvider implements ItemDataProviderInterface, Restr
         return $queryBuilder->getQuery()->getOneOrNullResult();
     }
 }
-```
-## Custom Subresources Data Provider
-
-You can add custom logic or update subresources data provider with the SubresourceDataProviderInterface .
-
-```php
-<?php
-// api/src/DataProvider/BlogPostCollectionDataProvider.php
-
-namespace App\DataProvider;
-
-use ApiPlatform\Core\DataProvider\SubresourceDataProviderInterface;
-use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
-use App\Entity\BlogPost;
-
-final class BlogPostCollectionDataProvider implements SubresourceDataProviderInterface, RestrictedDataProviderInterface
-{
-    public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
-    {
-        return BlogPost::class === $resourceClass;
-    }
-
-    public function getSubresource(string $resourceClass, array $identifiers, array $context, string $operationName = null): iterable
-    {
-        // Retrieve the blog post collection from somewhere
-        $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
-		
-		// write your own logic
-		
-		return blogPosts;
-    }
-}
-```
-
-Declare the service in your service.
-
-```yaml
-# api/config/services.yaml
-services:
-    # ...
-    'App\DataProvider\BlogPostCollectionDataProvider':
-        bind:
-            $subresourceDataProvider: '@api_platform.doctrine.orm.default.subresource_data_provider'
 ```
 
 ## Community Data Providers

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -154,6 +154,7 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
         // Retrieve the blog post collection from somewhere
         $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
         // write your own logic
+
         return blogPosts;
     }
 }

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -153,7 +153,6 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
     {
         // Retrieve the blog post collection from somewhere
         $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
-		
         // write your own logic
 		
         return blogPosts;

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -156,7 +156,7 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
 		
         // write your own logic
 		
-		return blogPosts;
+            return blogPosts;
     }
 }
 ```

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -154,7 +154,6 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
         // Retrieve the blog post collection from somewhere
         $blogPosts = $this->subresourceDataProvider->getSubresource($resourceClass, $identifiers, $context, $operationName);
         // write your own logic
-		
         return blogPosts;
     }
 }

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -156,7 +156,7 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
 		
         // write your own logic
 		
-            return blogPosts;
+        return blogPosts;
     }
 }
 ```

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -17,7 +17,7 @@ For a given resource, you can implement two kinds of interface:
   is used when fetching a collection.
 * the [`ItemDataProviderInterface`](https://github.com/api-platform/core/blob/main/src/Core/DataProvider/ItemDataProviderInterface.php)
   is used when fetching items.
-* the [`SubresourceDataProviderInterface`](https://github.com/api-platform/core/blob/main/src/Core/DataProvider/SubresourceDataProviderInterface.php)
+* the [`SubresourceDataProviderInterface`](https://github.com/api-platform/core/blob/2.6/src/DataProvider/SubresourceDataProviderInterface.php)
   is used when fetching items.
 
 Both implementations can also implement a third, optional, interface called


### PR DESCRIPTION
I added example to help user to custom the Subresources
https://github.com/api-platform/core/issues/2321#issuecomment-437357871

It would be nice to set a trace in the official doc.
