### PR TITLE
Adding a link to the React Admin Symfonycasts video

### DIFF
--- a/admin/index.md
+++ b/admin/index.md
@@ -17,6 +17,8 @@ library to expose a nice, responsive, management interface (Create-Retrieve-Upda
 
 You can **customize everything** by using provided React Admin and [MUI](https://mui.com/) components, or by writing your custom [React](https://reactjs.org/) components.
 
+<p align="center" class="symfonycasts"><a href="https://symfonycasts.com/screencast/api-platform/react-admin?cid=apip"><img src="../distribution/images/symfonycasts-player.png" alt="React Admin Screencast"><br>Watch the React Admin screencast</a></p>
+
 ## Features
 
 * Automatically generates an admin interface for all the resources of the API thanks to the hypermedia features of Hydra or to the OpenAPI documentation


### PR DESCRIPTION
Hi!

An updated API Platform tutorial is now on Symfonycasts for API Platform 3 - https://symfonycasts.com/screencast/api-platform

All the existing links in the docs that pointed to the old version of this tutorial work just fine: the new screencast uses the same URLs. We did add one new video showing how to bootstrap the React Admin, which might merit a link :).

When Ep2 is finished, I'll do the same audit - that has at least one new topic (state processors) that we can add a link to.

Thanks!