### PR TITLE
Document how to get introspection to work on any route

### DIFF
--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -79,9 +79,17 @@ const Admin = () => {
       </Head>
 
       <HydraAdmin dataProvider={dataProvider(setRedirectToLogin)} authProvider={authProvider} entrypoint={window.origin}>
-        <CustomRoutes>
-          {redirectToLogin ? <Route path="/" element={<RedirectToLogin />} /> : null}
-        </CustomRoutes>
+        {redirectToLogin ? (
+          <CustomRoutes>
+            <Route path="/" element={<RedirectToLogin />} />
+            <Route path="/:any" element={<RedirectToLogin />} />
+          </CustomRoutes>
+        ) : (
+          <>
+            <Resource name=".." list="..">
+            <Resource name=".." list="..">
+          </>
+        )}
       </HydraAdmin>
     </>
   );


### PR DESCRIPTION
The previously documented solution would only trigger introspection on the `/` route. Users directly navigating to a resource without being authenticated (eg. navigating to `/#/books` and then being redirected to the authentication page) would not hit the `<Route path="/">`, and thus wouldn't trigger introspection after authenticating.

If `redirectToLogin` is `true`, the `<Resource>`es shouldn't be defined in the application because otherwise they will register the specific routes, e.g. `/#/books`, meaning the `<Route path="/:any">` wouldn't be selected, and introspection also would not be triggered.
