### PR TITLE
Fix path to SerializerWorkflow.png image

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -8,7 +8,7 @@ API Platform embraces and extends the Symfony Serializer Component to transform 
 
 The main serialization process has two stages:
 
-![Serializer workflow](images/SerializerWorkflow.png)
+![Serializer workflow](/docs/core/images/SerializerWorkflow.png)
 
 > As you can see in the picture above, an array is used as a man-in-the-middle. This way, Encoders will only deal with turning specific formats into arrays and vice versa. The same way, Normalizers will deal with turning specific objects into arrays and vice versa.
 -- [The Symfony documentation](https://symfony.com/doc/current/components/serializer.html)


### PR DESCRIPTION
The image is broken all the way down to the [v2.1 docs](https://api-platform.com/docs/v2.1/core/serialization/), but not sure if it should be fixed all the way back to that branch (might make merging up to the latest version a bit difficult)