### PR TITLE
Add missing console styling to Minicube and Kubernetes code block docs in light mode

### DIFF
--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -38,7 +38,7 @@ curl https://sdk.cloud.google.com | bash
 Versioning: The 0.1.0 is the version. This value should be the same as the attribute `appVersion` in `Chart.yaml`.
 Infos for [Google Container pulling and pushing](https://cloud.google.com/container-registry/docs/pushing-and-pulling)
 
-```
+```console
 docker build -t gcr.io/test-api-platform/php:0.1.0 -t gcr.io/test-api-platform/php:latest api --target php_prod
 docker build -t gcr.io/test-api-platform/caddy:0.1.0 -t gcr.io/test-api-platform/caddy:latest api --target caddy_prod
 docker build -t gcr.io/test-api-platform/pwa:0.1.0 -t gcr.io/test-api-platform/pwa:latest pwa --target prod

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -6,7 +6,9 @@ If you have no existing installation of Minikube on your computer, [follow the o
 
 When Minikube is installed, start the cluster:
 
-    minikube start --addons registry --addons dashboard
+```console
+minikube start --addons registry --addons dashboard
+```
 
 The previous command starts Minikube with a Docker registry (we'll use it in the next step) and with the Kubernetes dashboard.
 
@@ -18,27 +20,33 @@ Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to de
 
 First, build the images:
 
-    docker build -t localhost:5000/php api --target api_platform_php
-    docker build -t localhost:5000/caddy api --target api_platform_caddy
-    docker build -t localhost:5000/pwa pwa --target api_platform_pwa_prod
+```console
+docker build -t localhost:5000/php api --target api_platform_php
+docker build -t localhost:5000/caddy api --target api_platform_caddy
+docker build -t localhost:5000/pwa pwa --target api_platform_pwa_prod
+```
 
 Then push the images in the registry installed in Minikube:
 
-    docker push localhost:5000/php
-    docker push localhost:5000/caddy
-    docker push localhost:5000/pwa
+```console
+docker push localhost:5000/php
+docker push localhost:5000/caddy
+docker push localhost:5000/pwa
+```
 
 ## Deploying
 
 Finally, deploy the project using the Helm chart:
 
-    $ helm install my-project helm/api-platform \
-      --set php.image.repository=localhost:5000/php \
-      --set php.image.tag=latest \
-      --set caddy.image.repository=localhost:5000/caddy \
-      --set caddy.image.tag=latest \
-      --set pwa.image.repository=localhost:5000/pwa \
-      --set pwa.image.tag=latest
+```console
+$ helm install my-project helm/api-platform \
+  --set php.image.repository=localhost:5000/php \
+  --set php.image.tag=latest \
+  --set caddy.image.repository=localhost:5000/caddy \
+  --set caddy.image.tag=latest \
+  --set pwa.image.repository=localhost:5000/pwa \
+  --set pwa.image.tag=latest
+```
 
 Copy and paste the commands displayed in the terminal to enable the port forwarding then go to `http://localhost:8080` to access your application!
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
Adds missing `console` definition on code blocks, on light mode it doesnt show the text color correct in code blocks.

It was missing on minikube docs page and in one place on the kubernetes pages as reported here https://github.com/api-platform/api-platform/discussions/2617