### PR TITLE
Removed - unused command

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -76,7 +76,7 @@ services using [Docker Compose](https://docs.docker.com/compose/):
 Download and build the latest versions of the images:
 
 ```console
-docker-compose build --pull --no-cache
+docker-compose build --pull
 ```
 
 Start Docker Compose in detached mode:


### PR DESCRIPTION
docker-compose no longer uses the --no-cache command.