### PR TITLE
Fix Typo in API-Platform Command

### DIFF
--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -105,7 +105,7 @@ Using [the API Platform Distribution](../distribution/index.md):
 
 ```console
 docker compose exec php \
-    vendor/bin/schema generate src/ config/schema.yaml -vv
+    vendor/bin/schema generate src/config/schema.yaml -vv
 ```
 
 The corresponding PHP classes will be automatically generated in the `src/` directory!


### PR DESCRIPTION
Now the command will properly work when copy/pasting.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
