### PR TITLE
add documentation for minikube deployment using skaffold.

### DIFF
--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -56,6 +56,8 @@ Then, run minikube:
 
     minikube start
 
+Add Skaffold configuration in the file `./helm/skaffold.yaml`. You can find a [complete configuration file for minikube](https://github.com/api-platform/api-platform/blob/main/helm/skaffold.yaml) with its [Helm values override](https://github.com/api-platform/api-platform/blob/main/helm/skaffold-values.yaml).
+
 Finally, go to the helm folder, and run skaffold in dev mode:
 
     cd ./helm

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -46,17 +46,17 @@ Run `minikube dashboard` at any moment to see the state of your deployments.
 
 ## Using Skaffold
 
-Skaffold is a tool for Kubernetes development: https://skaffold.dev/
+Skaffold is a tool for Kubernetes development: [https://skaffold.dev/](https://skaffold.dev/).
 
 It will build and deploy automatically your app in Kubernetes and apply every changes. The default configuration use minikube and helm. More configurations are available in Skaffold documentation.
 
-First, install the skaffold CLI: https://skaffold.dev/docs/install/#standalone-binary
+First, install the [skaffold CLI](https://skaffold.dev/docs/install/#standalone-binary).
 
 Then, run minikube:
 
-    $ minikube start
+    minikube start
 
 Finally, go to the helm folder, and run skaffold in dev mode:
 
-    $ cd ./helm
-    $ skaffold dev
+    cd ./helm
+    skaffold dev

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -43,3 +43,20 @@ Finally, deploy the project using the Helm chart:
 Copy and paste the commands displayed in the terminal to enable the port forwarding then go to `http://localhost:8080` to access your application!
 
 Run `minikube dashboard` at any moment to see the state of your deployments.
+
+## Using Skaffold
+
+Skaffold is a tool for Kubernetes development: https://skaffold.dev/
+
+It will build and deploy automatically your app in Kubernetes and apply every changes. The default configuration use minikube and helm. More configurations are available in Skaffold documentation.
+
+First, install the skaffold CLI: https://skaffold.dev/docs/install/#standalone-binary
+
+Then, run minikube:
+
+    $ minikube start
+
+Finally, go to the helm folder, and run skaffold in dev mode:
+
+    $ cd ./helm
+    $ skaffold dev


### PR DESCRIPTION
Linked to the PR for adding Skaffold configuration: https://github.com/api-platform/api-platform/pull/2457
If the PR on api-platform/api-platform is refused, and this PR for the documentation is accepted, need to change the doc before merging (replace links to /api-platform/helm/skaffold*.yaml by the content of this files.)