### PR TITLE
source folder for build caddy change

### DIFF
--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -19,7 +19,7 @@ Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to de
 First, build the images:
 
     docker build -t localhost:5000/php api --target api_platform_php
-    docker build -t localhost:5000/caddy caddy --target api_platform_caddy
+    docker build -t localhost:5000/caddy api --target api_platform_caddy
     docker build -t localhost:5000/pwa pwa --target api_platform_pwa_prod
 
 Then push the images in the registry installed in Minikube:


### PR DESCRIPTION
caddy is a part of the dockerfile who is located in api folder. The current source folder does not exist

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
