### PR TITLE
Fix variable name

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -237,9 +237,9 @@ final class CustomItemNormalizer implements NormalizerInterface, DenormalizerInt
         $this->normalizer = $normalizer;
     }
 
-    public function denormalize($data, $class, $format = null, array $context = [])
+    public function denormalize($data, $type, $format = null, array $context = [])
     {
-        return $this->normalizer->denormalize($data, $class, $format, $context);
+        return $this->normalizer->denormalize($data, $type, $format, $context);
     }
 
     public function supportsDenormalization($data, $type, $format = null)


### PR DESCRIPTION
Variable name should be `$type` instead of `$class`, as shown in interface source: https://github.com/symfony/serializer/blob/6.4/Normalizer/DenormalizerInterface.php#L49
