### PR TITLE
update link to marmelab's documention

### DIFF
--- a/admin/customizing.md
+++ b/admin/customizing.md
@@ -182,4 +182,4 @@ For instance, using an autocomplete input is straightforward, [checkout the dedi
 API Platform is built on top of [React Admin](https://marmelab.com/react-admin/).
 You can use all the features provided by the underlying library with API Platform Admin, including support for [authentication](https://marmelab.com/react-admin/Authentication.html), [authorization](https://marmelab.com/react-admin/Authorization.html) and deeper customization.
 
-To learn more about these capabilities, refer to [the React Admin documentation](https://marmelab.com/react-admin/).
+To learn more about these capabilities, refer to [the React Admin documentation](https://marmelab.com/react-admin/documentation.html).


### PR DESCRIPTION
The previous link https://marmelab.com/react-admin/ don't lead to the doc but the link https://marmelab.com/react-admin/documentation.html works
