### PR TITLE
docs(extra/releases): update Maintenance stable branch number

### DIFF
--- a/extra/releases.md
+++ b/extra/releases.md
@@ -15,7 +15,7 @@ For example:
 
 3 versions are maintained at the same time:
 
-* **stable** (currently the **3.1** branch): regular bugfixes are integrated in this version
+* **stable** (currently the **3.2** branch): regular bugfixes are integrated in this version
 * **old-stable** (are the last 2 minor branches: currently **3.0** and **3.1** branches): [security fixes](security.md) are integrated in this version, regular bugfixes are **not** backported in it
 * **development** (**main** branch): new features target this branch
 


### PR DESCRIPTION
Based on the example in the latest versions of Api Platform _(and the example just above)_, the _"stable"_ version should be `3.2`.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
