### PR TITLE
Fixed swagger_definition_name to openapi_definition_name

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -316,14 +316,14 @@ Note: as your route is not exposed, you may want to return a HTTP 404 if it's ca
 
 API Platform generates a definition name based on the serializer `groups` defined
 in the (`de`)`normalizationContext`. It's possible to override the name
-thanks to the `swagger_definition_name` option:
+thanks to the `openapi_definition_name` option:
 
 ```php
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Post;
 
 #[ApiResource]
-#[Post(denormalizationContext: ['groups' => ['user:read'], 'swagger_definition_name' => 'Read'])]
+#[Post(denormalizationContext: ['groups' => ['user:read'], 'openapi_definition_name' => 'Read'])]
 class User
 {
     // ...
@@ -342,7 +342,7 @@ class User
 {
     const API_WRITE = [
         'groups' => ['user:read'],
-        'swagger_definition_name' => 'Read',
+        'openapi_definition_name' => 'Read',
     ];
 }
 ```


### PR DESCRIPTION
When changing the name of a definition the newer `openapi_definition_name` key should be used, as `swagger_definition_name` does not seem to work when using api-platform/core 3.*
