### PR TITLE
Typo: Removed quotes around XxxException:class constants

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -125,9 +125,9 @@ use App\Exception\ProductWasRemovedException;
 use App\Exception\ProductNotFoundException;
 
 #[ApiResource(
-    exceptionToStatus: ['ProductNotFoundException::class' => 404]
+    exceptionToStatus: [ProductNotFoundException::class => 404]
     operations: [
-        new Get(exceptionToStatus: ['ProductWasRemovedException::class' => 410]),
+        new Get(exceptionToStatus: [ProductWasRemovedException::class => 410]),
         new GetCollection(),
         new Post()
     ]


### PR DESCRIPTION
For some reason quotes were applied around `ProductNotFoundException::class` and `ProductWasRemovedException::class` in the docs.