### PR TITLE
Fix wrong variable name in documentation about TypeConverter

### DIFF
--- a/core/graphql.md
+++ b/core/graphql.md
@@ -1860,7 +1860,7 @@ final class TypeConverter implements TypeConverterInterface
     public function convertType(Type $type, bool $input, Operation $rootOperation, string $resourceClass, string $rootResource, ?string $property, int $depth)
     {
         if ('publicationDate' === $property
-            && Book::class === $resourceClass
+            && Book::class === $rootResource
         ) {
             return 'DateTime';
         }


### PR DESCRIPTION
Fix var name

Trying to implement a TypeConverter, discover that the var used in docs is not the proper one. (See https://github.com/api-platform/core/blob/main/tests/Fixtures/TestBundle/GraphQl/Type/TypeConverter.php#L40)
