### PR TITLE
 Removes a deprecated link in releases documentation

### DIFF
--- a/extra/releases.md
+++ b/extra/releases.md
@@ -21,8 +21,6 @@ For example:
 
 Older versions (1.x, 2.6...) **are not maintained**. If you still use them, you must upgrade as soon as possible.
 
-There's a [crowdfunding for a 2.7 LTS version](https://opencollective.com/api-platform/projects/27-lts).
-
 The **old-stable** branch is merged in the **stable** branch on a regular basis to propagate [security fixes](security.md).
 The **stable** branch is merged in the **development** branch on a regular basis to propagate [security](security.md) and regular bugfixes.
 


### PR DESCRIPTION
<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
API PLatform 2.7 link was removed
