### PR TITLE
Document requirements for resources that are only acessible as a subresource

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -296,3 +296,9 @@ class Company {
     // ...
 }
 ```
+
+### Subresource only resource
+
+If a resource only has subresource definitions (no routes without `uriVariables`) it's not accessible directly by just it's own identifier.
+
+Note that [bidirectional associations](https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/association-mapping.html) between the subresource and any resources that are used as `Link` in the `uriVariables` are required for IRI generation to work in this case. In other words: The subresource needs to have direct access to any identifiers in the `uriTemplate`.


### PR DESCRIPTION
I recently ran into a limitation when referencing a resource that is only accessible as a subresource (api-platform/core#5108).
This PR adds a section about the requirements when using subresources in this way.


### Todos
- [ ] \(Optional) Add example code if desired.
