### PR TITLE
docs: remove indentation to fix faulty code blocks

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -23,112 +23,112 @@ to a Resource in two ways:
 
 1. Through the resource declaration, as the `filters` attribute.
 
-   For example, having a filter service declaration in `services.yaml`:
+For example, having a filter service declaration in `services.yaml`:
 
-    ```yaml
-    # api/config/services.yaml
-    services:
+```yaml
+# api/config/services.yaml
+services:
+    # ...
+    offer.date_filter:
+        parent: 'api_platform.doctrine.orm.date_filter'
+        arguments: [ { dateProperty: ~ } ]
+        tags:  [ 'api_platform.filter' ]
+        # The following are mandatory only if a _defaults section is defined with inverted values.
+        # You may want to isolate filters in a dedicated file to avoid adding the following lines.
+        autowire: false
+        autoconfigure: false
+        public: false
+```
+
+Alternatively, you can choose to use a dedicated file to gather filters together:
+
+```yaml
+# api/config/filters.yaml
+services:
+    offer.date_filter:
+        parent: 'api_platform.doctrine.orm.date_filter'
+        arguments: [ { dateProperty: ~ } ]
+        tags:  [ 'api_platform.filter' ]
+```
+
+We're linking the filter `offer.date_filter` with the resource like this:
+
+[codeSelector]
+
+```php
+<?php
+// api/src/Entity/Offer.php
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(filters: ['offer.date_filter'])]
+class Offer
+{
+    // ...
+}
+```
+
+```yaml
+# api/config/api_platform/resources.yaml
+resources:
+    App\Entity\Offer:
+        operations:
+            ApiPlatform\Metadata\GetCollection:
+                filters: ['offer.date_filter']
         # ...
-        offer.date_filter:
-            parent: 'api_platform.doctrine.orm.date_filter'
-            arguments: [ { dateProperty: ~ } ]
-            tags:  [ 'api_platform.filter' ]
-            # The following are mandatory only if a _defaults section is defined with inverted values.
-            # You may want to isolate filters in a dedicated file to avoid adding the following lines.
-            autowire: false
-            autoconfigure: false
-            public: false
-    ```
+```
 
-    Alternatively, you can choose to use a dedicated file to gather filters together:
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- api/config/api_platform/resources.xml -->
 
-    ```yaml
-    # api/config/filters.yaml
-    services:
-        offer.date_filter:
-            parent: 'api_platform.doctrine.orm.date_filter'
-            arguments: [ { dateProperty: ~ } ]
-            tags:  [ 'api_platform.filter' ]
-    ```
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+        https://api-platform.com/schema/metadata/resources-3.0.xsd">
+    <resource class="App\Entity\Offer">
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection">
+                <filters>
+                    <filter>offer.date_filter</filter>
+                </filters>
+            </operation>
+            <!-- ... -->
+        </operations>
+    </resource>
+</resources>
+```
 
-   We're linking the filter `offer.date_filter` with the resource like this:
-
-   [codeSelector]
-
-    ```php
-    <?php
-    // api/src/Entity/Offer.php
-    namespace App\Entity;
-
-    use ApiPlatform\Metadata\ApiResource;
-
-    #[ApiResource(filters: ['offer.date_filter'])]
-    class Offer
-    {
-        // ...
-    }
-    ```
-
-    ```yaml
-    # api/config/api_platform/resources.yaml
-    resources:
-        App\Entity\Offer:
-            operations:
-                ApiPlatform\Metadata\GetCollection:
-                    filters: ['offer.date_filter']
-            # ...
-    ```
-
-    ```xml
-    <?xml version="1.0" encoding="UTF-8" ?>
-    <!-- api/config/api_platform/resources.xml -->
-
-    <resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
-            https://api-platform.com/schema/metadata/resources-3.0.xsd">
-        <resource class="App\Entity\Offer">
-            <operations>
-                <operation class="ApiPlatform\Metadata\GetCollection">
-                    <filters>
-                        <filter>offer.date_filter</filter>
-                    </filters>
-                </operation>
-                <!-- ... -->
-            </operations>
-        </resource>
-    </resources>
-    ```
-
-   [/codeSelector]
+[/codeSelector]
 
 2. By using the `#[ApiFilter]` attribute.
 
-   This attribute automatically declares the service, and you just have to use the filter class you want:
+This attribute automatically declares the service, and you just have to use the filter class you want:
 
-    ```php
-    <?php
-    // api/src/Entity/Offer.php
-    namespace App\Entity;
+```php
+<?php
+// api/src/Entity/Offer.php
+namespace App\Entity;
 
-    use ApiPlatform\Metadata\ApiFilter;
-    use ApiPlatform\Metadata\ApiResource;
-    use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 
-    #[ApiResource]
-    #[ApiFilter(DateFilter::class, properties: ['dateProperty'])]
-    class Offer
-    {
-        // ...
-    }
-    ```
+#[ApiResource]
+#[ApiFilter(DateFilter::class, properties: ['dateProperty'])]
+class Offer
+{
+    // ...
+}
+```
 
