### PR TITLE
Fix doc: add Operation in processor and provider

### DIFF
--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -37,6 +37,7 @@ Here is an implementation example:
 namespace App\State;
 
 use App\Entity\BlogPost;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 
 class BlogPostProcessor implements ProcessorInterface

--- a/core/state-providers.md
+++ b/core/state-providers.md
@@ -37,6 +37,7 @@ First, your `BlogPostProvider` has to implement the
 namespace App\State;
 
 use App\Entity\BlogPost;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 
 final class BlogPostProvider implements ProviderInterface
@@ -90,6 +91,7 @@ supporting a wider range of operations. Then we can provide a collection of blog
 namespace App\State;
 
 use App\Entity\BlogPost;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 


### PR DESCRIPTION
Missing import addition in example code in Provider and Processor

For exemple :

![image](https://user-images.githubusercontent.com/12426580/191551906-470e15c5-aa8d-4649-84f3-831cf6db0a2c.png)

additional with https://github.com/api-platform/docs/pull/1610
