### PR TITLE
Update minikube.md

### DIFF
--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -34,8 +34,8 @@ docker build -t localhost:5000/pwa pwa --target prod
 Then push the images in the registry available in minikube:
 
 ```console
-    docker push localhost:5000/php
-    docker push localhost:5000/pwa
+docker push localhost:5000/php
+docker push localhost:5000/pwa
 ```
     
 ## Deploying

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -22,7 +22,7 @@ On GNU/Linux and macOS, run the following command following command to point you
 eval $(minikube docker-env)
 ```
 
-Now any `docker` command you run in this current terminal will run against the docker inside minikube cluster. For detailed explanation and instructions for Windows [visit official minikube documentation](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env).
+Now any `docker` command you run in this current terminal will run against the Docker Engine inside the minikube cluster. For detailed explanation and instructions for Windows [visit official minikube documentation](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env).
 
 Build the images in minikube:
 

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -43,8 +43,8 @@ docker push localhost:5000/pwa
 Fetch Helm chart dependencies:
 
 ```console
-    helm repo add postgresql https://charts.bitnami.com/bitnami/
-    helm dependency build helm/api-platform
+helm repo add postgresql https://charts.bitnami.com/bitnami/
+helm dependency build helm/api-platform
 ```
     
 Finally, deploy the project using the Helm chart:

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -27,8 +27,8 @@ Now any `docker` command you run in this current terminal will run against the D
 Build the images in minikube:
 
 ```console
