### PR TITLE
Update filters.md

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1215,10 +1215,12 @@ final class RegexpFilter extends AbstractContextAwareFilter
                 'property' => $property,
                 'type' => Type::BUILTIN_TYPE_STRING,
                 'required' => false,
-                'swagger' => [
-                    'description' => 'Filter using a regex. This will appear in the Swagger documentation!',
-                    'name' => 'Custom name to use in the Swagger documentation',
-                    'type' => 'Will appear below the name in the Swagger documentation',
+                'description' => 'Filter using a regex. This will appear in the OpenApi documentation!',
+                'openapi' => [
+                    'example' => 'Custom example that will be in the documentation and be the default value of the sandbox',
+                    'allowReserved' => false,// if true, query parameters will be not percent-encoded
+                    'allowEmptyValue' => true,
+                    'explode' => false, // to be true, the type must be Type::BUILTIN_TYPE_ARRAY, ?product=blue,green will be ?product=blue&product=green
                 ],
             ];
         }


### PR DESCRIPTION
The example of custom orm filter used swagger attribute in the description. Openapi replaced swagger in OpenApiFactory:getFiltersParameters

