### PR TITLE
Replace namespace - Deprecated

### DIFF
--- a/core/extensions.md
+++ b/core/extensions.md
@@ -63,7 +63,7 @@ use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use App\Entity\Offer;
 use Doctrine\ORM\QueryBuilder;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 
 final class CurrentUserExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
 {


### PR DESCRIPTION
Use namespace Symfony\Bundle\SecurityBundle\Security instead Symfony\Component\Security\Core\Security

Deprecated: since Symfony 6.2

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
