### PR TITLE
Document the new release process announced at API Platform Conference

### DIFF
--- a/extra/releases.md
+++ b/extra/releases.md
@@ -1,6 +1,19 @@
 # The Release Process
 
 API Platform follows the [Semantic Versioning](https://semver.org) strategy.
+A new minor version is released every six months, and a new major version is released every two years, along with a last minor version on the previous major one with the same features and an upgrade path.
+
+For example:
+
+- version 3.0 has been released on 15 September, 2022;
+- version 3.1 will be released on March, 2023;
+- version 3.2 will be released on September, 2023;
+- version 3.3 will be released on March, 2024;
+- versions 3.4 and 4.0 will be released on September, 2024.
+
+<!-- TODO: add a graph similar to https://symfony.com/releases#symfony-releases-calendar here? -->
+
+## Maintenance
 
 Only 3 versions are maintained at the same time:
 

--- a/extra/releases.md
+++ b/extra/releases.md
@@ -11,8 +11,6 @@ For example:
 - version 3.3 will be released on March, 2024;
 - versions 3.4 and 4.0 will be released on September, 2024.
 
-<!-- TODO: add a graph similar to https://symfony.com/releases#symfony-releases-calendar here? -->
-
 ## Maintenance
 
 Only 3 versions are maintained at the same time:


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->

On 15 Sept., 2022, a new release process has been announced starting from API Platform 3.0.
This PR provides some adjustments to the documentation to reflect those changes.

~~Remains to do: maybe a graph similar to the one we can see on [Symfony release page](https://symfony.com/releases#symfony-releases-calendar) to give a clear view of the process?~~