### PR TITLE
docs: add note on using PUT method to upload files

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -42,6 +42,9 @@ resource (in our case: `Book`).
 This example will use a custom controller to receive the file.
 The second example will use a custom `multipart/form-data` decoder to deserialize the resource instead.
 
+**Note**: Uploading files won't work in `PUT` or `PATCH` requests, you must use `POST` method to upload files.
+See [this issue on Symfony](https://github.com/symfony/symfony/issues/36146) talking of this behaviour.
+
 ### Configuring the Resource Receiving the Uploaded File
 
 The `MediaObject` resource is implemented like this:

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -43,7 +43,7 @@ This example will use a custom controller to receive the file.
 The second example will use a custom `multipart/form-data` decoder to deserialize the resource instead.
 
 **Note**: Uploading files won't work in `PUT` or `PATCH` requests, you must use `POST` method to upload files.
-See [this issue on Symfony](https://github.com/symfony/symfony/issues/36146) talking of this behaviour.
+See [the related issue on Symfony](https://github.com/symfony/symfony/issues/9226) and [the related bug in PHP](https://bugs.php.net/bug.php?id=55815) talking about this behavior.
 
 ### Configuring the Resource Receiving the Uploaded File
 


### PR DESCRIPTION
I lost few hours on trying to figure why I had an empty filebag, using first or second file upload examples.

So I added a note.
