### PR TITLE
[Laravel > index] Remove failing assets part after api plaform install

### DIFF
--- a/laravel/index.md
+++ b/laravel/index.md
@@ -47,12 +47,6 @@ In your Laravel project, install the API Platform integration for Laravel:
 composer require api-platform/laravel
 ```
 
-After installing API Platform, publish its assets and config:
-
-```console
-php artisan api-platform:install
-```
-
 If it's not already done, start the built-in web server:
 
 ```console


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->

After installing Laravel via `laravel new` and adding API Platform by running `composer require api-platform/laravel`.

Everything works correctly except for the following command in this tutorial (Error on command run: “There is no command defined in the ‘api-platform’ namespace.")

![image](https://github.com/user-attachments/assets/fb452b6f-227c-4a0c-b67d-fc6119c4591a)
![image](https://github.com/user-attachments/assets/b63c1bc6-a528-4c2f-89bf-d23b6d26fa59)

Tell me if I'm wrong, but the asset will already be cleaned up automatically using the composer scripts and this is already done after each installation, for example after API Platform installation, as can be seen here :

![image](https://github.com/user-attachments/assets/944a2d92-4cbe-4af4-be3e-b7d52f15f55c)

That's why I'm proposing in this PR to delete this failed command.

