### PR TITLE
patch(filters) fix openapi property in custom filter documentation

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -1534,6 +1534,7 @@ use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\PropertyInfo\Type;
+use ApiPlatform\OpenApi\Model\Parameter;
 
 final class RegexpFilter extends AbstractFilter
 {
@@ -1567,12 +1568,14 @@ final class RegexpFilter extends AbstractFilter
                 'type' => Type::BUILTIN_TYPE_STRING,
                 'required' => false,
                 'description' => 'Filter using a regex. This will appear in the OpenApi documentation!',
-                'openapi' => [
-                    'example' => 'Custom example that will be in the documentation and be the default value of the sandbox',
-                    'allowReserved' => false,// if true, query parameters will be not percent-encoded
-                    'allowEmptyValue' => true,
-                    'explode' => false, // to be true, the type must be Type::BUILTIN_TYPE_ARRAY, ?product=blue,green will be ?product=blue&product=green
-                ],
+                'openapi' => new Parameter(
+                    name: $property,
+                    in: 'query',
+                    allowEmptyValue: true,
+                    explode: false, // to be true, the type must be Type::BUILTIN_TYPE_ARRAY, ?product=blue,green will be ?product=blue&product=green
+                    allowReserved: false, // if true, query parameters will be not percent-encoded
+                    example: 'Custom example that will be in the documentation and be the default value of the sandbox',
+                ),
             ];
         }
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->

I noticed that starting from api-platform:4.0 the `openapi` property expects `ApiPlatform\OpenApi\Model\Parameter` object instead of the array in the filter description. 