### PR TITLE
fix(performance): add warning about Serializer groups being mandatory in order to trigger EagerLoadingExtension

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -201,6 +201,8 @@ public $foo;
 ...
 ```
 
+> **Warning**: in order to trigger the `EagerLoadingExtension` you must use [Serializer groups](serialization.md) on relations properties.
+
 #### Max Joins
 
 There is a default restriction with this feature. We allow up to 30 joins per query. Beyond that, an


### PR DESCRIPTION
This is a long due fix that had been discussed here: https://github.com/api-platform/core/issues/5062

Since v2.2.7 the EagerLoadingExtension is only trigger for relation properties using Serializer groups but it is never stated in the documentation.