### PR TITLE
Update user.md update PasswordHasher code sample to fix syntax error

### DIFF
--- a/core/user.md
+++ b/core/user.md
@@ -248,7 +248,7 @@ final readonly class UserPasswordHasher implements ProcessorInterface
     /**
      * @param User $data
      */
-    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): User|void
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): User
     {
         if (!$data->getPlainPassword()) {
             return $this->processor->process($data, $operation, $uriVariables, $context);


### PR DESCRIPTION
`User|void` generate this error `Compile Error: Void can only be used as a standalone type` with PHP 8.3 (at least). Removing void fix it.