### PR TITLE
fix: use the alias for the decorated state processor

### DIFF
--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -132,7 +132,7 @@ services:
     # ...
     App\State\UserProcessor:
         bind:
-            $decorated: '@api_platform.doctrine.orm.state_processor'
+            $decorated: '@api_platform.doctrine.orm.state.persist_processor'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\State\UserProcessor.inner']
         #tags: [ 'api_platform.state_processor' ]


### PR DESCRIPTION
Related to https://github.com/api-platform/core/pull/4859.

Supersedes https://github.com/api-platform/docs/pull/1583.