### PR TITLE
Update state-processor.md

### DIFF
--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -132,7 +132,7 @@ services:
     # ...
     App\State\UserProcessor:
         bind:
-            $decorated: '@api_platform.doctrine.orm.state.persist_processor'
+            $decorated: '@ApiPlatform\Doctrine\Common\State\PersistProcessor'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\State\UserProcessor.inner']
         #tags: [ 'api_platform.state_processor' ]


### PR DESCRIPTION
The service '@api_platform.doctrine.orm.state.persist_processor' no longer exists, but replacing it with "@ApiPlatform\Doctrine\Common\State\PersistProcessor" seems to be working in my local implementation

Maybe the service needs to be tagged and the documentation is correct