### PR TITLE
Fix command line to generate public and private keys using lexik:jwt:…

### DIFF
--- a/core/jwt.md
+++ b/core/jwt.md
@@ -23,7 +23,7 @@ Then we need to generate the public and private keys used for signing JWT tokens
 ```console
 docker compose exec php sh -c '
     set -e
-    apk add openssl
+    apt-get install openssl
     php bin/console lexik:jwt:generate-keypair
     setfacl -R -m u:www-data:rX -m u:"$(whoami)":rwX config/jwt
     setfacl -dR -m u:www-data:rX -m u:"$(whoami)":rwX config/jwt


### PR DESCRIPTION
…generate-keypair

In the doc for [JWT Authentication](https://api-platform.com/docs/core/jwt/) there's this command line to use with the docker install : 

```sh
docker compose exec php sh -c '
    set -e
    apk add openssl
    php bin/console lexik:jwt:generate-keypair
    setfacl -R -m u:www-data:rX -m u:"$(whoami)":rwX config/jwt
    setfacl -dR -m u:www-data:rX -m u:"$(whoami)":rwX config/jwt
```

The command line use `apk add openssl` but apk is not found in the container.

I changed it for `apt-get install openssl` and it works perfectly :)

Cheers
