### PR TITLE
Update state-processors.md

### DIFF
--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -132,7 +132,7 @@ services:
     # ...
     App\State\UserProcessor:
         bind:
-            $decorated: '@api_platform.doctrine.orm.state.persist_processor'
+            $decorated: '@ApiPlatform\Doctrine\Common\State\PersistProcessor'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\State\UserProcessor.inner']
         #tags: [ 'api_platform.state_processor' ]


### PR DESCRIPTION
I got error using @api_platform.doctrine.orm.state.persist_processor because it doesn't exist

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
