### PR TITLE
Update index.md

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -393,7 +393,7 @@ Modify these files as described in these patches:
      public string $author = '';
  
      /** The publication date of this book. */
-+    #[ORM\Column(type: 'datetime')]
++    #[ORM\Column]
      public ?\DateTimeImmutable $publicationDate = null;
  
      /** @var Review[] Available reviews for this book. */
@@ -433,7 +433,7 @@ Modify these files as described in these patches:
      public string $author = '';
  
      /** The date of publication of this review.*/
-+    #[ORM\Column(type: 'datetime')]
++    #[ORM\Column]
      public ?\DateTimeImmutable $publicationDate = null;
  
      /** The book this review is about. */


### PR DESCRIPTION
Specifying type:'datetime' for $publicationDate causes a denormalization failure. Removing it or replacing it with 'datetime_immutable' fixes the issue.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
