### PR TITLE
Fix typo in security.md

### DIFF
--- a/core/security.md
+++ b/core/security.md
@@ -111,7 +111,7 @@ Available variables are:
 * `request` (only at the resource level): the current request
 
 Access control checks in the `security` attribute are always executed before the [denormalization step](serialization.md).
-It means than for `PUT` or `PATCH` requests, `object` doesn't contain the value submitted by the user, but values currently stored in [the persistence layer](data-persisters.md).
+It means that for `PUT` or `PATCH` requests, `object` doesn't contain the value submitted by the user, but values currently stored in [the persistence layer](data-persisters.md).
 
 ## Executing Access Control Rules After Denormalization
 


### PR DESCRIPTION
**Original**: It means *than* for `PUT` or `PATCH` requests, ...
**Fixed**: It means *that* for `PUT` or `PATCH` requests, ...

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
