### PR TITLE
fix(controllers): replace "path" by "uriTemplate" attribute

### DIFF
--- a/core/controllers.md
+++ b/core/controllers.md
@@ -148,7 +148,7 @@ App\Entity\Book:
 
 [/codeSelector]
 
-It is mandatory to set the `method`, `path` and `controller` attributes. They allow API Platform to configure the routing path and
+It is mandatory to set the `method`, `uriTemplate` and `controller` attributes. They allow API Platform to configure the routing path and
 the associated controller respectively.
 
 ## Using Serialization Groups


### PR DESCRIPTION
The documentation related to the version 3.0 and 3.1 describing the custom operation configuration example contains a version 2.6 mandatory attribute ("path" instead of "uriTemplate").