### PR TITLE
Update yaml operations

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -486,19 +486,23 @@ class User
 # api/config/api_platform/resources.yaml
 resources:
     App\Entity\Book:
-        - operations:
-            ApiPlatform\Metadata\GetCollection: ~
-            ApiPlatform\Metadata\Get: ~
-        - operations:
-            ApiPlatform\Metadata\GetCollection:
+        operations:
+            - ApiPlatform\Metadata\GetCollection:
+                class: ApiPlatform\Metadata\GetCollection
+            - ApiPlatform\Metadata\Get:
+                class: ApiPlatform\Metadata\Get
+            - ApiPlatform\Metadata\GetCollection:
+                class: ApiPlatform\Metadata\GetCollection
                 uriTemplate: /companies/{companyId}/users
                 itemUriTemplate: /companies/{companyId}/users/{id}
                 # ...
-            ApiPlatform\Metadata\Post:
+            - ApiPlatform\Metadata\Post:
+                class: ApiPlatform\Metadata\Post
                 uriTemplate: /companies/{companyId}/users
                 itemUriTemplate: /companies/{companyId}/users/{id}
                 # ...
-            ApiPlatform\Metadata\Get:
+            - ApiPlatform\Metadata\Get:
+                class: ApiPlatform\Metadata\Get
                 uriTemplate: /companies/{companyId}/users/{id}
                 # ...
 ```


### PR DESCRIPTION
Hello team, I need to create the same operation with different uriTemplate for the same resource.

In the doc I see:

```
#[GetCollection] // auto-generated path will be /users
#[Get] // auto-generated path will be /users/{id}
#[GetCollection(uriTemplate: '/companies/{companyId}/users', itemUriTemplate: '/companies/{companyId}/users/{id}'/*, ... */)]
#[Post(uriTemplate: '/companies/{companyId}/users', itemUriTemplate: '/companies/{companyId}/users/{id}'/*, ... */)]
#[Get(uriTemplate: '/companies/{companyId}/users/{id}'/*, ... */)]
class User
{
    //...
}
```

But I use yaml and the doc show:
```

resources:
    App\Entity\Book:
        - operations:
            ApiPlatform\Metadata\GetCollection: ~
            ApiPlatform\Metadata\Get: ~
        - operations:
            ApiPlatform\Metadata\GetCollection:
                uriTemplate: /companies/{companyId}/users
                itemUriTemplate: /companies/{companyId}/users/{id}
                # ...
            ApiPlatform\Metadata\Post:
                uriTemplate: /companies/{companyId}/users
                itemUriTemplate: /companies/{companyId}/users/{id}
                # ...
            ApiPlatform\Metadata\Get:
                uriTemplate: /companies/{companyId}/users/{id}
```

I try it but I have the error:

ApiPlatform\Core\Metadata\Property\Factory\CachedPropertyMetadataFactory::create(): Argument #2 ($property) must be of type string, int given, called in /var/www/html/vendor/api-platform/core/src/Core/Operation/Factory/SubresourceOperationFactory.php on line 79

I finally succeeded with the code that I propose

Thanks