### PR TITLE
Docs: JWT needs user identity field

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -45,6 +45,22 @@ environment, where you don't want to accidentally invalidate all your clients' t
 For more information, refer to [the bundle's documentation](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/index.md)
 or read a [general introduction to JWT here](https://jwt.io/introduction/).
 
+## Configuring LexikJWTAuthenticationBundle
+
+Once the bundle has been installed, a new file is created: `config/packages/lexik_jwt_authentication.yaml`. Adjust it as follows:
+
+```yaml
+lexik_jwt_authentication:
+    secret_key: '%env(resolve:JWT_SECRET_KEY)%'
+    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
+    pass_phrase: '%env(JWT_PASSPHRASE)%'
+    user_identity_field: email # key under which the user identity will be stored in the token payload
+```
+
+This configures the JWT to use the user's `email` as the identity field.
+
+The [full default configuration](https://github.com/lexik/LexikJWTAuthenticationBundle/blob/2.x/Resources/doc/1-configuration-reference.md#full-default-configuration) may be of interest.
+
 We're not done yet! Let's move on to configuring the Symfony SecurityBundle for JWT authentication.
 
 ## Configuring the Symfony SecurityBundle

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -170,6 +170,38 @@ security:
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
 ```
 
+## Getting a JWT token
+
+To get a JWT token, post the following to `/authentication_token`:
+
+```json
+{
+    "email": "me@example.com",
+    "password": "my-secret-password"
+}
+```
+
+Assuming this user exists in the database and the password is correct, you will get a response as follows:
+
+```json
+{
+    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE2NDQ0ODc0MzAsImV4cCI6MTY0NDQ5MTAzMCwicm9sZXMiOlsiUk9MRV9VU0VSIl0sImVtYWlsIjoibWVAZXhhbXBsZS5jb20ifQ.ZHobfJ6Mq5RGbeLR2thnsXHq7B9-IkPuQ2gwQj3XViAHmmUt8tIIuWpsViZF0RldAmVZyzGzlG1vaqIjdaD2FDj9dD7z1CAXPkQ24iDjeOby-rOme2MewrtwIcgtbNXHRwzog679W8rWv6m89EVhayXWSwlCTqvltornh9lOBkUSmMnbhRf_cWIexCJutwvthB_OjzFoCFpDt4K0egMkAuQBLDyJSJaNDkDvIsil5R0F6I3XynUlxUgU1eCIjp4YaaaS2XKrKn4coqY5fO-B0pu0UvijzAE9O0pVbsLK2DbXQ5wljg264WrfQOFBvqHXlVpKwd4OWbZWesvXbpCl4Q"
+}
+```
+
+Take the value of the `token` - the JWT token - and paste it into [https://jwt.io/](https://jwt.io/). You should be able to see the decoded payload as follows:
+
+```json
+{
+  "iat": 1644487430,
+  "exp": 1644491030,
+  "roles": [
+    "ROLE_USER"
+  ],
+  "email": "me@example.com"
+}
+```
+
 ## Documenting the Authentication Mechanism with Swagger/Open API
 
 Want to test the routes of your JWT-authentication-protected API?


### PR DESCRIPTION
If the user identity field is not specified, then although a JWT token is successfully issued, any requests with it result in a `401 Invalid credentials`. Given that elsewhere on the JWT docs the user identity field is specified as `email`, we need to change the JWT bundle config from the default of `username` to `email`.

This PR also adds some helpful info for how to decode a JWT token for debugging.