### PR TITLE
fix(doc): Remove keep_legacy_inflector from docs

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -68,9 +68,6 @@ api_platform:
     # Enable the data collector and the WebProfilerBundle integration.
     enable_profiler: true
 
-    # Keep doctrine/inflector instead of symfony/string to generate plurals for routes.
-    keep_legacy_inflector: true
-
     collection:
         # The name of the query parameter to filter nullable results (with the ExistsFilter).
         exists_parameter_name: 'exists'


### PR DESCRIPTION
`keep_legacy_inflector` was deprecated and 3.3 and supposed to removed by 4.0
