### PR TITLE
Update link to Json Hal in content negotiation documentation

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -23,7 +23,7 @@ Format                                                          | Format name  |
 [JSON-LD](https://json-ld.org)                                  | `jsonld`     | `application/ld+json`         | yes
 [GraphQL](graphql.md)                                           | n/a          | n/a                           | yes
 [JSON:API](http://jsonapi.org/)                                 | `jsonapi`    | `application/vnd.api+json`    | yes
-[HAL](http://stateless.co/hal_specification.html)               | `jsonhal`    | `application/hal+json`        | yes
+[HAL](https://stateless.group/hal_specification.html)           | `jsonhal`    | `application/hal+json`        | yes
 [YAML](http://yaml.org/)                                        | `yaml`       | `application/x-yaml`          | no
 [CSV](https://tools.ietf.org/html/rfc4180)                      | `csv`        | `text/csv`                    | no
 [HTML](https://whatwg.org/) (API docs)                          | `html`       | `text/html`                   | no


### PR DESCRIPTION
The link to the Json HAL specifications in the content negotiation documentation page returns a 404. 

Change the link to the new URI. 
I cannot verify that stateless.co has moved to stateless.group because there is no redirection in place, but my assumption is that this is the new house for that documentation source. 
