### PR TITLE
Update mentions of OpenAPI docs.json to docs.jsonopenapi

### DIFF
--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -8,7 +8,7 @@ To use it, use the `OpenApiAdmin` component, with the entrypoint of the API and 
 import { OpenApiAdmin } from "@api-platform/admin";
 
 export default () => (
-  <OpenApiAdmin entrypoint="https://demo.api-platform.com" docEntrypoint="https://demo.api-platform.com/docs.json" />
+  <OpenApiAdmin entrypoint="https://demo.api-platform.com" docEntrypoint="https://demo.api-platform.com/docs.jsonopenapi" />
 );
 ```
 

--- a/admin/real-time-mercure.md
+++ b/admin/real-time-mercure.md
@@ -18,7 +18,7 @@ import { OpenApiAdmin } from "@api-platform/admin";
 export default () => (
   <OpenApiAdmin
     entrypoint="https://demo.api-platform.com"
-    docEntrypoint="https://demo.api-platform.com/docs.json"
+    docEntrypoint="https://demo.api-platform.com/docs.jsonopenapi"
     mercure={{ hub: "https://mercure.rocks/hub" }}
   />
 );

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -6,9 +6,9 @@ API Platform natively supports the [OpenAPI](https://www.openapis.org/) API spec
 
 <p align="center" class="symfonycasts"><a href="https://symfonycasts.com/screencast/api-platform/open-api-spec?cid=apip"><img src="../distribution/images/symfonycasts-player.png" alt="OpenAPI screencast"><br>Watch the OpenAPI screencast</a></p>
 
-The specification of the API is available at the `/docs.json` path.
+The specification of the API is available at the `/docs.jsonopenapi` path.
 By default, OpenAPI v3 is used.
-You can also get an OpenAPI v3-compliant version thanks to the `spec_version` query parameter: `/docs.json?spec_version=3`
+You can also get an OpenAPI v3-compliant version thanks to the `spec_version` query parameter: `/docs.jsonopenapi?spec_version=3`
 
 It also integrates a customized version of [Swagger UI](https://swagger.io/swagger-ui/) and [ReDoc](https://rebilly.github.io/ReDoc/), some nice tools to display the
 API documentation in a user friendly way.
@@ -583,7 +583,7 @@ You may want to copy the [one shipped with API Platform](https://github.com/api-
 [AWS API Gateway](https://aws.amazon.com/api-gateway/) supports OpenAPI partially, but it [requires some changes](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-known-issues.html).
 API Platform provides a way to be compatible with Amazon API Gateway.
 
-To enable API Gateway compatibility on your OpenAPI docs, add `api_gateway=true` as query parameter: `http://www.example.com/docs.json?api_gateway=true`.
+To enable API Gateway compatibility on your OpenAPI docs, add `api_gateway=true` as query parameter: `http://www.example.com/docs.jsonopenapi?api_gateway=true`.
 The flag `--api-gateway` is also available through the command-line.
 
 ## OAuth

--- a/create-client/nuxt.md
+++ b/create-client/nuxt.md
@@ -19,7 +19,7 @@ To generate the code you need for a given resource, run the following command:
 yarn create @api-platform/client https://demo.api-platform.com . --generator nuxt --resource foo
 ```
 
-Replace the URL with the entrypoint of your Hydra-enabled API. You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.json` and `-f openapi3`.
+Replace the URL with the entrypoint of your Hydra-enabled API. You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.jsonopenapi` and `-f openapi3`.
 
 Omit the resource flag to generate files for all resource types exposed by the API.
 

--- a/create-client/quasar.md
+++ b/create-client/quasar.md
@@ -36,7 +36,7 @@ npm init @api-platform/client https://demo.api-platform.com src/ -- --generator 
 ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.
-You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.json` and `-f openapi3`.
+You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.jsonopenapi` and `-f openapi3`.
 
 Omit the resource flag to generate files for all resource types exposed by the API.
 

--- a/create-client/vuejs.md
+++ b/create-client/vuejs.md
@@ -20,7 +20,7 @@ npm init @api-platform/client https://demo.api-platform.com src/ -- --generator 
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.
-You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.json` and `-f openapi3`.
+You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.jsonopenapi` and `-f openapi3`.
 
 Omit the resource flag to generate files for all resource types exposed by the API.
 

--- a/create-client/vuetify.md
+++ b/create-client/vuetify.md
@@ -20,7 +20,7 @@ npm init @api-platform/client https://demo.api-platform.com src/ -- --generator 
 ```
 
 Replace the URL with the entrypoint of your Hydra-enabled API.
-You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.json` and `-f openapi3`.
+You can also use an OpenAPI documentation with `https://demo.api-platform.com/docs.jsonopenapi` and `-f openapi3`.
 
 Omit the resource flag to generate files for all resource types exposed by the API.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
Starting with 3.2, and since https://github.com/api-platform/core/pull/5808 and https://github.com/api-platform/api-platform/pull/2521, we cannot use /docs.json anymore
