### PR TITLE
correct launch.json path mapping to /app

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -44,7 +44,7 @@ Note that this configuration includes the path mappings for the Docker image.
             "port": 9003,
             "log": true,
             "pathMappings": {
-                "/srv/api": "${workspaceFolder}/api"
+                "/app": "${workspaceFolder}/api"
             },
         },
     ]


### PR DESCRIPTION
Docs show `/srv/api` for `launch.json`, however the docker container now contains the app in `/app`.