### PR TITLE
fix property name for displaying related resource name instead of iri

### DIFF
--- a/admin/schema.org.md
+++ b/admin/schema.org.md
@@ -18,7 +18,7 @@ To configure which property should be shown to represent your entity, map the pr
 // api/src/Entity/Person.php
 ...
 
-#[ApiProperty(types: ["https://schema.org/name"])]
+#[ApiProperty(iris: ["https://schema.org/name"])]
 private $name;
 
 ...


### PR DESCRIPTION
It seems that this does not work with new metadata system:
```
#[ApiProperty(types: ["https://schema.org/name"])]
private $name;
```
but this one works:
```
#[ApiProperty(iris: ["https://schema.org/name"])]
private $name;
```
https://api-platform.com/docs/admin/schema.org/#displaying-related-resources-name-instead-of-its-iri