### PR TITLE
Fix documentation for using a service to generate validation groups

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -288,7 +288,7 @@ use ApiPlatform\Metadata\ApiResource;
 use App\Validator\AdminGroupsGenerator;
 use Symfony\Component\Validator\Constraints as Assert;
 
-#[ApiResource(validationContext: ['groups' => [AdminGroupsGenerator::class]])
+#[ApiResource(validationContext: ['groups' => AdminGroupsGenerator::class])
 class Book
 {
     #[Assert\NotBlank(groups: ['a'])] 


### PR DESCRIPTION
The documentation says the following annotation should be used if you want to dynamically set validation groups using a service:

```php
#[ApiResource(validationContext: ['groups' => [AdminGroupsGenerator::class]])
```

However, this does not work. The API Platform validator only tries to fetch a service when a string is passed as `groups`:

```
if (
    $this->container &&
    \is_string($validationGroups) &&
    $this->container->has($validationGroups) &&
    ($service = $this->container->get($validationGroups)) &&
    \is_callable($service)
) {
```
