### PR TITLE
include default validation group

### DIFF
--- a/core/user.md
+++ b/core/user.md
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new GetCollection(),
-        new Post(processor: UserPasswordHasher::class, validationContext: ['groups' => ['user:create']]),
+        new Post(processor: UserPasswordHasher::class, validationContext: ['groups' => ['Default', 'user:create']]),
         new Get(),
         new Put(processor: UserPasswordHasher::class),
         new Patch(processor: UserPasswordHasher::class),


### PR DESCRIPTION
I realized after time that default validation group must be given explicitly when validationContext is used, so this add-on (#1712) PR for completeness.