### PR TITLE
Update state-processors.md

### DIFF
--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -97,9 +97,9 @@ use Symfony\Component\Mailer\MailerInterface;
 final class UserProcessor implements ProcessorInterface
 {
     public function __construct(
-        #[Autowire('api_platform.doctrine.orm.state.persist_processor')]
+        #[Autowire('@api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        #[Autowire('api_platform.doctrine.orm.state.remove_processor')]
+        #[Autowire('@api_platform.doctrine.orm.state.remove_processor')]
         private ProcessorInterface $removeProcessor,
         MailerInterface $mailer,
     )

--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -99,7 +99,7 @@ final class UserProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
-        #[Autowire('@api_platform.doctrine.orm.state.remove_processor')]
+        #[Autowire(service: 'api_platform.doctrine.orm.state.remove_processor')]
         private ProcessorInterface $removeProcessor,
         MailerInterface $mailer,
     )

--- a/core/state-processors.md
+++ b/core/state-processors.md
@@ -97,7 +97,7 @@ use Symfony\Component\Mailer\MailerInterface;
 final class UserProcessor implements ProcessorInterface
 {
     public function __construct(
-        #[Autowire('@api_platform.doctrine.orm.state.persist_processor')]
+        #[Autowire(service: 'api_platform.doctrine.orm.state.persist_processor')]
         private ProcessorInterface $persistProcessor,
         #[Autowire('@api_platform.doctrine.orm.state.remove_processor')]
         private ProcessorInterface $removeProcessor,


### PR DESCRIPTION
Add missing `@` character in the `#[Autowire('api_platform.doctrine.orm.state.persist_processor')]` example code.

The correct statement should be:
`#[Autowire('@api_platform.doctrine.orm.state.persist_processor')]`

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
