### PR TITLE
Update filters.md

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1331,7 +1331,7 @@ services:
     # This whole definition can be omitted if automatic service loading is enabled
     'App\Filter\RegexpFilter':
         # The "arguments" key can be omitted if the autowiring is enabled
-        arguments: [ '@doctrine', ~, '@?logger' ]
+        arguments: [ '@doctrine', '@?logger' ]
         # The "tags" key can be omitted if the autoconfiguration is enabled
         tags: [ 'api_platform.filter' ]
 ```
@@ -1343,7 +1343,7 @@ it can also be enabled for some properties:
 # api/config/services.yaml
 services:
     'App\Filter\RegexpFilter':
-        arguments: [ '@doctrine', ~, '@?logger', { email: ~, anOtherProperty: ~ } ]
+        arguments: [ '@doctrine', '@?logger', { email: ~, anOtherProperty: ~ } ]
         tags: [ 'api_platform.filter' ]
 ```
 


### PR DESCRIPTION
```php
abstract class AbstractFilter implements FilterInterface :

public function __construct(protected ManagerRegistry $managerRegistry, LoggerInterface $logger = null, protected ?array $properties = null, protected ?NameConverterInterface $nameConverter = null)
{
    $this->logger = $logger ?? new NullLogger();
}
```

The tild should not be in second position, it should be the log as shown in the AbstractFilter constructor

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
