### PR TITLE
docs(kubernetes) : Adding instruction for the messenger queue with Fr…

### DIFF
--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -227,6 +227,8 @@ The `readinessProbe` and the `livenessProble` can not use the default `docker-he
 
 First, make sure to install the `/bin/ps` binary, otherwise the `readinessProbe` and `livenessProbe` will fail:
 
+<!-- markdownlint-disable no-hard-tabs -->
+
 ```patch
 # api/Dockerfile
 
@@ -234,6 +236,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 +	procps \
 # ...
 ```
+
+<!-- markdownlint-enable no-hard-tabs -->
 
 Then, update the probes:
 

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -225,7 +225,7 @@ commandArgs: ['messenger:consume', 'async', '--memory-limit=100M']
 
 The `readinessProbe` and the `livenessProble` can not use the default `docker-healthcheck` but should test if the command is running.
 
-Finally, make sure to install the `/bin/ps` binary), otherwise the `readinessProbe` and `livenessProbe` will fail:
+Finally, make sure to install the `/bin/ps` binary, otherwise the `readinessProbe` and `livenessProbe` will fail:
 
 ```patch
 # api/Dockerfile

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -225,6 +225,8 @@ commandArgs: ['messenger:consume', 'async', '--memory-limit=100M']
 
 The `readinessProbe` and the `livenessProble` can not use the default `docker-healthcheck` but should test if the command is running.
 
+If you are using the FrankenPHP image make sure to install the `/bin/ps` binary (just add `procps` in the `apt-get install script`), otherwise the `readinessProbe` and `livenessProbe` will fail.
+
 ```yaml
 readinessProbe:
     exec:

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -225,7 +225,13 @@ commandArgs: ['messenger:consume', 'async', '--memory-limit=100M']
 
 The `readinessProbe` and the `livenessProble` can not use the default `docker-healthcheck` but should test if the command is running.
 
-If you are using the FrankenPHP image make sure to install the `/bin/ps` binary (just add `procps` in the `apt-get install script`), otherwise the `readinessProbe` and `livenessProbe` will fail.
+Finally, make sure to install the `/bin/ps` binary), otherwise the `readinessProbe` and `livenessProbe` will fail:
+
+```patch
+# api/Dockerfile
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
++	procps \
 
 ```yaml
 readinessProbe:

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -225,16 +225,25 @@ commandArgs: ['messenger:consume', 'async', '--memory-limit=100M']
 
 The `readinessProbe` and the `livenessProble` can not use the default `docker-healthcheck` but should test if the command is running.
 
-Finally, make sure to install the `/bin/ps` binary, otherwise the `readinessProbe` and `livenessProbe` will fail:
+First, make sure to install the `/bin/ps` binary, otherwise the `readinessProbe` and `livenessProbe` will fail:
 
 ```patch
 # api/Dockerfile
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
 +	procps \
+# ...
+```
+
+Then, update the probes:
 
 ```yaml
 readinessProbe:
+    exec:
+        command: ["/bin/sh", "-c", "/bin/ps -ef | grep messenger:consume | grep -v grep"]
+    initialDelaySeconds: 120
+    periodSeconds: 3
+livenessProbe:
     exec:
         command: ["/bin/sh", "-c", "/bin/ps -ef | grep messenger:consume | grep -v grep"]
     initialDelaySeconds: 120


### PR DESCRIPTION
FrankenPHP image Kubernetes instruction incomplete

The readinessProbe and livenessProbe suggested in the documentation failed because the /bin/ps wasn't installed on the Docker Image.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
