### PR TITLE
Specify a minimym of 2Go RAM server

### DIFF
--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -19,7 +19,7 @@ Otherwise, use [this affiliate link](https://m.do.co/c/5d8aabe3ab80) to get $100
 Then, click on the "Marketplace" tab under the "Choose an image" section and search for the app named "Docker".
 This will provision an Ubuntu server with the latest versions of Docker and Docker Compose already installed!
 
-For test purposes, cheapest plans will be enough, even though you might want at least 2Go of RAM to execute docker compose for the first time. For real production usage, you'll probably want to pick a plan in the "general purpose" section that will fit your needs. 
+For test purposes, cheapest plans will be enough, even though you might want at least 2GB of RAM to execute Docker Compose for the first time. For real production usage, you'll probably want to pick a plan in the "general purpose" section that will fit your needs.
 
 ![Deploying a Symfony app on DigitalOcean with Docker Compose](digitalocean-droplet.png)
 

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -19,7 +19,7 @@ Otherwise, use [this affiliate link](https://m.do.co/c/5d8aabe3ab80) to get $100
 Then, click on the "Marketplace" tab under the "Choose an image" section and search for the app named "Docker".
 This will provision an Ubuntu server with the latest versions of Docker and Docker Compose already installed!
 
-For test purposes, the cheapest plan will be enough. For real production usage, you'll probably want to pick a plan in the "general purpose" section that will fit your needs.
+For test purposes, cheapest plans will be enough, even though you might want at least 2Go of RAM to execute docker compose for the first time. For real production usage, you'll probably want to pick a plan in the "general purpose" section that will fit your needs. 
 
 ![Deploying a Symfony app on DigitalOcean with Docker Compose](digitalocean-droplet.png)
 


### PR DESCRIPTION
Hello,

Tried for a good amount of time to run the docker compose command proposed within the tutorial off a droplet but to no avail.  Upgrading to 2Go of RAM instead of the cheapest 1Go, did the trick.

Thought it was worth mentioning in the doc.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
