### PR TITLE
doc: Update openapi.md properties issue

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -166,16 +166,14 @@ class Product // The class name will be used to name exposed resources
 properties:
     App\Entity\Product:
         name:
-            attributes:
-                openapiContext:
-                    type: string
-                    enum: ['one', 'two']
-                    example: one
+            openapiContext:
+                type: string
+                enum: ['one', 'two']
+                example: one
         timestamp:
-            attributes:
-                openapiContext:
-                    type: string
-                    format: date-time
+            openapiContext:
+                type: string
+                format: date-time
 ```
 
 ```xml


### PR DESCRIPTION
There is a trailing `attributes` in the documentation. `openapiContext` should comes directly inside class attributes.

See how it is handled here: https://github.com/api-platform/core/blob/40fd6006bff137893cbe465ddb1d5bceca133ecc/src/JsonSchema/SchemaFactory.php#L153