-   Learn more on how the [ApiFilter attribute](filters.md#apifilter-attribute) works.
+Learn more on how the [ApiFilter attribute](filters.md#apifilter-attribute) works.
 
-   For the sake of consistency, we're using the attribute in the below documentation.
+For the sake of consistency, we're using the attribute in the below documentation.
 
-   For MongoDB ODM, all the filters are in the namespace `ApiPlatform\Doctrine\Odm\Filter`. The filter
-   services all begin with `api_platform.doctrine_mongodb.odm`.
+For MongoDB ODM, all the filters are in the namespace `ApiPlatform\Doctrine\Odm\Filter`. The filter
+services all begin with `api_platform.doctrine_mongodb.odm`.
 
 ### Search Filter
 

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -410,45 +410,45 @@ The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Doc
 
 * `$fetchJoinCollection` argument: Whether there is a join to a collection-valued association. When set to `true`, the Doctrine ORM Paginator will perform an additional query, in order to get the correct number of results.
 
-    You can configure this using the `paginationFetchJoinCollection` attribute on a resource or on a per-operation basis:
+You can configure this using the `paginationFetchJoinCollection` attribute on a resource or on a per-operation basis:
 
-    ```php
-    <?php
-    // api/src/Entity/Book.php
-    namespace App\Entity;
+```php
+<?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-    use ApiPlatform\Metadata\ApiResource;
-    use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 
-    #[ApiResource(paginationFetchJoinCollection: false)]
-    #[GetCollection]
-    #[GetCollection(name: 'get_custom', paginationFetchJoinCollection: true)]
-    class Book
-    {
-        // ...
-    }
-    ```
+#[ApiResource(paginationFetchJoinCollection: false)]
+#[GetCollection]
+#[GetCollection(name: 'get_custom', paginationFetchJoinCollection: true)]
+class Book
+{
+    // ...
+}
+```
 
 * `setUseOutputWalkers` setter: Whether to use output walkers. When set to `true`, the Doctrine ORM Paginator will use output walkers, which are compulsory for some types of queries.
 
-    You can configure this using the `paginationUseOutputWalkers` attribute on a resource or on a per-operation basis:
+You can configure this using the `paginationUseOutputWalkers` attribute on a resource or on a per-operation basis:
 
-    ```php
-    <?php
-    // api/src/Entity/Book.php
-    namespace App\Entity;
+```php
+<?php
+// api/src/Entity/Book.php
+namespace App\Entity;
 
-    use ApiPlatform\Metadata\ApiResource;
-    use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
 
-    #[ApiResource(paginationUseOutputWalkers: false)]
-    #[GetCollection]
-    #[GetCollection(name: 'get_custom', paginationUseOutputWalkers: true)]
-    class Book
-    {
-        // ...
-    }
-    ```
+#[ApiResource(paginationUseOutputWalkers: false)]
+#[GetCollection]
+#[GetCollection(name: 'get_custom', paginationUseOutputWalkers: true)]
+class Book
+{
+    // ...
+}
+```
 
 For more information, please see the [Pagination](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/pagination.html) entry in the Doctrine ORM documentation.
 

--- a/core/performance.md
+++ b/core/performance.md
@@ -357,46 +357,46 @@ To configure Blackfire.io follow these simple steps:
 
 1. Add the following to your `docker-compose.override.yml` file:
 
-    ```yaml
-        blackfire:
-            image: blackfire/blackfire:2
-            environment:
-                # Exposes the host BLACKFIRE_SERVER_ID and TOKEN environment variables.
-                - BLACKFIRE_SERVER_ID
-                - BLACKFIRE_SERVER_TOKEN
-                - BLACKFIRE_DISABLE_LEGACY_PORT=1
-    ```
+```yaml
+    blackfire:
+        image: blackfire/blackfire:2
+        environment:
+            # Exposes the host BLACKFIRE_SERVER_ID and TOKEN environment variables.
+            - BLACKFIRE_SERVER_ID
+            - BLACKFIRE_SERVER_TOKEN
+            - BLACKFIRE_DISABLE_LEGACY_PORT=1
+```
 
 2. Add your Blackfire.io ID and server token to your `.env` file at the root of your project (be sure not to commit this to a public repository):
 
-    ```shell
-    BLACKFIRE_SERVER_ID=xxxxxxxxxx
-    BLACKFIRE_SERVER_TOKEN=xxxxxxxxxx
-    ```
+```shell
+BLACKFIRE_SERVER_ID=xxxxxxxxxx
+BLACKFIRE_SERVER_TOKEN=xxxxxxxxxx
+```
 
-    Or set it in the console before running Docker commands:
+Or set it in the console before running Docker commands:
 
-    ```shell
-    export BLACKFIRE_SERVER_ID=xxxxxxxxxx
-    export BLACKFIRE_SERVER_TOKEN=xxxxxxxxxx
-    ```
+```shell
+export BLACKFIRE_SERVER_ID=xxxxxxxxxx
+export BLACKFIRE_SERVER_TOKEN=xxxxxxxxxx
+```
 
 3. Install and configure the Blackfire probe in the app container, by adding the following to your `./Dockerfile`:
 
-    ```dockerfile
-            RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
-                && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
-                && mkdir -p /tmp/blackfire \
-                && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \                        
-                && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
-                && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8307\n" > $PHP_INI_DIR/conf.d/blackfire.ini
-    ```
+```dockerfile
+        RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+            && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
+            && mkdir -p /tmp/blackfire \
+            && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \                        
+            && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+            && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8307\n" > $PHP_INI_DIR/conf.d/blackfire.ini
+```
 
 4. Rebuild and restart all your containers
 
-    ```console
-    docker compose build
-    docker compose up --wait
-    ```
+```console
+docker compose build
+docker compose up --wait
+```
 
 For details on how to perform profiling, see [the Blackfire.io documentation](https://blackfire.io/docs/integrations/docker#using-the-client-for-http-profiling).


### PR DESCRIPTION
Currently indented text is being displayed as code blocks. 
I guess having no indentation is better than faulty code blocks for now.

![image](https://github.com/api-platform/docs/assets/40628500/5e6f14b6-31de-4838-9d24-cf68abe65740)
