### PR TITLE
Improves file upload testing documentation

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -308,12 +308,13 @@ class MediaObjectTest extends ApiTestCase
         $file = new UploadedFile('fixtures/files/image.png', 'image.png');
         $client = self::createClient();
 
+        // Do not pass extra form fields through the "body" option as it won't work
         $client->request('POST', '/media_objects', [
             'headers' => ['Content-Type' => 'multipart/form-data'],
             'extra' => [
                 // If you have additional fields in your MediaObject entity, use the parameters.
                 'parameters' => [
-                    'title' => 'My file uploaded',
+                    'title' => 'My file uploaded', // These parameters will be available in the application through $request->request
                 ],
                 'files' => [
                     'file' => $file,
@@ -328,6 +329,8 @@ class MediaObjectTest extends ApiTestCase
     }
 }
 ```
+
+**Important:** Using Symfony's `FormDataPart` Class will not work with the ApiTestCase Client.
 
 ## Uploading to an Existing Resource with its Fields
 

--- a/core/testing.md
+++ b/core/testing.md
@@ -209,3 +209,10 @@ class BooksTest extends ApiTestCase
 ```
 
 [Check out the dedicated Symfony documentation entry](https://symfony.com/doc/current/testing/functional_tests_assertions.html).
+
+
+## Testing File Uploads and multipart/form-data Requests
+
+It is also possible to test file uploads and `multipart/form-data` requests with the API Platform test client.
+
+[Check out the dedicated File Upload Testing documentation entry](https://api-platform.com/docs/core/file-upload/#testing).

--- a/extra/releases.md
+++ b/extra/releases.md
@@ -15,7 +15,7 @@ For example:
 
 3 versions are maintained at the same time:
 
-* **stable** (currently the **3.1** branch): regular bugfixes are integrated in this version
+* **stable** (currently the **3.2** branch): regular bugfixes are integrated in this version
 * **old-stable** (are the last 2 minor branches: currently **3.0** and **3.1** branches): [security fixes](security.md) are integrated in this version, regular bugfixes are **not** backported in it
 * **development** (**main** branch): new features target this branch
 


### PR DESCRIPTION
This change will improve the File Upload Testing Documentation, as this has been hidden in the "File Upload" Section when it should be under the Testing section. 
It was not clearly pointed out how to only pass form fields with the `extra` option instead of the `body` (like one would assume) 
Also, it was not clearly pointed out that Symfony's `FormDataPart` Class won't work (like described at https://symfony.com/doc/current/http_client.html).