### PR TITLE
Change composer require package name

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -23,7 +23,7 @@ Alternatively, you can use [Composer](https://getcomposer.org/) to install the s
 project:
 
 ```console
-composer require API
+composer require api
 ```
 
 There are no mandatory configuration options although [many settings are available](configuration.md).


### PR DESCRIPTION
If you try to require with `API` in uppercase, it returns this error
![image](https://github.com/user-attachments/assets/e358afb3-6b6c-44fb-971c-8a5cb73d9b52)

Whereas lowercase `api` it goes fine