### PR TITLE
 fix: add missing import in code example in validation.md

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -407,6 +407,7 @@ Create a processor, which receives the default processor, where you will trigger
 namespace App\State;
 
 use ApiPlatform\Doctrine\Common\State\RemoveProcessor as DoctrineRemoveProcessor;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\Validator\ValidatorInterface;
 use App\Entity\MyEntity;


### PR DESCRIPTION
The code example for the processor is missing the import for the Operation class.