### PR TITLE
fix(jwt): fix error on jwt decorator

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -249,7 +249,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
         ]);
 
         $schemas = $openApi->getComponents()->getSecuritySchemes() ?? [];
-        $schemas['JWT'] = new ArrayObject([
+        $schemas['JWT'] = new \ArrayObject([
             'type' => 'http',
             'scheme' => 'bearer',
             'bearerFormat' => 'JWT',


### PR DESCRIPTION
Add missing `\` to new ArrayObject()

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
