### PR TITLE
docs(core/pagination): remove extra codeSelector tag

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -72,8 +72,6 @@ api_platform:
 
 It can also be disabled for a specific resource:
 
-[codeSelector]
-
 ```php
 <?php
 // api/src/Entity/Book.php
@@ -94,13 +92,10 @@ resources:
     App\Entity\Book:
        paginationEnabled: false
 ```
-[/codeSelector]
 
 ### Disabling the Pagination For a Specific Operation
 
 You can also disable an operation for a specific operation:
-
-[codeSelector]
 
 ```php
 <?php
@@ -148,7 +143,6 @@ resources:
     </resource>
 </resources>
 ```
-[/codeSelector]
 
 ### Disabling the Pagination Client-side
 


### PR DESCRIPTION
Some `[codeSelector]` are present in the .md files and do appears in the pagination documentation web page.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
