### PR TITLE
plainPassoword validator needs validationContext

### DIFF
--- a/core/user.md
+++ b/core/user.md
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new GetCollection(),
-        new Post(processor: UserPasswordHasher::class),
+        new Post(processor: UserPasswordHasher::class, validationContext: ['groups' => ['user:create']]),
         new Get(),
         new Put(processor: UserPasswordHasher::class),
         new Patch(processor: UserPasswordHasher::class),


### PR DESCRIPTION
```
class User
(...)
    #[Assert\NotBlank(groups: ['user:create'])]
    #[Groups(['user:create', 'user:update'])]
    private ?string $plainPassword = null;

```

Per group  validator needs proper validationContext set to make it work.