### PR TITLE
Update serialization.md

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -608,6 +608,55 @@ class PlainIdentifierDenormalizer implements ContextAwareDenormalizerInterface, 
 }
 ```
 
+the `ContextAwareDenormalizerInterface` is removed in Symfony 7, use `DenormalizerInterface` instead:
+
+```php
+<?php
+// api/src/Serializer/PlainIdentifierDenormalizer
+
+namespace App\Serializer;
+
+use ApiPlatform\Api\IriConverterInterface;
+use App\Entity\Dummy;
+use App\Entity\RelatedDummy;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
+
+class PlainIdentifierDenormalizer implements DenormalizerInterface, DenormalizerAwareInterface
+{
+    use DenormalizerAwareTrait;
+
+    private $iriConverter;
+
+    public function __construct(IriConverterInterface $iriConverter)
+    {
+        $this->iriConverter = $iriConverter;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = [])
+    {
+        $data['relatedDummy'] = $this->iriConverter->getIriFromResource(resource: RelatedDummy::class, context: ['uri_variables' => ['id' => $data['relatedDummy']]]);
+
+        return $this->denormalizer->denormalize($data, $class, $format, $context + [__CLASS__ => true]);
+    }
+
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
+    {
+        return \in_array($format, ['json', 'jsonld'], true) && is_a($type, Dummy::class, true) && !empty($data['relatedDummy']) && !isset($context[__CLASS__]);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            'object' => null,
+            '*' => false,
+            Dummy::class => true
+        ];
+    }
+}
+```
+
 ## Property Normalization Context
 
 If you want to change the (de)normalization context of a property, for instance if you want to change the format of the date time,

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -579,46 +579,6 @@ namespace App\Serializer;
 use ApiPlatform\Api\IriConverterInterface;
 use App\Entity\Dummy;
 use App\Entity\RelatedDummy;
-use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;
-
-class PlainIdentifierDenormalizer implements ContextAwareDenormalizerInterface, DenormalizerAwareInterface
-{
-    use DenormalizerAwareTrait;
-
-    private $iriConverter;
-
-    public function __construct(IriConverterInterface $iriConverter)
-    {
-        $this->iriConverter = $iriConverter;
-    }
-
-    public function denormalize($data, $class, $format = null, array $context = [])
-    {
-        $data['relatedDummy'] = $this->iriConverter->getIriFromResource(resource: RelatedDummy::class, context: ['uri_variables' => ['id' => $data['relatedDummy']]]);
-
-        return $this->denormalizer->denormalize($data, $class, $format, $context + [__CLASS__ => true]);
-    }
-
-    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
-    {
-        return \in_array($format, ['json', 'jsonld'], true) && is_a($type, Dummy::class, true) && !empty($data['relatedDummy']) && !isset($context[__CLASS__]);
-    }
-}
-```
-
-the `ContextAwareDenormalizerInterface` is removed in Symfony 7, use `DenormalizerInterface` instead:
-
-```php
-<?php
-// api/src/Serializer/PlainIdentifierDenormalizer
-
-namespace App\Serializer;
-
-use ApiPlatform\Api\IriConverterInterface;
-use App\Entity\Dummy;
-use App\Entity\RelatedDummy;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareTrait;


### PR DESCRIPTION
Add notice about using `DenormalizerInterface` instead of `ContextAwareDenormalizerInterface` for denormalizers in [Symfony 7](https://github.com/symfony/serializer/blob/7.0/CHANGELOG.md).

