### PR TITLE
docs(contributing): fix broken link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Before submitting your issue:
 
 ## Code of Conduct
 
-By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/api-platform/docs#contributor-code-of-conduct). We expect all contributors to foster a welcoming and inclusive environment.
+By contributing to this project, you agree to abide by our [Code of Conduct](https://github.com/api-platform/docs#coc-ov-file). We expect all contributors to foster a welcoming and inclusive environment.
 
 ## How to Contribute
 


### PR DESCRIPTION
Since we have a README.md file (#2050), the code of conduct is not in the first index page, so the link to the current code of conduct, using the header, is broken. It's more reliable to point to it using ` #coc-ov-file`.

