### PR TITLE
Fix markdown to correctly close preformatted blocks

### DIFF
--- a/distribution/testing.md
+++ b/distribution/testing.md
@@ -36,6 +36,7 @@ docker compose exec php \
     bin/console make:factory 'App\Entity\Book'
 docker compose exec php \
     bin/console make:factory 'App\Entity\Review'
+```
 
 Improve the default values:
 
@@ -82,6 +83,7 @@ docker compose exec php \
     bin/console make:story 'DefaultBooks'
 docker compose exec php \
     bin/console make:story 'DefaultReviews'
+```
 
 ```php
 // src/Story/DefaultBooksStory.php
@@ -98,7 +100,6 @@ final class DefaultBooksStory extends Story
         BookFactory::createMany(100);
     }
 }
-
 ```
 
 ```php


### PR DESCRIPTION
I was reading through docs looking for the usage of Alice to see it replaced by Foundry. That's fine. But the format of some preformatted blocks was not ;)