### PR TITLE
Add precision about behavior of get op. when identifier changes

### DIFF
--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -174,6 +174,8 @@ final class Person
 }
 ```
 
+Changing Identifier will automatically change the behaviour of [get operation](operations), instead of the resource `id` field, the get operation will try to retrieve resource by using the `code` field.
+
 ## Supported Identifiers
 
 API Platform supports the following identifier types:


### PR DESCRIPTION
Considering this code
```php
#[ApiProperty(identifier: false)]
public $id;

#[ApiProperty(identifier: true)]
public $code;
```

The get operation will now expect `code` value to retrieve the resource.