### PR TITLE
Fix JWT authentication test file with static container

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -120,7 +120,7 @@ security:
     # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
         App\Entity\User: 'auto'
-    
+
     # https://symfony.com/doc/current/security/authenticator_manager.html
     enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
@@ -280,11 +280,11 @@ And register this service in `config/services.yaml`:
 ```yaml
 # api/config/services.yaml
 services:
-    # ...   
+    # ...
 
     App\OpenApi\JwtDecorator:
         decorates: 'api_platform.openapi.factory'
-        arguments: ['@.inner'] 
+        arguments: ['@.inner']
 ```
 
 ## Testing
@@ -308,14 +308,15 @@ class AuthenticationTest extends ApiTestCase
     public function testLogin(): void
     {
         $client = self::createClient();
+        $container = self::getContainer();
 
         $user = new User();
         $user->setEmail('test@example.com');
         $user->setPassword(
-            self::$container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')
+            $container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')
         );
 
-        $manager = self::$container->get('doctrine')->getManager();
+        $manager = $container->get('doctrine')->getManager();
         $manager->persist($user);
         $manager->flush();
 

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -352,7 +352,7 @@ Since now we have a `JWT` authentication, functional tests require us to log in 
 
 Hashers are used for 2 reasons:
 
-1. To generate a hash for a raw password (`self::$container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')`)
+1. To generate a hash for a raw password (`$container->get('security.user_password_hasher')->hashPassword($user, '$3CR3T')`)
 2. To verify a password during authentication
 
 While hashing and verifying 1 password is quite a fast operation, doing it hundreds or even thousands of times in a tests suite becomes a bottleneck, because reliable hashing algorithms are slow by their nature.


### PR DESCRIPTION
Fix an error thrown while launching the AuthenticationTest because of the use of `self::$container`. Assign it in a variable first fixes the issue.