-    docker build -t localhost:5000/php api --target frankenphp_prod
-    docker build -t localhost:5000/pwa pwa --target prod
+docker build -t localhost:5000/php api --target frankenphp_prod
+docker build -t localhost:5000/pwa pwa --target prod
 ```
     
 Then push the images in the registry installed in Minikube:

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -16,7 +16,7 @@ Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to de
 
 ## Building and Pushing Docker Images
 
-On GNU/Linux and macOS, to point your terminal to use the docker daemon inside minikube run this:
+On GNU/Linux and macOS, run the following command following command to point your terminal’s docker-cli to the Docker Engine inside minikube:
 
 ```console
     eval $(minikube docker-env)

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -31,7 +31,7 @@ docker build -t localhost:5000/php api --target frankenphp_prod
 docker build -t localhost:5000/pwa pwa --target prod
 ```
     
-Then push the images in the registry installed in Minikube:
+Then push the images in the registry available in minikube:
 
 ```console
     docker push localhost:5000/php

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -12,40 +12,49 @@ minikube start --addons registry --addons dashboard
 
 The previous command starts Minikube with a Docker registry (we'll use it in the next step) and with the Kubernetes dashboard.
 
-If you use Mac or Windows, [refer to the documentation](https://minikube.sigs.k8s.io/docs/handbook/registry/#docker-on-macos) to learn how to expose the Docker registry installed as an addon on the port 5000 of the host.
-
 Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to deploy the application in the cluster thanks to the chart provided in the API Platform distribution.
 
 ## Building and Pushing Docker Images
 
-First, build the images:
+On GNU/Linux and macOS, to point your terminal to use the docker daemon inside minikube run this:
 
 ```console
-docker build -t localhost:5000/php api --target api_platform_php
-docker build -t localhost:5000/caddy api --target api_platform_caddy
-docker build -t localhost:5000/pwa pwa --target api_platform_pwa_prod
+    eval $(minikube docker-env)
 ```
 
+Now any `docker` command you run in this current terminal will run against the docker inside minikube cluster. For detailed explanation and instructions for Windows [visit official minikube documentation](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env).
+
+Build the images in minikube:
+
+```console
+    docker build -t localhost:5000/php api --target frankenphp_prod
+    docker build -t localhost:5000/pwa pwa --target prod
+```
+    
 Then push the images in the registry installed in Minikube:
 
 ```console
-docker push localhost:5000/php
-docker push localhost:5000/caddy
-docker push localhost:5000/pwa
+    docker push localhost:5000/php
+    docker push localhost:5000/pwa
 ```
-
+    
 ## Deploying
 
+Fetch Helm chart dependencies:
+
+```console
+    helm repo add postgresql https://charts.bitnami.com/bitnami/
+    helm dependency build helm/api-platform
+```
+    
 Finally, deploy the project using the Helm chart:
 
 ```console
-$ helm install my-project helm/api-platform \
-  --set php.image.repository=localhost:5000/php \
-  --set php.image.tag=latest \
-  --set caddy.image.repository=localhost:5000/caddy \
-  --set caddy.image.tag=latest \
-  --set pwa.image.repository=localhost:5000/pwa \
-  --set pwa.image.tag=latest
+    helm install my-project helm/api-platform \
+      --set php.image.repository=localhost:5000/php \
+      --set php.image.tag=latest \
+      --set pwa.image.repository=localhost:5000/pwa \
+      --set pwa.image.tag=latest
 ```
 
 Copy and paste the commands displayed in the terminal to enable the port forwarding then go to `http://localhost:8080` to access your application!

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -1,8 +1,8 @@
-# Deploying to Minikube
+# Deploying to minikube
 
-## Install Minikube
+## Install minikube
 
-If you have no existing installation of Minikube on your computer, [follow the official tutorial](https://minikube.sigs.k8s.io/docs/start/).
+If you have no existing installation of minikube on your computer, [follow the official tutorial](https://minikube.sigs.k8s.io/docs/start/).
 
 When Minikube is installed, start the cluster:
 
@@ -10,7 +10,7 @@ When Minikube is installed, start the cluster:
 minikube start --addons registry --addons dashboard
 ```
 
-The previous command starts Minikube with a Docker registry (we'll use it in the next step) and with the Kubernetes dashboard.
+The previous command starts minikube with a Docker registry (we'll use it in the next step) and with the Kubernetes dashboard.
 
 Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to deploy the application in the cluster thanks to the chart provided in the API Platform distribution.
 
@@ -30,14 +30,14 @@ Build the images in minikube:
 docker build -t localhost:5000/php api --target frankenphp_prod
 docker build -t localhost:5000/pwa pwa --target prod
 ```
-    
+
 Then push the images in the registry available in minikube:
 
 ```console
 docker push localhost:5000/php
 docker push localhost:5000/pwa
 ```
-    
+
 ## Deploying
 
 Fetch Helm chart dependencies:
@@ -46,7 +46,7 @@ Fetch Helm chart dependencies:
 helm repo add postgresql https://charts.bitnami.com/bitnami/
 helm dependency build helm/api-platform
 ```
-    
+
 Finally, deploy the project using the Helm chart:
 
 ```console

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -50,11 +50,11 @@ helm dependency build helm/api-platform
 Finally, deploy the project using the Helm chart:
 
 ```console
-    helm install my-project helm/api-platform \
-      --set php.image.repository=localhost:5000/php \
-      --set php.image.tag=latest \
-      --set pwa.image.repository=localhost:5000/pwa \
-      --set pwa.image.tag=latest
+helm install my-project helm/api-platform \
+  --set php.image.repository=localhost:5000/php \
+  --set php.image.tag=latest \
+  --set pwa.image.repository=localhost:5000/pwa \
+  --set pwa.image.tag=latest
 ```
 
 Copy and paste the commands displayed in the terminal to enable the port forwarding then go to `http://localhost:8080` to access your application!

--- a/deployment/minikube.md
+++ b/deployment/minikube.md
@@ -19,7 +19,7 @@ Finally, [install Helm](https://helm.sh/docs/intro/install/). We'll use it to de
 On GNU/Linux and macOS, run the following command following command to point your terminal’s docker-cli to the Docker Engine inside minikube:
 
 ```console
-    eval $(minikube docker-env)
+eval $(minikube docker-env)
 ```
 
 Now any `docker` command you run in this current terminal will run against the docker inside minikube cluster. For detailed explanation and instructions for Windows [visit official minikube documentation](https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env).


### PR DESCRIPTION
Recently I used [Helm chart from api-platform](https://github.com/api-platform/api-platform) in [my little project](https://github.com/k-37/dolphin-is-symfony-ddd-experiment#locally-to-minikube). Along the way I discovered that documentation on `minikube.md` page is obsolete. Proposed changes are what I had to do to make it work on Debian 12.