### PR TITLE
Partial Pagination parameter updated in 3

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -343,9 +343,8 @@ If you don't mind not having the last page available, you can enable partial pag
 ```yaml
 # api/config/packages/api_platform.yaml
 api_platform:
-    collection:
-        pagination:
-            partial: true # Disabled by default
+    defaults:
+        pagination_partial: true # Disabled by default
 ```
 
 More details are available on the [pagination documentation](pagination.md#partial-pagination).


### PR DESCRIPTION
The suggested configuration in this documentation section triggers the following error:
> Unrecognized option "partial" under "api_platform.collection.pagination". Available options are "enabled", "enabled_parameter_name", "items_per_page_parameter_name", "page_parameter_name", "partial_parameter_name".

The correct parameter is already on the [pagination](https://api-platform.com/docs/core/pagination/#partial-pagination) docs