### PR TITLE
fix: LexikJWTAuthenticationBundle isn't supported out of the box anymore

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -201,10 +201,7 @@ You must set the [JWT token](https://github.com/lexik/LexikJWTAuthenticationBund
 
 ### Adding endpoint to SwaggerUI to retrieve a JWT token
 
-LexikJWTAuthenticationBundle has an integration with API Platform to automatically
-add an OpenAPI endpoint to conveniently retrieve the token in Swagger UI.
-
-If you need to modify the default configuration, you can do it in the dedicated configuration file:
+The integration between LexikJWTAuthenticationBundle and API Platform does not automatically add an OpenAPI endpoint to retrieve the token in Swagger UI. If you want to have this functionality, you need to modify the default configuration , you can do it in the dedicated configuration file:
 
 ```yaml
 # config/packages/lexik_jwt_authentication.yaml


### PR DESCRIPTION
After upgrading [LexikJWTAuthenticationBundle](https://github.com/lexik/LexikJWTAuthenticationBundle) to latest version [v2.19.0](https://github.com/lexik/LexikJWTAuthenticationBundle/releases) it's not supported anymore.

Login endpoint just disappeared and I needed to manually add the configuration.

See @ https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1119

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
