### PR TITLE
Annotation instead of Attribute

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1427,7 +1427,7 @@ Start by creating a custom attribute to mark restricted entities:
 
 ```php
 <?php
-// api/Attribute/UserAware.php
+// api/src/Attribute/UserAware.php
 
 namespace App\Attribute;
 

--- a/core/filters.md
+++ b/core/filters.md
@@ -1427,7 +1427,7 @@ Start by creating a custom attribute to mark restricted entities:
 
 ```php
 <?php
-// api/Annotation/UserAware.php
+// api/Attribute/UserAware.php
 
 namespace App\Attribute;
 


### PR DESCRIPTION
Small typo in comment. 
"Annotation" namespace used instead of "Attribute"
