### PR TITLE
Update readinessProbe and livenessProbe in kubernetes.md

### DIFF
--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -244,12 +244,12 @@ Then, update the probes:
 ```yaml
 readinessProbe:
     exec:
-        command: ["/bin/sh", "-c", "/bin/ps -ef | grep messenger:consume | grep -v grep"]
+        command: ["/bin/sh", "-c", "/usr/bin/pgrep -af '^php.*bin/console.*messenger:consume'"]
     initialDelaySeconds: 120
     periodSeconds: 3
 livenessProbe:
     exec:
-        command: ["/bin/sh", "-c", "/bin/ps -ef | grep messenger:consume | grep -v grep"]
+        command: ["/bin/sh", "-c", "/usr/bin/pgrep -af '^php.*bin/console.*messenger:consume'"]
     initialDelaySeconds: 120
     periodSeconds: 3
 ```


### PR DESCRIPTION
The previous probe reported the container as ready during entrypoint.

During container start, the process (ps output) might looks like `{docker-entrypoi} /bin/sh /usr/local/bin/docker-entrypoint bin/console messenger:consume something`
