### PR TITLE
Bumped up xdebug version to support php 8.1

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -17,7 +17,7 @@ it's recommended to add a custom stage to the end of the `api/Dockerfile`.
 # api/Dockerfile
 FROM api_platform_php as api_platform_php_dev
 
-ARG XDEBUG_VERSION=3.0.2
+ARG XDEBUG_VERSION=3.1.3
 RUN set -eux; \
  apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
  pecl install xdebug-$XDEBUG_VERSION; \
@@ -94,6 +94,6 @@ $ docker-compose exec php \
     php --version
 
 PHP …
-    with Xdebug v3.0.2, Copyright (c) 2002-2021, by Derick Rethans
+    with Xdebug v3.1.3, Copyright (c) 2002-2021, by Derick Rethans
     …
 ```


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
