### PR TITLE
Update filters.md: place nested openapi properties on same level as o…

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1222,12 +1222,10 @@ final class RegexpFilter extends AbstractFilter
                 'type' => Type::BUILTIN_TYPE_STRING,
                 'required' => false,
                 'description' => 'Filter using a regex. This will appear in the OpenApi documentation!',
-                'openapi' => [
-                    'example' => 'Custom example that will be in the documentation and be the default value of the sandbox',
-                    'allowReserved' => false,// if true, query parameters will be not percent-encoded
-                    'allowEmptyValue' => true,
-                    'explode' => false, // to be true, the type must be Type::BUILTIN_TYPE_ARRAY, ?product=blue,green will be ?product=blue&product=green
-                ],
+                'example' => 'Custom example that will be in the documentation and be the default value of the sandbox',
+                'allowReserved' => false,// if true, query parameters will be not percent-encoded
+                'allowEmptyValue' => true,
+                'explode' => false, // to be true, the type must be Type::BUILTIN_TYPE_ARRAY, ?product=blue,green will be ?product=blue&product=green
             ];
         }
 


### PR DESCRIPTION
…ther properties

Place nested openapi properties on same level as other properties as nesting this properties has no effect. Only non-nested properties seem to work.

Place nested openapi properties on same level as other properties in getDescription() method on a custom filter as nesting this properties has no effect. Only non-nested properties seem to work.
