### PR TITLE
[BUG] Fixed normalization context group value

### DIFF
--- a/core/controllers.md
+++ b/core/controllers.md
@@ -240,7 +240,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
         name: 'publication', 
         uriTemplate: '/books/{id}/publication', 
         controller: CreateBookPublication::class, 
-        normalizationContext: ['groups' => 'publication']
+        normalizationContext: ['groups' => ['publication']],
     )
 ])]
 class Book


### PR DESCRIPTION
`groups` expect for array, but not a string
