### PR TITLE
Update identifiers.md

### DIFF
--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -68,6 +68,7 @@ Let's create a `Provider` for the `Person` entity:
 namespace App\State;
 
 use App\Entity\Person;
+use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Uuid;
 


### PR DESCRIPTION
Add missing in identifiers.md.

```diff
<?php
// api/src/State/PersonProvider.php

namespace App\State;

use App\Entity\Person;
+ use ApiPlatform\Metadata\Operation;
use ApiPlatform\State\ProviderInterface;
use App\Uuid;

/**
 * @implements ProviderInterface<Person>
 */
final class PersonProvider implements ProviderInterface
{
    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Person
    {
        // Our identifier is:
        // $uriVariables['code']
        // although it's a string, it's not an instance of Uuid and we wanted to retrieve the timestamp of our time-based uuid:
        // $uriVariable['code']->getTimestamp()
    }
}
```