### PR TITLE
Add instructions for building Next.js client with SSG locally in Docker Compose

### DIFF
--- a/create-client/nextjs.md
+++ b/create-client/nextjs.md
@@ -98,6 +98,10 @@ yarn dev
 
 Go to `http://localhost:3000/books/` to start using your app.
 
+## Generating a production build locally with docker compose
+
+If you want to generate a production build locally with docker compose, follow [these instructions](../deployment/docker-compose.md)
+
 ## Screenshots
 
 ![List](images/nextjs/create-client-nextjs-list.png)

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -122,7 +122,18 @@ This setup ensures the Next.js client can access the API at build time to genera
 
 ### Configuration Steps
 
-#### 1. Adjust the compose.prod.yaml file
+#### 1. Adjust the compose.yaml file
+
+Modify the php service to allow overriding the TRUSTED_HOSTS and MERCURE_PUBLIC_URL environment variables:
+
+```yaml
+  php:
+    environment:
+      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
+      MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
+```
+
+#### 2. Adjust the compose.prod.yaml file
 
 Modify the pwa service to ensure network communication between the pwa and php services during the build:
 
@@ -136,36 +147,40 @@ Modify the pwa service to ensure network communication between the pwa and php s
         - php=127.0.0.1
 ```
 
-#### 2. Build and start the php service
+#### 3. Build and start the php service
 
 Begin by starting the php service container:
 
 ```bash
 SERVER_NAME=http://localhost \
+MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
+TRUSTED_HOSTS='^localhost|php$$' \
 APP_SECRET=!ChangeMe! \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
 POSTGRES_PASSWORD=!ChangeMe! \
 docker compose -f compose.yaml -f compose.prod.yaml up -d --build --wait php
 ```
 
-#### 3. Optional: Env file with create-client:
+#### 4. Optional: Env file with create-client
 
-If your are using the [create-client](../create-client/nextjs.md) generator inside your Next client, you need to create a `.env` file in the `pwa` directory with the `NEXT_PUBLIC_ENTRYPOINT` environment variable to ensure the Next.js client knows where to find the API:
+If your are using the [create-client](../create-client/nextjs.md) generator inside your Next.js client, you need to create a `.env` file in the `pwa` directory with the `NEXT_PUBLIC_ENTRYPOINT` environment variable to ensure the Next.js client knows where to find the API:
 
 ```dotenv
 NEXT_PUBLIC_ENTRYPOINT=http://php
 ```
 
-#### 4. Build the pwa service
+#### 5. Build the pwa service
 
 ```bash
 docker compose -f compose.yaml -f compose.prod.yaml build pwa
 ```
 
-#### 5. Finally, bring up the full project
+#### 6. Finally, bring up the full project
 
 ```bash
 SERVER_NAME=http://localhost \
+MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
+TRUSTED_HOSTS='^localhost|php$$' \
 APP_SECRET=!ChangeMe! \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
 POSTGRES_PASSWORD=!ChangeMe! \

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -89,8 +89,10 @@ Go to `https://your-domain-name.example.com` and enjoy!
 
 Alternatively, if you don't want to expose an HTTPS server but only an HTTP one, run the following command:
 
-```console
-SERVER_NAME=:80 \
+```bash
+SERVER_NAME=http://localhost \
+MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
+TRUSTED_HOSTS='^localhost|php$' \
 APP_SECRET=ChangeMe \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
 docker compose -f -compose.yaml -f compose.prod.yaml up --wait
@@ -122,18 +124,7 @@ This setup ensures the Next.js client can access the API at build time to genera
 
 ### Configuration Steps
 
-#### 1. Adjust the compose.yaml file
-
-Modify the php service to allow overriding the TRUSTED_HOSTS and MERCURE_PUBLIC_URL environment variables:
-
-```yaml
-  php:
-    environment:
-      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
-      MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
-```
-
-#### 2. Adjust the compose.prod.yaml file
+#### 1. Adjust the compose.prod.yaml file
 
 Modify the pwa service to ensure network communication between the pwa and php services during the build:
 
@@ -147,21 +138,21 @@ Modify the pwa service to ensure network communication between the pwa and php s
         - php=127.0.0.1
 ```
 
-#### 3. Build and start the php service
+#### 2. Build and start the php service
 
 Begin by starting the php service container:
 
 ```bash
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
-TRUSTED_HOSTS='^localhost|php$$' \
+TRUSTED_HOSTS='^localhost|php$' \
 APP_SECRET=!ChangeMe! \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
 POSTGRES_PASSWORD=!ChangeMe! \
 docker compose -f compose.yaml -f compose.prod.yaml up -d --build --wait php
 ```
 
-#### 4. Optional: Env file with create-client
+#### 3. Optional: Env file with create-client
 
 If your are using the [create-client](../create-client/nextjs.md) generator inside your Next.js client, you need to create a `.env` file in the `pwa` directory with the `NEXT_PUBLIC_ENTRYPOINT` environment variable to ensure the Next.js client knows where to find the API:
 
@@ -169,18 +160,18 @@ If your are using the [create-client](../create-client/nextjs.md) generator insi
 NEXT_PUBLIC_ENTRYPOINT=http://php
 ```
 
-#### 5. Build the pwa service
+#### 4. Build the pwa service
 
 ```bash
 docker compose -f compose.yaml -f compose.prod.yaml build pwa
 ```
 
