### PR TITLE
[Core > getting started] Remove empty block quote

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -5,7 +5,6 @@
 You can choose your preferred stack between Symfony, Laravel, or bootstrapping the API Platform core library manually.
 
 > [!CAUTION]
->
 > If you are migrating from an older version of API Platform, make sure you read the [Upgrade Guide](upgrade-guide.md).
 
 ### Symfony


### PR DESCRIPTION
Removed an unnecessary empty block in the "CAUTION" section of the documentation. This change cleans up the formatting and ensures the documentation is more readable and concise.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->

While fixing this I realized that the rendering is not very nice on the doc site @dunglas.

Expected rendering (with the actual code):
![image](https://github.com/user-attachments/assets/a7b37b49-f07c-41c8-8856-e7822b0dbf5f)

But in the documentation website we have this rendering:
![image](https://github.com/user-attachments/assets/8bc23e54-d487-4f98-8b7b-4a1d08eba312)
