### PR TITLE
Documentation fix for subresource custom path.

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -178,7 +178,7 @@ may use `bin/console debug:router`.
 
 ## Using Custom Paths
 
-You can control the path of subresources with the `path` option of the `subresourceOperations` parameter:
+You can control the path of subresources with the `path` option of the `subresourceOperations` parameter. Notice that you don't have to use the prefix `api_questions_` because it's an operation name:
 
 ```php
 <?php
@@ -186,7 +186,7 @@ You can control the path of subresources with the `path` option of the `subresou
 
 #[ApiResource(
     subresourceOperations: [
-        'api_questions_answer_get_subresource' => [
+        'answer_get_subresource' => [
             'method' => 'GET',
             'path' => '/questions/{id}/all-answers',
         ],


### PR DESCRIPTION
I was having problems with adding custom path name for subresource operation. I've followed suggestions from [this comment](https://github.com/api-platform/api-platform/issues/1581#issuecomment-1098064070) and it worked fine, so I am proposing a change to the documentation.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
