### PR TITLE
Correction to upgrade guide

### DIFF
--- a/core/upgrade-guide.md
+++ b/core/upgrade-guide.md
@@ -51,8 +51,9 @@ Standard PUT is now `true` by default, you can change its value using:
 
 ```yaml
 api_platform:
-  extra_properties:
-    standard_put: true
+  default:
+    extra_properties:
+      standard_put: true
 ```
 
 We recommend using the standalone API Platform packages instead of the Core monolithic repository.

--- a/core/upgrade-guide.md
+++ b/core/upgrade-guide.md
@@ -51,7 +51,7 @@ Standard PUT is now `true` by default, you can change its value using:
 
 ```yaml
 api_platform:
-  default:
+  defaults:
     extra_properties:
       standard_put: true
 ```


### PR DESCRIPTION
Update to upgrade guide - 

extra_properties should live under 'default:'

