### PR TITLE
Note requirement to explicitly enable multipart as an input format

### DIFF
--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -79,6 +79,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
         new Get(),
         new GetCollection(),
         new Post(
+            inputFormats: ['multipart' => ['multipart/form-data']],
             controller: CreateMediaObjectAction::class, 
             deserialize: false, 
             validationContext: ['groups' => ['Default', 'media_object_create']], 
@@ -124,6 +125,7 @@ class MediaObject
     }
 }
 ```
+Note: From V3.3 onwards, `'multipart/form-data'` must either be including in the global API-Platform config, either in `formats` or `defaults->inputFormats`, or defined as an `inputFormats` parameter on an operation by operation basis.
 
 ### Creating the Controller
 


### PR DESCRIPTION
V3.3 has become more strict about input format checking (intentionally or otherwise) and users need to be more rigorous in allowing multipart when using it for file uploads.

Prior to v3.3, I suspect people should have been defining this, but it wasn't being checked, so many won't have done.

Not sure my "note" format is in the preferred document style - possibly we don't want to mention the version for example?  Feel free to edit or request changes.
