### PR TITLE
docs:Update filters.md - change wrong dependency injection

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -894,7 +894,7 @@ namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;
 
 #[ApiResource]
 #[ApiFilter(ExistsFilter::class, properties: ['transportFees'])]


### PR DESCRIPTION
We have to use =>

use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;

Instead of :

use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\ExistsFilter;

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
