### PR TITLE
fix(doc) : Add slash to the documentation for fix swagger

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -85,7 +85,7 @@ security:
             stateless: true
             provider: users
             json_login:
-                check_path: auth # The name in routes.yaml is enough for mapping
+                check_path: /auth # The name in routes.yaml is enough for mapping
                 username_path: email
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success


### PR DESCRIPTION
If the / of auth is missing in Api Swager the Url should be localhostauth

If you add / the url should localhost/auth

Before : 

![image](https://github.com/api-platform/docs/assets/18017015/a34fbc5e-b337-43a2-9da3-99e5dba84da8)

After :

![image](https://github.com/api-platform/docs/assets/18017015/a737d3f7-e75f-456f-9c05-e44e2ff731ad)


<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
