### PR TITLE
Fix CurrentUserExtension example

### DIFF
--- a/core/extensions.md
+++ b/core/extensions.md
@@ -73,12 +73,12 @@ final class CurrentUserExtension implements QueryCollectionExtensionInterface, Q
         $this->security = $security;
     }
 
-    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $operationName = null): void
+    public function applyToCollection(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, Operation $operation = null, array $context = []): void;
     {
         $this->addWhere($queryBuilder, $resourceClass);
     }
 
-    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, string $operationName = null, array $context = []): void
+    public function applyToItem(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, array $identifiers, Operation $operation = null, array $context = []): void
     {
         $this->addWhere($queryBuilder, $resourceClass);
     }

--- a/core/extensions.md
+++ b/core/extensions.md
@@ -60,6 +60,7 @@ namespace App\Doctrine;
 use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
 use App\Entity\Offer;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Security\Core\Security;


### PR DESCRIPTION
In the example, the methods `applyToCollection` and `applyToItem` implements incorrectly their definitions :

* [QueryCollectionExtensionInterface](https://github.com/api-platform/core/blob/3.0/src/Doctrine/Orm/Extension/QueryCollectionExtensionInterface.php)
* [QueryItemExtensionInterface](https://github.com/api-platform/core/blob/3.0/src/Doctrine/Orm/Extension/QueryItemExtensionInterface.php)

The problem may also exists on v2.7 documentation

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
