### PR TITLE
Update container directory for volume mount

### DIFF
--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -54,9 +54,9 @@ Add a MongoDB image to the docker-compose file:
           # You should definitely change the password in production
           - MONGO_INITDB_ROOT_PASSWORD=!ChangeMe!
       volumes:
-          - db-data:/var/lib/mongodb/data:rw
+          - db-data:/data/db:rw
           # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-          # - ./docker/db/data:/var/lib/mongodb/data:rw
+          # - ./docker/db/data:/data/db:rw
       ports:
           - "27017:27017"
 # ...


### PR DESCRIPTION
The [documentation](https://hub.docker.com/_/mongo) of the MongoDB docker image points out that the DB is stored at `/data/db`, described in the **Caveats** section under **Where to Store Data**.
> The -v /my/own/datadir:/data/db part of the command mounts the `/my/own/datadir` directory from the underlying host system as `/data/db` inside the container, where MongoDB by default will write its data files.
