### PR TITLE
Added XDEBUG_SESSION=1 to console instruction enabling xdebug

### DIFF
--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -10,7 +10,7 @@ For development purposes such as debugging tests or remote API requests,
 To enable it, run:
 
 ```console
-XDEBUG_MODE=debug docker compose up --wait
+XDEBUG_MODE=debug XDEBUG_SESSION=1 docker compose up --wait
 ```
 
 ## Using Xdebug with PhpStorm


### PR DESCRIPTION
'Debug' concept is widely understood as the way xdebug step-debugging runs, so there is an explicit need to use XDEBUG_SESSION in order to enable step-debugging. Otherwise it seems not to work, cause providing `XDEBUG_MODE=debug` is not enough if using the api-platform distribution on its release v3.3.7 (which is the latest currently)
