### PR TITLE
Fix code example in subresource

### DIFF
--- a/core/subresources.md
+++ b/core/subresources.md
@@ -102,6 +102,7 @@ To make things work, API Platform needs information about how to retrieve the `A
 the `Question`, this is done by configuring the `uriVariables`:
 
 <code-selector>
+
 ```php
 <?php
 // api/src/Entity/Answer.php


### PR DESCRIPTION
While reading [subresources docs](https://api-platform.com/docs/v3.0/core/subresources/)

I noticed a weird '```php' so I tried to fix it :)