### PR TITLE
Use php 8 attributes for Vich\UploadableBundle

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -25,7 +25,7 @@ to make it look like this.
 vich_uploader:
     db_driver: orm
     metadata:
-        type: attribute ## Here we want to use the PHP 8.0 attributes
+        type: attribute
     mappings:
         media_object:
             uri_prefix: /media
@@ -108,7 +108,6 @@ class MediaObject
     #[Groups(['media_object:read'])]
     public ?string $contentUrl = null;
 
-    
     #[Vich\UploadableField(mapping: "media_object", fileNameProperty: "filePath")]
     #[Assert\NotNull(groups: ['media_object_create'])]
     public ?File $file = null;

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -24,7 +24,8 @@ to make it look like this.
 # api/config/packages/vich_uploader.yaml
 vich_uploader:
     db_driver: orm
-
+    metadata:
+        type: attribute ## Here we want to use the PHP 8.0 attributes
     mappings:
         media_object:
             uri_prefix: /media
@@ -66,9 +67,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
-/**
- * @Vich\Uploadable
- */
+#[Vich\Uploadable]
 #[ORM\Entity]
 #[ApiResource(
     normalizationContext: ['groups' => ['media_object:read']], 
@@ -109,9 +108,8 @@ class MediaObject
     #[Groups(['media_object:read'])]
     public ?string $contentUrl = null;
 
-    /**
-     * @Vich\UploadableField(mapping="media_object", fileNameProperty="filePath")
-     */
+    
+    #[Vich\UploadableField(mapping: "media_object", fileNameProperty: "filePath")]
     #[Assert\NotNull(groups: ['media_object_create'])]
     public ?File $file = null;
 


### PR DESCRIPTION
The whole documentation for the version 2.7 is using the PHP attributes, so I feel, as Vich\UploadableBundle now supports them, we can use them for this bundle

