### PR TITLE
fix: autowire item provider

### DIFF
--- a/core/state-providers.md
+++ b/core/state-providers.md
@@ -153,7 +153,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 final class BookRepresentationProvider implements ProviderInterface
 {
     public function __construct(
-        #[Autowire('api_platform.doctrine.orm.state.item_provider')]
+        #[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
         private ProviderInterface $itemProvider,
     )
     {


### PR DESCRIPTION
Fix a typo in State Provider (missing the `service:` for autowire attribute).

Before :
```php
#[Autowire('api_platform.doctrine.orm.state.item_provider')]
```

After :

```php
#[Autowire(service: 'api_platform.doctrine.orm.state.item_provider')]
```