### PR TITLE
Fix: Update identifiers.md

### DIFF
--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -108,7 +108,7 @@ final class UuidUriVariableTransformer implements UriVariableTransformerInterfac
      */
      public function transform($value, array $types, array $context = []) {
         try {
-            return Uuid::fromString($data);
+            return Uuid::fromString($value);
         } catch (InvalidUuidStringException $e) {
             throw new InvalidUriVariableException($e->getMessage());
         }
@@ -123,7 +123,13 @@ final class UuidUriVariableTransformer implements UriVariableTransformerInterfac
      */
     public function supportsTransformation($value, array $types, array $context = []): bool
     {
-        return is_a($type, Uuid::class, true);
+        foreach ($types as $type) {
+            if (is_a($type, Uuid::class, true)) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 }
 ```


### PR DESCRIPTION
The example code for supportsTransformation expected `$types` (or `$type`) to be a scalaric value and not an array. This PR updates it to work with arrays.

See https://3v4l.org/Tn37N for "working" example code

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
