### PR TITLE
fix: [DOC] Use argument binding instead of decoration for Data Persister

### DIFF
--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -142,7 +142,8 @@ Even with service autowiring and autoconfiguration enabled, you must still confi
 services:
     # ...
     App\DataPersister\UserDataPersister:
-        decorates: 'api_platform.doctrine.orm.data_persister'
+        bind:
+            $decorated: '@api_platform.doctrine.orm.data_persister'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\DataPersister\UserDataPersister.inner']
         #tags: [ 'api_platform.data_persister' ]


### PR DESCRIPTION
Using classic decoration for the custom Data Persister in services.yaml will replace the core persister.
Probably this isn't the most common case scenario; normally you would _add_ your custom Data Persister to the chain of persisters instead of replacing it.
Use attribute binding instead, as already explained in SymfonyCasts' video.
