### PR TITLE
docs(openapi): Fix broken image link in overriding-the-openapi-specif…

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -103,7 +103,7 @@ class OpenApiFactory implements OpenApiFactoryInterface
 
 The impact on the swagger-ui is the following:
 
-![Swagger UI](core/images/swagger-ui-modified.png)
+![Swagger UI](images/swagger-ui-modified.png)
 
 ## Using the OpenAPI and Swagger Contexts
 


### PR DESCRIPTION
Hello.

There was a broken image in the [Overriding the OpenAPI Specification](https://api-platform.com/docs/core/openapi/#overriding-the-openapi-specification) section of the Core > OpenAPI section.

A simple link fix.