### PR TITLE
docs: Add information about how to significantly improve the test suite

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -345,7 +345,7 @@ class AuthenticationTest extends ApiTestCase
 
 Refer to [Testing the API](../distribution/testing.md) for more information about testing API Platform.
 
-### Improving tests suite speed
+### Improving Tests Suite Speed
 
 Since now we have a `JWT` authentication, functional tests require us to log in each time we want to test an API endpoint. This is where [Password Hashers](https://symfony.com/doc/current/security/passwords.html) come into play.
 

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -344,3 +344,26 @@ class AuthenticationTest extends ApiTestCase
 ```
 
 Refer to [Testing the API](../distribution/testing.md) for more information about testing API Platform.
+
+### Improving tests suite speed
+
+Since now we have a `JWT` authentication, functional tests require us to log in each time we want to test an API endpoint. This is where [Password Hashers](https://symfony.com/doc/current/security/passwords.html) come into play.
+
+Hashers are used for 2 reasons:
+
+1. To generate a hash for a raw password (`self::$container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')`)
+2. To verify a password during authentication
+
+While hashing and verifying 1 password is quite a fast operation, doing it hundreds or even thousands of times in a tests suite becomes a bottleneck, because reliable hashing algorithms are slow by their nature.
+
+To significantly improve the test suite speed, we can use more simple password hasher specifically for the `test` environment.
+
+```yaml
+# override in api/config/packages/test/security.yaml for test env
+security:
+    password_hashers:
+        App\Entity\User:
+            algorithm: md5
+            encode_as_base64: false
+            iterations: 0
+```


### PR DESCRIPTION
Hi,

this PR adds an information for the page about `JWT` authentication about how to make the tests fast.

The issue boils down to the very slow password hashers that are used in tests by default.

Each time we start a new project, or make a review of the existing one, we have to do it, because tests are extremely slow.

This is only one of the many optimizations available for the end developer, but let's start here. Other ones are listed in my blog post: https://maks-rafalko.github.io/blog/2021-11-21/symfony-tests-performance/#using-more-simple-password-hasher

In our cases, such change can improve tests speed by 2-5 times, depending on the project.
