### PR TITLE
docs(create-client): Forward options to create-client script

### DIFF
--- a/create-client/custom.md
+++ b/create-client/custom.md
@@ -7,7 +7,7 @@ You will probably want to extend or, at least, take a look at [BaseGenerator.js]
 ## Usage
 
 ```shell
-npm init @api-platform/client -g "$(pwd)/path/to/custom/generator.js" -t "$(pwd)/path/to/templates"
+npm init @api-platform/client -- --generator "$(pwd)/path/to/custom/generator.js" -t "$(pwd)/path/to/templates"
 ```
 
 The `-g` argument can point to any resolvable node module which means it can be a package dependency of the current project as well as any js file.

--- a/create-client/nextjs.md
+++ b/create-client/nextjs.md
@@ -41,7 +41,7 @@ If you use the API Platform distribution, generating all the code you need for a
 
 ```console
 docker compose exec pwa \
-    pnpm create @api-platform/client --resource book -g next
+    pnpm create @api-platform/client -- --resource book -g next
 ```
 
 Omit the resource flag to generate files for all resource types exposed by the API.
@@ -50,11 +50,11 @@ If you don't use the standalone installation, run the following command instead:
 
 ```console
 # using pnpm
-pnpm create @api-platform/client https://demo.api-platform.com . --generator next --resource book
+pnpm create @api-platform/client https://demo.api-platform.com . -- --generator next --resource book
 # or using npm
-npm init @api-platform/client https://demo.api-platform.com . --generator next --resource book
+npm init @api-platform/client https://demo.api-platform.com . -- --generator next --resource book
 # or using yarn
-yarn create @api-platform/client https://demo.api-platform.com . --generator next --resource book
+yarn create @api-platform/client https://demo.api-platform.com . -- --generator next --resource book
 ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.

--- a/create-client/nuxtjs.md
+++ b/create-client/nuxtjs.md
@@ -54,7 +54,7 @@ Update your `nuxt.config.js` with following:
 ## Generating Routes
 
 ```console
-npm init @api-platform/client https://demo.api-platform.com . --generator nuxt
+npm init @api-platform/client https://demo.api-platform.com . -- --generator nuxt
 ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.

--- a/create-client/quasar.md
+++ b/create-client/quasar.md
@@ -11,7 +11,7 @@ cd my-app
 In the app directory, generate the files for the resource you want:
 
 ```console
-npm init @api-platform/client https://demo.api-platform.com src/ --generator quasar --resource foo
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator quasar --resource foo
 ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.

--- a/create-client/react-native.md
+++ b/create-client/react-native.md
@@ -30,7 +30,7 @@ npm install redux react-redux redux-thunk redux-form react-native-elements react
 In the app directory, generate the files for the resource you want:
 
 ```console
-npm init @api-platform/client https://demo.api-platform.com . --generator react-native --resource book
+npm init @api-platform/client https://demo.api-platform.com . -- --generator react-native --resource book
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.

--- a/create-client/react.md
+++ b/create-client/react.md
@@ -41,7 +41,7 @@ npm run start
 ## Generating a Web App
 
 ```console
-npm init @api-platform/client https://demo.api-platform.com src/ --generator next --resource book
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator next --resource book
 ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.

--- a/create-client/typescript.md
+++ b/create-client/typescript.md
@@ -6,7 +6,7 @@ that you can embed in any TypeScript-enabled project (React, Vue.js, Angular..).
 To do so, run the generator:
 
 ```console
-npm init @api-platform/client --generator typescript https://demo.api-platform.com src/ --resource foo
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator typescript --resource foo
 # Replace the URL with the entrypoint of your Hydra-enabled API.
 ```
 
@@ -24,7 +24,7 @@ This command parses the Hydra documentation and creates one `.ts` file for each 
 Assuming you have 2 resources in your application, `Foo` and `Bar`, when you run:
 
 ```console
-npm init @api-platform/client --generator typescript https://demo.api-platform.com src/
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator typescript
 ```
 
 You will obtain 2 `.ts` files arranged as following:

--- a/create-client/vuejs.md
+++ b/create-client/vuejs.md
@@ -22,7 +22,7 @@ npm install add bootstrap font-awesome
 To generate all the code you need for a given resource run the following command:
 
 ```console
-npm init @api-platform/client https://demo.api-platform.com src/ --generator vue --resource book
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator vue --resource book
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.

--- a/create-client/vuetify.md
+++ b/create-client/vuetify.md
@@ -48,7 +48,7 @@ Generate the vuetify components with the following command:
 
 ```console
 docker compose exec pwa \
-    pnpm create @api-platform/client -g vuetify --resource book
+    pnpm create @api-platform/client -- --generator vuetify --resource book
 ```
 
 Omit the resource flag to generate files for all resource types exposed by the API.
@@ -75,7 +75,7 @@ npm install router lodash moment vue-i18n vue-router vuelidate vuex vuex-map-fie
 In the app directory, generate the files for the resource you want:
 
 ```console
-npm init @api-platform/client -g vuetify https://demo.api-platform.com src/
+npm init @api-platform/client https://demo.api-platform.com src/ -- --generator vuetify
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.


### PR DESCRIPTION
Options (like `--generator`) were not pass to @api-platform/client script but to npm init script. We have to use `--` before options to forward it to @api-platform/client script