### PR TITLE
docs: remove obsolete warning in controllers.md

### DIFF
--- a/core/controllers.md
+++ b/core/controllers.md
@@ -71,7 +71,6 @@ The entity is retrieved in the `__invoke` method thanks to a dedicated argument 
 
 When using `GET`, the `__invoke()` method parameter will receive the identifier and should be called the same as the resource identifier.
 So for the path `/user/{uuid}/bookmarks`, you must use `__invoke(string $uuid)`.
-**Warning: the `__invoke()` method parameter [MUST be called `$data`](https://symfony.com/doc/current/components/http_kernel.html#4-getting-the-controller-arguments)**, otherwise, it will not be filled correctly!
 
 Services (`$bookPublishingHandler` here) are automatically injected thanks to the autowiring feature. You can type-hint any service
 you need and it will be autowired too.


### PR DESCRIPTION
Since version [**2.7.0-alpha.1**](https://github.com/api-platform/core/blob/main/CHANGELOG.md#270-alpha1) (PR #3263), the __invoke() method parameter does not have to be named `$data` anymore. Code sample has been updated (`Book $data` => `Book $book`), but the warning has been forgotten and could be confusing.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
