### PR TITLE
Add information on how to get a user in a provider

### DIFF
--- a/core/state-providers.md
+++ b/core/state-providers.md
@@ -125,6 +125,40 @@ use App\State\BlogPostProvider;
 class BlogPost {}
 ```
 
+## Getting the user in a provider
+
+Receiving a user in your provider to allow for filtering of entities can be achieved by adding the `Security` class in your constructor;
+
+```php
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Repository\BlogPostRepository;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class BlogPostProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly BlogPostRepository $blogPostRepository,
+        private readonly Security $security
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof CollectionOperationInterface) {
+            return $this->blogPostRepository->findAllForUser($this->security->getToken()->getUser());
+        }
+
+        return $this->blogPostRepository->find($uriVariables['id']);
+    }
+}
+```
+
 ## Hooking into the Built-In State Provider
 
 If you want to execute custom business logic before or after retrieving data, this can be achieved by [decorating](https://symfony.com/doc/current/service_container/service_decoration.html) the built-in state providers or using [composition](https://en.wikipedia.org/wiki/Object_composition).


### PR DESCRIPTION
As this is the most basic usecases for using a provider ever (showing entities that only relate to the current user), adding it to the docs would have saved me a lot of time.

There's way more docs to be updated - nothing seems to even remotely indicate some kind of ACL / User related data filtering.

Isn't it one of the most basic usecases ever? Where you want someone to only see their own data?

This usecase doesn't seem to be documented anywhere. It doesn't seem doable by using the annotations (albeit there's security and IRI overrides everywhere) it would never just shows this users' own stuff.