### PR TITLE
fix: Use NormalizerInterface

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -911,11 +911,11 @@ Here is an example:
 namespace App\Serializer;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class BookAttributeNormalizer implements ContextAwareNormalizerInterface, NormalizerAwareInterface
+class BookAttributeNormalizer implements NormalizerInterface, NormalizerAwareInterface
 {
     use NormalizerAwareTrait;
 


### PR DESCRIPTION
`ContextAwareNormalizerInterface` is deprecated since Sf 6.1 and remove in Sf 7