-#### 6. Finally, bring up the full project
+#### 5. Finally, bring up the full project
 
 ```bash
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
-TRUSTED_HOSTS='^localhost|php$$' \
+TRUSTED_HOSTS='^localhost|php$' \
 APP_SECRET=!ChangeMe! \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
 POSTGRES_PASSWORD=!ChangeMe! \

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -114,3 +114,62 @@ As a shortcut, `private_ranges` may be configured to trust all private IP ranges
 +    trusted_proxies private_ranges
 +}
 ```
+
+## Building Next.js client locally with SSG
+
+When deploying API Platform with Docker Compose and you need to build a Next.js client that utilizes Static Site Generation (SSG), a specific setup is required.  
+This setup ensures the Next.js client can access the API at build time to generate static pages.
+
+### Configuration Steps
+
+#### 1. Adjust the compose.prod.yaml file
+
+Modify the pwa service to ensure network communication between the pwa and php services during the build:
+
+```yaml
+  pwa:
+    build:
+      context: ./pwa
+      target: prod
+      network: host
+      extra_hosts:
+        - php=127.0.0.1
+```
+
+#### 2. Build and start the php service
+
+Begin by starting the php service container:
+
+```bash
+SERVER_NAME=http://localhost \
+APP_SECRET=!ChangeMe! \
+CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
+POSTGRES_PASSWORD=!ChangeMe! \
+docker compose -f compose.yaml -f compose.prod.yaml up -d --build --wait php
+```
+
+#### 3. Optional: Env file with create-client:
+
+If your are using the [create-client](../create-client/nextjs.md) generator inside your Next client, you need to create a `.env` file in the `pwa` directory with the `NEXT_PUBLIC_ENTRYPOINT` environment variable to ensure the Next.js client knows where to find the API:
+
+```dotenv
+NEXT_PUBLIC_ENTRYPOINT=http://php
+```
+
+#### 4. Build the pwa service
+
+```bash
+docker compose -f compose.yaml -f compose.prod.yaml build pwa
+```
+
+#### 5. Finally, bring up the full project
+
+```bash
+SERVER_NAME=http://localhost \
+APP_SECRET=!ChangeMe! \
+CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
+POSTGRES_PASSWORD=!ChangeMe! \
+docker compose -f compose.yaml -f compose.prod.yaml up -d --wait
+```
+
+These steps ensure the Next.js client can statically generate pages by accessing the API during the build process.

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -44,6 +44,12 @@ docker build -t gcr.io/test-api-platform/caddy:0.1.0 -t gcr.io/test-api-platform
 docker build -t gcr.io/test-api-platform/pwa:0.1.0 -t gcr.io/test-api-platform/pwa:latest pwa --target prod
 ```
 
+Optional: If your pwa project use Static Site Generation (SSG) and you need to build it against the API running locally, you can build the pwa with the command below.
+
+```bash
+docker build -t gcr.io/test-api-platform/pwa:0.1.0 -t gcr.io/test-api-platform/pwa:latest pwa --target prod --network=host --add-host php=127.0.0.1
+```
+
 #### 2. Push your images to your Docker registry
 
 ```console
@@ -53,12 +59,12 @@ docker push gcr.io/test-api-platform/caddy
 docker push gcr.io/test-api-platform/pwa
 ```
 
-Optional push the version images:
+Optional: push the version images:
 
 ```console
-docker push gcr.io/test-api-platform/php:0.1.0 
-docker push gcr.io/test-api-platform/caddy:0.1.0 
-docker push gcr.io/test-api-platform/pwa:0.1.0 
+docker push gcr.io/test-api-platform/php:0.1.0
+docker push gcr.io/test-api-platform/caddy:0.1.0
+docker push gcr.io/test-api-platform/pwa:0.1.0
 ```
 
 The result should look similar to these images.
@@ -114,7 +120,7 @@ Replace the values with the image parameters from the stage above.
 The parameter `php.appSecret` is the `AppSecret` from ./.env
 Fill the rest of the values with the correct settings.
 For available options see /helm/api-platform/values.yaml.
-If you want a test deploy you can set corsAllowOrigin='*'
+If you want a test deploy you can set corsAllowOrigin='\*'
 
 After a successful installation, there is a message at the end.
 You can copy these commands and execute them to set a port-forwarding and
@@ -166,7 +172,7 @@ You can upgrade with the same command from the installation and pass all paramet
 ### 2. Use :latest tags
 
 Infos about [best practices for tagging images for Kubernetes](https://kubernetes.io/docs/concepts/containers/images/)
-You have to use the *.image.pullPolicy=Always see the last 3 parameters.
+You have to use the \*.image.pullPolicy=Always see the last 3 parameters.
 
 ```console
 PHP_POD=$(kubectl --namespace=bar get pods -l app=php -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
This pull request adds detailed instructions for building a Next.js client with Static Site Generation (SSG) locally with http in a Docker Compose environment.

The steps include adjustments to the compose.yaml and compose.prod.yaml files, building and starting the php service container, optional creation of a .env file for the Next.js client, building the pwa service, and finally bringing up the full project.

This setup ensures the Next.js client can access the API locally at build time for static page generation.


The last commit adapt the docker compose documentation to reflect the changes of this [PR](https://github.com/api-platform/api-platform/pull/2666) adding the MERCURE_PUBLIC_URL and
TRUSTED_HOSTS environment variables.