### PR TITLE
Replace "informations" with "information"

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -98,7 +98,7 @@ class Question
 [/codeSelector]
 
 Now to create a new way of retrieving an Answer we will declare another resource on the `Answer` class.
-To make things work, API Platform needs informations about how to retrieve the `Answer` belonging to
+To make things work, API Platform needs information about how to retrieve the `Answer` belonging to
 the `Question`, this is done by configuring the `uriVariables`:
 
 [codeSelector]

--- a/distribution/testing.md
+++ b/distribution/testing.md
@@ -262,7 +262,7 @@ You may also be interested in these alternative testing tools (not included in t
 
 * [Foundry](https://github.com/zenstruck/foundry), a modern fixtures library that will replace Alice as the recommended fixtures library soon;
 * [Hoppscotch](https://docs.hoppscotch.io/features/tests), create functional test for your API
-  Platform project using a nice UI, benefit from its Swagger integration and run tests in the CI using [the CLI tool](https://docs.hoppscotch.io/cli);
+  Platform project using a nice UI, benefit from its Swagger integration and run tests in the CI using [the command-line tool](https://docs.hoppscotch.io/cli);
 * [Behat](http://behat.org), a
   [behavior-driven development (BDD)](https://en.wikipedia.org/wiki/Behavior-driven_development) framework to write the API
   specification as user stories and in natural language then execute these scenarios against the application to validate


### PR DESCRIPTION
In this context, "information" should not be pluralised.

Some nouns do not have a plural form. "Information" is one of them. Information is a [mass noun](https://en.wikipedia.org/wiki/Mass_noun). It has no plural form.

Additionally, CI flagged that "CLI" should be replaced with "command-line". This is resolved too.