### PR TITLE
Fix registering the Swagger UI controller

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -509,7 +509,7 @@ Manually register the Swagger UI controller:
 # app/config/routes.yaml
 api_doc:
     path: /api_documentation
-    controller: api_platform.swagger.action.ui
+    controller: api_platform.swagger_ui.action
 ```
 
 Change `/api_documentation` to the URI you wish Swagger UI to be accessible on.


### PR DESCRIPTION
The controller for registering the Swagger UI controller was the deprecated one.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
