### PR TITLE
fix: typo in subresources.md

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -109,6 +109,7 @@ To make things work, API Platform needs information about how to retrieve the `A
 the `Question`, this is done by configuring the `uriVariables`:
 
 <code-selector>
+
 ```php
 <?php
 // api/src/Entity/Answer.php


### PR DESCRIPTION
Fix [Subresources](https://api-platform.com/docs/core/subresources/) page

<img width="1438" alt="image" src="https://github.com/api-platform/docs/assets/61290725/87e2be3d-8d49-4c13-90ff-d4fd562d2e99">
