### PR TITLE
Docs: Fix small typos in Getting started documentation page

### DIFF
--- a/distribution/index.md
+++ b/distribution/index.md
@@ -189,7 +189,7 @@ symfony serve
 All JavaScript components are also [available as standalone libraries](https://github.com/api-platform?language=javascript)
 installable with npm (or any other package manager).  
 
-**Note:** when installing API Platform this way, the API will be exposed as the `/api/` path. You need to open `http://localhost:8000/api/` to see the API documentation.
+**Note:** when installing API Platform this way, the API will be exposed at the `/api/` path. You need to open `http://localhost:8000/api/` to see the API documentation.
 If you are deploying API Platform directly on an Apache or NGINX webserver and getting a 404 error on opening this link, you will need to enable the [rewriting rules](https://symfony.com/doc/current/setup/web_server_configuration.html) for your specific webserver software.
 
 ## It's Ready
@@ -329,11 +329,11 @@ Reload `https://localhost/docs/`: API Platform used these classes to generate an
 
 Operations available for our 2 resource types appear in the UI. We can also see the awesome [Web Debug Toolbar](https://symfonycasts.com/screencast/symfony/profiler?cid=apip).
 
-Note that entities' and properties' descriptions in the API documentation, and that API Platform use PHP types to generate the appropriate JSON Schemas.
+Note that the entities' and properties' descriptions are present in the API documentation, and that API Platform uses PHP types to generate the appropriate JSON Schemas.
 
 ![Bookshop JSON Schemas](images/api-platform-2.6-bookshop-json-schemas.png)
 
-The framework also use these metadata to serialize and deserialize data from JSON (and other formats) to PHP objects (back and forth)!
+The framework also uses these metadata to serialize and deserialize data from JSON (and other formats) to PHP objects (back and forth)!
 
 For the sake of simplicity, in this example we used public properties (except for the ID, see below). API Platform (as well
 as Symfony and Doctrine) also supports accessor methods (getters/setters), use them if you want to.


### PR DESCRIPTION
I  didn't went through the whole page, but I spotted some tiny typos here and there :)
Thanks for your work :pray: 