### PR TITLE
docs: add doctrine odm state processor

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -73,6 +73,9 @@ security:
             entity:
                 class: App\Entity\User
                 property: email
+            # mongodb:
+            #    class: App\Document\User
+            #    property: email    
 
     firewalls:
         dev:

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -73,7 +73,7 @@ security:
             entity:
                 class: App\Entity\User
                 property: email
-            # mongodb:
+            # document:
             #    class: App\Document\User
             #    property: email    
 

--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -135,9 +135,9 @@ services:
         bind:
             $persistProcessor: '@api_platform.doctrine.orm.state.persist_processor'
             $removeProcessor: '@api_platform.doctrine.orm.state.remove_processor'
-            # If you're using Doctrine ODM, you can use the following code:
-            #$persistProcessor: '@api_platform.doctrine_mongodb.odm.state.persist_processor'
-            #$removeProcessor: '@api_platform.doctrine_mongodb.odm.state.remove_processor'
+            # If you're using Doctrine MongoDB ODM, you can use the following code:
+            # $persistProcessor: '@api_platform.doctrine_mongodb.odm.state.persist_processor'
+            # $removeProcessor: '@api_platform.doctrine_mongodb.odm.state.remove_processor'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\State\UserProcessor.inner']
         #tags: [ 'api_platform.state_processor' ]

--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -135,6 +135,9 @@ services:
         bind:
             $persistProcessor: '@api_platform.doctrine.orm.state.persist_processor'
             $removeProcessor: '@api_platform.doctrine.orm.state.remove_processor'
+            # If you're using Doctrine ODM, you can use the following code:
+            #$persistProcessor: '@api_platform.doctrine_mongodb.odm.state.persist_processor'
+            #$removeProcessor: '@api_platform.doctrine_mongodb.odm.state.remove_processor'
         # Uncomment only if autoconfiguration is disabled
         #arguments: ['@App\State\UserProcessor.inner']
         #tags: [ 'api_platform.state_processor' ]


### PR DESCRIPTION
This is definitely missing in a documentation on how to use state processor with mongodb