### PR TITLE
refactor: clean up docker cmds and improve code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,11 @@ By contributing to this project, you agree to abide by our [Code of Conduct](htt
 1. Fork this repository by clicking the "Fork" button at the top right of the `api-platform/docs` repository page.
 
 2. Clone the forked repository to your local machine:
-   ```bash
+   ```console
      git clone https://github.com/your-username/repository-name.git
    ```
 3. Create a new branch for your contribution:
-   ```bash
+   ```console
      git switch -c docs-your-branch-name
    ```
 4. Commit and push your changes

--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -58,8 +58,7 @@ nelmio_cors:
 Clear the cache to apply this change:
 
 ```console
-docker compose exec php \
-    bin/console cache:clear --env=prod
+bin/console cache:clear --env=prod
 ```
 
 Your new administration interface is ready! Type `npm start` to try it!

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -25,8 +25,7 @@ api_platform:
 Install the bundle with the help of Composer:
 
 ```console
-docker compose exec php \
-    composer require vich/uploader-bundle
+composer require vich/uploader-bundle
 ```
 
 This will create a new configuration file that you will need to slightly change

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -13,7 +13,7 @@ Once enabled, you have nothing to do: your schema describing your API is automat
 To enable GraphQL and its IDE (GraphiQL and GraphQL Playground) in your API, simply require the `api-platform/graphql` package using Composer:
 
 ```console
-    composer require api-platform/graphql
+composer require api-platform/graphql
 ```
 
 You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.

--- a/core/json-schema.md
+++ b/core/json-schema.md
@@ -10,15 +10,13 @@ The generated schema can be used with libraries such as [react-json-schema-form]
 To export the schema corresponding to an API Resource, run the following command:
 
 ```console
-docker compose exec php \
-    bin/console api:json-schema:generate 'App\Entity\Book'
+bin/console api:json-schema:generate 'App\Entity\Book'
 ```
 
 To see all options available, try:
 
 ```console
-docker compose exec php \
-    bin/console help api:json-schema:generate
+bin/console help api:json-schema:generate
 ```
 
 ## Overriding the JSON Schema Specification

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -1,7 +1,10 @@
 # JWT Authentication
 
-> [JSON Web Token (JWT)](https://jwt.io/) is a JSON-based open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for creating access tokens that assert some number of claims. For example, a server could generate a token that has the claim "logged in as admin" and provide that to a client. The client could then use that token to prove that he/she is logged in as admin.
-> The tokens are signed by the server's key, so the server is able to verify that the token is legitimate. The tokens are designed to be compact, URL-safe and usable especially in web browser single sign-on (SSO) context.
+> [JSON Web Token (JWT)](https://jwt.io/) is a JSON-based open standard ([RFC 7519](https://tools.ietf.org/html/rfc7519)) for creating access tokens that assert
+> some number of claims. For example, a server could generate a token that has the claim "logged in as admin" and
+> provide that to a client. The client could then use that token to prove that he/she is logged in as admin.
+> The tokens are signed by the server's key, so the server is able to verify that the token is legitimate. The tokens
+> are designed to be compact, URL-safe and usable especially in web browser single sign-on (SSO) context.
 >
 > ―[Wikipedia](https://en.wikipedia.org/wiki/JSON_Web_Token)
 
@@ -14,11 +17,17 @@ API Platform allows to easily add a JWT-based authentication to your API using [
 We begin by installing the bundle:
 
 ```console
-docker compose exec php \
-    composer require lexik/jwt-authentication-bundle
+composer require lexik/jwt-authentication-bundle
+```
+Then we need to generate the public and private keys used for signing JWT tokens.
+
+You can generate them by using this command:
+
+```console
+php bin/console lexik:jwt:generate-keypair
 ```
 
-Then we need to generate the public and private keys used for signing JWT tokens. If you're using the [API Platform distribution](../symfony/index.md), you may run this from the project's root directory:
+Or if you're using the [API Platform distribution with Symfony](../symfony/index.md), you may run this from the project's root directory:
 
 ```console
 docker compose exec php sh -c '
@@ -30,13 +39,15 @@ docker compose exec php sh -c '
 '
 ```
 
-Note that the `setfacl` command relies on the `acl` package. This is installed by default when using the API Platform docker distribution but may need to be installed in your working environment in order to execute the `setfacl` command.
+Note that the `setfacl` command relies on the `acl` package. This is installed by default when using the API Platform
+docker distribution but may need to be installed in your working environment in order to execute the `setfacl` command.
 
-This takes care of keypair creation (including using the correct passphrase to encrypt the private key), and setting the correct permissions on the keys allowing the web server to read them.
+This takes care of keypair creation (including using the correct passphrase to encrypt the private key), and setting the
+correct permissions on the keys allowing the web server to read them.
 
-Since these keys are created by the `root` user from a container, your host user will not be able to read them during the `docker compose build caddy` process. Add the `config/jwt/` folder to the `api/.dockerignore` file so that they are skipped from the result image.
-
-If you want the keys to be auto generated in `dev` environment, see an example in the [docker-entrypoint script of api-platform/demo](https://github.com/api-platform/demo/blob/master/api/docker/php/docker-entrypoint.sh).
+Since these keys are created by the `root` user from a container, your host user will not be able to read them during
+the `docker compose build caddy` process. Add the `config/jwt/` folder to the `api/.dockerignore` file so that they are
+skipped from the result image.
 
 The keys should not be checked in to the repository (i.e. it's in `api/.gitignore`). However, note that a JWT token could
 only pass signature validation against the same pair of keys it was signed with. This is especially relevant in a production

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -45,6 +45,9 @@ docker distribution but may need to be installed in your working environment in 
 This takes care of keypair creation (including using the correct passphrase to encrypt the private key), and setting the
 correct permissions on the keys allowing the web server to read them.
 
+If you want the keys to be auto generated in `dev` environment, see an example in the
+[docker-entrypoint script of api-platform/demo](https://github.com/api-platform/demo/blob/a03ce4fb1f0e072c126e8104e42a938bb840bffc/api/docker/php/docker-entrypoint.sh#L16-L17).
+
 Since these keys are created by the `root` user from a container, your host user will not be able to read them during
 the `docker compose build caddy` process. Add the `config/jwt/` folder to the `api/.dockerignore` file so that they are
 skipped from the result image.

--- a/core/messenger.md
+++ b/core/messenger.md
@@ -12,8 +12,7 @@ Many transports are supported to dispatch messages to async consumers, including
 To enable the support of Messenger, install the library:
 
 ```console
-docker compose exec php \
-    composer require messenger
+composer require symfony/messenger
 ```
 
 ## Dispatching a Resource through the Message Bus

--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -18,7 +18,7 @@ the legacy [mongo](https://secure.php.net/manual/en/book.mongo.php) extension.
 
 If the `mongodb` PHP extension is not installed yet, [install it beforehand](https://secure.php.net/manual/en/mongodb.installation.pecl.php).
 
-If you are using the [API Platform Distribution](../symfony/index.md), modify the `Dockerfile` to add the extension:
+Or if you are using the [API Platform Distribution with Symfony](../symfony/index.md), modify the `Dockerfile` to add the extension:
 
 ```diff
 # api/Dockerfile
@@ -64,12 +64,11 @@ services:
 # ...
 ```
 
-Once the extension is installed, to enable the MongoDB support, require the [Doctrine MongoDB ODM bundle](https://github.com/doctrine/DoctrineMongoDBBundle)
+In all cases, enable the MongoDB support by requiring the [Doctrine MongoDB ODM bundle](https://github.com/doctrine/DoctrineMongoDBBundle)
 package using Composer:
 
 ```console
-docker compose exec php \
-    composer require doctrine/mongodb-odm-bundle
+composer require doctrine/mongodb-odm-bundle
 ```
 
 Execute the contrib recipe to have it already configured.

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -20,36 +20,31 @@ You can also dump an OpenAPI specification for your API.
 OpenAPI, JSON format:
 
 ```console
-docker compose exec php \
-    bin/console api:openapi:export
+bin/console api:openapi:export
 ```
 
 OpenAPI, YAML format:
 
 ```console
-docker compose exec php \
-    bin/console api:openapi:export --yaml
+bin/console api:openapi:export --yaml
 ```
 
 Create a file containing the specification:
 
 ```console
-docker compose exec php \
-    bin/console api:openapi:export --output=swagger_docs.json
+bin/console api:openapi:export --output=swagger_docs.json
 ```
 
 If you want to use the old OpenAPI v2 (Swagger) JSON format, use:
 
 ```console
-docker compose exec php \
-    bin/console api:swagger:export
+bin/console api:swagger:export
 ```
 
 It is also possible to use OpenAPI v3.0.0 format:
 
 ```console
-docker compose exec php \
-    bin/console api:openapi:export --spec-version=3.0.0
+bin/console api:openapi:export --spec-version=3.0.0
 ```
 
 ## Overriding the OpenAPI Specification

--- a/core/testing.md
+++ b/core/testing.md
@@ -17,8 +17,7 @@ Reuse them to run, for instance, SQL queries or requests to external APIs direct
 Install the `symfony/http-client` and `symfony/browser-kit` packages to enabled the API Platform test client:
 
 ```console
-docker compose exec php \
-    composer require symfony/browser-kit symfony/http-client
+composer require symfony/browser-kit symfony/http-client
 ```
 
 To use the testing client, your test class must extend the `ApiTestCase` class:

--- a/create-client/nextjs.md
+++ b/create-client/nextjs.md
@@ -15,25 +15,34 @@ If you use API Platform, jump to the next section!
 
 Alternatively, create a Next.js application by executing:
 
-```console
-# using pnpm (recommended)
-pnpm create next-app --typescript
-# or using npm
-npm init next-app --typescript
-# or using yarn
-yarn create next-app --typescript
-```
+- Pnpm (recommended)
+    ```console
+    pnpm create next-app --typescript
+    ```
+- Npm
+    ```console
+    npm init next-app --typescript
+    ```
+- Yarn
+    ```console
+    yarn reate next-app --typescript
+    ```
+
 
 Install the required dependencies:
 
-```console
-# using pnpm
-pnpm install isomorphic-unfetch formik react-query
-# or using npm
-npm install isomorphic-unfetch formik react-query
-# or using yarn
-yarn add isomorphic-unfetch formik react-query
-```
+- Pnpm (recommended)
+    ```console
+    pnpm install isomorphic-unfetch formik react-query
+    ```
+- Npm
+    ```console
+    npm install isomorphic-unfetch formik react-query
+    ```
+- Yarn
+    ```console
+    yarn add isomorphic-unfetch formik react-query
+    ```
 
 The generated HTML will contain [Tailwind CSS](https://tailwindcss.com) classes.
 Optionally, [follow the Tailwind installation guide for Next.js projects](https://tailwindcss.com/docs/guides/nextjs)
@@ -41,7 +50,7 @@ Optionally, [follow the Tailwind installation guide for Next.js projects](https:
 
 ## Generating Routes
 
-If you use the API Platform symfony variant, generating all the code you need for a given resource is as simple as running the following command:
+If you are using the [API Platform Distribution with Symfony](../symfony/index.md) generating all the code you need for a given resource is as simple as running the following command:
 
 ```console
 docker compose exec pwa \
@@ -50,16 +59,20 @@ docker compose exec pwa \
 
 Omit the resource flag to generate files for all resource types exposed by the API.
 
-If you don't use the standalone installation, run the following command instead:
+Or if you don't use the standalone installation, run the following command instead:
 
-```console
-# using pnpm
-pnpm create @api-platform/client https://demo.api-platform.com . --generator next --resource book
-# or using npm
-npm init @api-platform/client https://demo.api-platform.com . -- --generator next --resource book
-# or using yarn
-yarn create @api-platform/client https://demo.api-platform.com . --generator next --resource book
-```
+- Pnpm (recommended)
+    ```console
+    pnpm create @api-platform/client https://demo.api-platform.com . --generator next --resource book
+    ```
+- Npm
+    ```console
+    npm init @api-platform/client https://demo.api-platform.com . -- --generator next --resource book
+    ```
+- Yarn
+    ```console
+    yarn create @api-platform/client https://demo.api-platform.com . --generator next --resource book
+    ```
 
 Replace the URL by the entrypoint of your Hydra-enabled API.
 You can also use an OpenAPI documentation with `-f openapi3`.
@@ -85,22 +98,26 @@ export default App;
 
 ## Starting the Project
 
-You can launch the server with
+You can launch the server with:
 
-```console
-# using pnpm
-pnpm dev
-# or using npm
-npm run dev
-# or using yarn
-yarn dev
-```
-
+- Pnpm (recommended)
+    ```console
+    pnpm dev
+    ```
+- Npm
+    ```console
+    npm run dev
+    ```
+- Yarn
+    ```console
+    yarn dev
+    ```
+  
 Go to `http://localhost:3000/books/` to start using your app.
 
 ## Generating a production build locally with docker compose
 
-If you want to generate a production build locally with docker compose, follow [these instructions](../deployment/docker-compose.md)
+If you want to generate a production build locally with docker compose, follow [these instructions](../deployment/docker-compose.md).
 
 ## Screenshots
 

--- a/deployment/docker-compose.md
+++ b/deployment/docker-compose.md
@@ -89,7 +89,7 @@ Go to `https://your-domain-name.example.com` and enjoy!
 
 Alternatively, if you don't want to expose an HTTPS server but only an HTTP one, run the following command:
 
-```bash
+```console
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
 TRUSTED_HOSTS='^localhost|php$' \
@@ -142,7 +142,7 @@ pwa:
 
 Begin by starting the php service container:
 
-```bash
+```console
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
 TRUSTED_HOSTS='^localhost|php$' \
@@ -162,13 +162,13 @@ NEXT_PUBLIC_ENTRYPOINT=http://php
 
 #### 4. Build the pwa service
 
-```bash
+```console
 docker compose -f compose.yaml -f compose.prod.yaml build pwa
 ```
 
 #### 5. Finally, bring up the full project
 
-```bash
+```console
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
 TRUSTED_HOSTS='^localhost|php$' \

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -97,31 +97,31 @@ Go to the `api/` directory, then
 
 1. Initialize a Git repository:
 
-```bash
+```console
 git init
 ```
 
 2. Add all existing files:
 
-```bash
+```console
 git add --all
 ```
 
 3. Commit:
 
-```bash
+```console
 git commit -a -m "My first API Platform app running on Heroku!"
 ```
 
 4. Create the Heroku application:
 
-```bash
+```console
 heroku create
 ```
 
 5. And deploy for the first time:
 
-```bash
+```console
 git push heroku master
 ```
 

--- a/deployment/kubernetes.md
+++ b/deployment/kubernetes.md
@@ -45,7 +45,7 @@ docker build -t gcr.io/test-api-platform/pwa:0.1.0 -t gcr.io/test-api-platform/p
 
 Optional: If your pwa project use Static Site Generation (SSG) and you need to build it against the API running locally, you can build the pwa with the command below.
 
-```bash
+```console
 docker build -t gcr.io/test-api-platform/pwa:0.1.0 -t gcr.io/test-api-platform/pwa:latest pwa --target prod --network=host --add-host php=127.0.0.1
 ```
 

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -62,7 +62,7 @@ First, install the [skaffold CLI](https://skaffold.dev/docs/install/#standalone-
 
 Then, run minikube:
 
-```bash
+```console
 minikube start
 ```
 
@@ -70,7 +70,7 @@ Add Skaffold configuration in the file `./helm/skaffold.yaml`. You can find a [c
 
 Finally, go to the helm folder, and run skaffold in dev mode:
 
-```bash
+```console
 cd ./helm
 skaffold dev
 ```

--- a/deployment/traefik.md
+++ b/deployment/traefik.md
@@ -453,7 +453,7 @@ We assume that you've set `EXPOSE 3000` in your client and admin Dockerfile.
 
 Create a new `init-dc.sh` which contains the generation code that will be written in `compose.override.yaml` file.
 
-```bash
+```console
 #!/bin/sh
 # /anywhere/api-platform/init-dc.sh
 

--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -2,15 +2,15 @@
 
 ## Installation
 
-If you use [the API Platform Symfony variant](../symfony/index.md), the Schema Generator is already installed as a development
-dependency of your project and can be invoked through Docker:
+If you use [the API Platform Distribution with Symfony](../symfony/index.md), the Schema Generator is already installed
+as a development dependency of your project and can be invoked with:
 
 ```console
-docker compose exec php \
-    vendor/bin/schema
+vendor/bin/schema
 ```
 
-The Schema Generator can also [be downloaded independently as a PHAR](https://github.com/api-platform/schema-generator/releases) or installed in an existing project using [Composer](https://getcomposer.org):
+The Schema Generator can also [be downloaded independently as a PHAR](https://github.com/api-platform/schema-generator/releases)
+or installed in an existing project using [Composer](https://getcomposer.org):
 
 ```console
 composer require --dev api-platform/schema-generator
@@ -104,8 +104,7 @@ vendor/bin/schema generate api/src/ api/config/schema.yaml -vv
 Using [the API Platform Symfony variant](../symfony/index.md):
 
 ```console
-docker compose exec php \
-    vendor/bin/schema generate src/ config/schema.yaml -vv
+vendor/bin/schema generate src/ config/schema.yaml -vv
 ```
 
 The corresponding PHP classes will be automatically generated in the `src/` directory!

--- a/symfony/index.md
+++ b/symfony/index.md
@@ -147,6 +147,11 @@ That being said, keep in mind that API Platform is 100% independent of the persi
 best suit(s) your needs (including NoSQL databases or remote web services) by implementing the [right interfaces](../core/state-providers.md). API Platform even supports using several persistence
 systems together in the same project.
 
+> [!TIP]
+> The `php` container is where your API app stands. Prefixing a command by `docker compose exec php` allows executing the
+> given command in this container. You may want [to create an alias](https://www.linfo.org/alias.html) to make your life easier.
+> So, for example, you could run a command like this: `docker compose exec php <command>`.
+
 ### Using Symfony CLI
 
 Alternatively, the API Platform server component can also be installed directly on a local machine.
@@ -451,8 +456,7 @@ Modify these files as described in these patches:
 **Tip**: you can also use Symfony [MakerBundle](https://symfonycasts.com/screencast/symfony-fundamentals/maker-command?cid=apip) thanks to the `--api-resource` option:
 
 ```console
-docker compose exec php \
-    bin/console make:entity --api-resource
+bin/console make:entity --api-resource
 ```
 
 Doctrine's [attributes](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/attributes-reference.html) map these entities to tables in the database.
@@ -467,14 +471,9 @@ Now, delete the file `api/src/Entity/Greeting.php`. This demo entity isn't usefu
 Finally, generate a new database migration using [Doctrine Migrations](https://symfony.com/doc/current/doctrine.html#migrations-creating-the-database-tables-schema) and apply it:
 
 ```console
-docker compose exec php \
-    bin/console doctrine:migrations:diff
-docker compose exec php \
-    bin/console doctrine:migrations:migrate
+bin/console doctrine:migrations:diff
+bin/console doctrine:migrations:migrate
 ```
-
-The `php` container is where your API app stands. Prefixing a command by `docker compose exec php` allows executing the
-given command in this container. You may want [to create an alias](https://www.linfo.org/alias.html) to make your life easier.
 
 **We now have a working API with read and write capabilities!**
 
@@ -667,13 +666,11 @@ Isn't API Platform a REST **and** GraphQL framework? That's true! GraphQL suppor
 need to install the [graphql-php](https://webonyx.github.io/graphql-php/) library. Run the following command:
 
 ```console
-docker compose exec php sh -c '
-    composer require webonyx/graphql-php
-    bin/console cache:clear
-'
+composer require api-platform/graphql
 ```
 
-You now have a GraphQL API! Open `https://localhost/graphql` (or `https://localhost/api/graphql` if you used Symfony Flex to install API Platform) to play with it using the nice [GraphiQL](https://github.com/graphql/graphiql)
+You now have a GraphQL API! Open `https://localhost/graphql` (or `https://localhost/api/graphql` if you used Symfony Flex
+to install API Platform) to play with it using the nice [GraphiQL](https://github.com/graphql/graphiql)
 UI that is shipped with API Platform:
 
 ![GraphQL endpoint](images/api-platform-2.6-graphql.png)

--- a/symfony/testing.md
+++ b/symfony/testing.md
@@ -23,8 +23,7 @@ Before creating your functional tests, you will need a dataset to pre-populate y
 First, install [Foundry](https://github.com/zenstruck/foundry) and [Doctrine/DoctrineFixturesBundle](https://github.com/doctrine/DoctrineFixturesBundle):
 
 ```console
-docker compose exec php \
-    composer require --dev foundry orm-fixtures
+composer require --dev foundry orm-fixtures
 ```
 
 Thanks to Symfony Flex, [DoctrineFixturesBundle](https://github.com/doctrine/DoctrineFixturesBundle) and [Foundry](https://github.com/zenstruck/foundry) are ready to use!
@@ -32,10 +31,8 @@ Thanks to Symfony Flex, [DoctrineFixturesBundle](https://github.com/doctrine/Doc
 Then, create some factories for [the bookstore API you created in the tutorial](index.md):
 
 ```console
-docker compose exec php \
-    bin/console make:factory 'App\Entity\Book'
-docker compose exec php \
-    bin/console make:factory 'App\Entity\Review'
+bin/console make:factory 'App\Entity\Book'
+bin/console make:factory 'App\Entity\Review'
 ```
 
 Improve the default values:
@@ -79,10 +76,8 @@ use function Zenstruck\Foundry\lazy;
 Create some stories:
 
 ```console
-docker compose exec php \
-    bin/console make:story 'DefaultBooks'
-docker compose exec php \
-    bin/console make:story 'DefaultReviews'
+bin/console make:story 'DefaultBooks'
+bin/console make:story 'DefaultReviews'
 ```
 
 ```php
@@ -144,8 +139,7 @@ class AppFixtures extends Fixture
 You can now load your fixtures in the database with the following command:
 
 ```console
-docker compose exec php \
-    bin/console doctrine:fixtures:load
+bin/console doctrine:fixtures:load
 ```
 
 To learn more about fixtures, take a look at the documentation of [Foundry](https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html).
@@ -162,8 +156,7 @@ If you don't use the distribution, run `composer require --dev symfony/test-pack
 Install [DAMADoctrineTestBundle](https://github.com/dmaicher/doctrine-test-bundle) to reset the database automatically before each test:
 
 ```console
-docker compose exec php \
-    composer require --dev dama/doctrine-test-bundle
+composer require --dev dama/doctrine-test-bundle
 ```
 
 And activate it in the `phpunit.xml.dist` file:
@@ -179,11 +172,11 @@ And activate it in the `phpunit.xml.dist` file:
 </phpunit>
 ```
 
-Optionally, you can install [JSON Schema for PHP](https://github.com/justinrainbow/json-schema) if you want to use the [JSON Schema](https://json-schema.org) test assertions provided by API Platform:
+Optionally, you can install [JSON Schema for PHP](https://github.com/justinrainbow/json-schema) if you want to use the
+[JSON Schema](https://json-schema.org) test assertions provided by API Platform:
 
 ```console
-docker compose exec php \
-    composer require --dev justinrainbow/json-schema
+composer require --dev justinrainbow/json-schema
 ```
 
 Your API is now ready to be functionally tested. Create your test classes under the `tests/` directory.
@@ -345,8 +338,7 @@ There is one caveat though: in some tests, it is necessary to perform multiple r
 All you have to do now is to run your tests:
 
 ```console
-docker compose exec php \
-    bin/phpunit
+bin/phpunit
 ```
 
 If everything is working properly, you should see `OK (5 tests, 17 assertions)`.


### PR DESCRIPTION
Partially solves #1995 by solving these 2 subtasks : 
- "Remove all `docker compose` prefixes for commands, as we don't use Docker for Laravel"
- "Explain how to run commands with Symfony and Docker in the `symfony/index.md`"

:warning:  Don't forget to check the checkbox in the issue if the PR is merged