### PR TITLE
docs(testing): removing unused variable

### DIFF
--- a/core/testing.md
+++ b/core/testing.md
@@ -56,8 +56,7 @@ use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 
 abstract class AbstractTest extends ApiTestCase
 {
-    private $token;
-    private $clientWithCredentials;
+    private ?string $token = null;
 
     use RefreshDatabaseTrait;
 


### PR DESCRIPTION
Remove $clientWithCredentials unused variable from AbstractTest class and adding type for $token variable.