### PR TITLE
docs(contribution-guides): fix typo by adding a closing parenthesis

### DIFF
--- a/extra/contribution-guides.md
+++ b/extra/contribution-guides.md
@@ -7,4 +7,4 @@
 
 **To report a security issue, please refer to [the dedicated document](security.md).**
 
-<p align="center" class="symfonycasts"><a href="https://symfonycasts.com/screencast/contributing?cid=apip"><img src="../distribution/images/symfonycasts-player.png" alt="JWT screencast"><br>Watch the Contributing back to Symfony screencast (free-</a></p>
+<p align="center" class="symfonycasts"><a href="https://symfonycasts.com/screencast/contributing?cid=apip"><img src="../distribution/images/symfonycasts-player.png" alt="JWT screencast"><br>Watch the Contributing back to Symfony screencast (free)</a></p>


### PR DESCRIPTION
This typo is also present in the documentation from version [2.5](https://github.com/api-platform/docs/blob/2.5/extra/contribution-guides.md) to version [3.0](https://github.com/api-platform/docs/blob/3.0/extra/contribution-guides.md).