### PR TITLE
chore: update jwt configuration

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -73,7 +73,7 @@ security:
             entity:
                 class: App\Entity\User
                 property: email
-            # document:
+            # mongodb:
             #    class: App\Document\User
             #    property: email    
 
@@ -124,9 +124,6 @@ security:
     # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
         App\Entity\User: 'auto'
-
-    # https://symfony.com/doc/current/security/authenticator_manager.html
-    enable_authenticator_manager: true
     # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
     providers:
         # used to reload user from session & other features (e.g. switch_user)


### PR DESCRIPTION
Unrecognized option document under security.providers.users Available options are chain, entity, id, ldap, lexik_jwt, memory, mongodb. 

Since symfony/security-bundle 6.2: The "enable_authenticator_manager" option at "security" is deprecated.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
