### PR TITLE
docs(pagination): support for laravel and reorganize

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -43,12 +43,29 @@ of total items in the collection.
 
 The name of the page parameter can be changed with the following configuration:
 
+## Changing page parameter name with Symfony
+
 ```yaml
 # api/config/packages/api_platform.yaml
 api_platform:
   collection:
     pagination:
       page_parameter_name: _page
+```
+
+## Changing page parameter name with Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'collection' => [
+        'pagination' => [
+            'page_parameter_name' => '_page',
+        ]
+    ],
+];
 ```
 
 ## Disabling the Pagination
@@ -59,6 +76,8 @@ However, for small collections, it can be convenient to fully disable the pagina
 
 ### Disabling the Pagination Globally
 
+#### Disabling the Pagination Globally with Symfony
+
 The pagination can be disabled for all resources using this configuration:
 
 ```yaml
@@ -66,6 +85,21 @@ The pagination can be disabled for all resources using this configuration:
 api_platform:
   defaults:
     pagination_enabled: false
+```
+
+#### Disabling the Pagination Globally with Laravel
+
+The pagination can be disabled for all resources using this configuration:
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_enabled' => false,
+    ],
+];
 ```
 
 ### Disabling the Pagination For a Specific Resource
@@ -76,8 +110,8 @@ It can also be disabled for a specific resource:
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -90,8 +124,9 @@ class Book
 
 ```yaml
 # api/config/api_platform/resources.yaml
+# The YAML syntax is only supported for Symfony
 resources:
-  App\Entity\Book:
+  App\ApiResource\Book:
     paginationEnabled: false
 ```
 
@@ -105,7 +140,7 @@ You can also disable an operation for a specific operation:
 
 ```php
 <?php
-// api/src/Entity/Book.php
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
 namespace App\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
@@ -126,8 +161,9 @@ class Book
 
 ```yaml
 # api/config/api_platform/resources.yaml
+# The YAML syntax is only supported for Symfony
 resources:
-  App\Entity\Book:
+  App\ApiResource\Book:
     operations:
       ApiPlatform\Metadata\GetCollection:
         paginationEnabled: false
@@ -135,13 +171,14 @@ resources:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- The XML syntax is only supported for Symfony -->
 <!-- api/config/api_platform/resources.xml -->
 
 <resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
         https://api-platform.com/schema/metadata/resources-3.0.xsd">
-    <resource class="App\Entity\Book">
+    <resource class="App\ApiResource\Book">
         <operations>
             <operation class="ApiPlatform\Metadata\GetCollection"
                        paginationEnabled="false" />
@@ -156,17 +193,48 @@ resources:
 
 #### Disabling the Pagination Client-side Globally
 
-You can configure API Platform to let the client enable or disable the pagination. To activate this feature globally,
-use the following configuration:
+You can configure API Platform to let the client enable or disable the pagination.
+
+##### Disabling the Pagination Client-side Globally with Symfony
+
+To configure this feature globally, use the following configuration:
 
 ```yaml
 # api/config/packages/api_platform.yaml
 api_platform:
   defaults:
-    pagination_client_enabled: true
+    pagination_client_enabled: false
   collection:
     pagination:
       enabled_parameter_name: pagination # optional
+```
+
+The pagination can now be enabled or disabled by adding a query parameter named `pagination`:
+
+- `GET /books?pagination=false`: disabled
+- `GET /books?pagination=true`: enabled
+
+Any value accepted by the [`FILTER_VALIDATE_BOOLEAN`](https://www.php.net/manual/en/filter.filters.validate.php) filter can be
+used as the value.
+
+##### Disabling the Pagination Client-side Globally with Laravel
+
+To configure this feature globally, use the following configuration:
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_client_enabled' => false,
+    ],
+    'collection' => [
+        'pagination' => [
+            'enabled_parameter_name' => 'pagination', // optional
+        ],
+    ],
+];
 ```
 
 The pagination can now be enabled or disabled by adding a query parameter named `pagination`:
@@ -183,8 +251,8 @@ The client ability to disable the pagination can also be set in the resource con
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -201,7 +269,9 @@ In the same manner, the number of items per page is configurable and can be set 
 
 ### Changing the Number of Items per Page Globally
 
-The number of items per page can be configured for all resources:
+The number of items per page can be configured for all resources.
+
+#### Changing the Number of Items per Page Globally with Symfony
 
 ```yaml
 # api/config/packages/api_platform.yaml
@@ -210,12 +280,25 @@ api_platform:
     pagination_items_per_page: 30 # Default value
 ```
 
+#### Changing the Number of Items per Page Globally with Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_items_per_page' => 30,
+    ],
+];
+```
+
 ### Changing the Number of Items per Page For a Specific Resource
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -230,6 +313,8 @@ class Book
 
 #### Changing the Number of Items per Page Client-side Globally
 
+#### Changing the Number of Items per Page Client-side Globally using Symfony
+
 ```yaml
 # api/config/packages/api_platform.yaml
 api_platform:
@@ -242,14 +327,34 @@ api_platform:
 
 The number of items per page can now be changed adding a query parameter named `itemsPerPage`: `GET /books?itemsPerPage=20`.
 
+#### Changing the Number of Items per Page Client-side Globally using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_client_items_per_page' => true,
+    ],
+    'collection' => [
+        'pagination' => [
+            'items_per_page_parameter_name' => 'itemsPerPage',
+        ],
+    ],
+];
+```
+
+The number of items per page can now be changed adding a query parameter named `itemsPerPage`: `GET /books?itemsPerPage=20`.
+
 #### Changing the Number of Items per Page Client-side For a Specific Resource
 
 Changing the number of items per page can be enabled (or disabled) for a specific resource:
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -264,7 +369,9 @@ class Book
 
 ### Changing Maximum Items Per Page Globally
 
-The number of maximum items per page can be configured for all resources:
+The number of maximum items per page can be configured for all resources.
+
+#### Changing Maximum Items Per Page Globally using Symfony
 
 ```yaml
 # api/config/packages/api_platform.yaml
@@ -273,12 +380,25 @@ api_platform:
     pagination_maximum_items_per_page: 50
 ```
 
+#### Changing Maximum Items Per Page Globally using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_maximum_items_per_page' => 50,
+    ],
+];
+```
+
 ### Changing Maximum Items Per Page For a Specific Resource
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -293,8 +413,8 @@ class Book
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
@@ -310,11 +430,13 @@ class Book
 ## Partial Pagination
 
 When using the default pagination, a `COUNT` query will be issued against the current requested collection. This may have a
-performance impact on really big collections. The downside is that the information about the last page is lost (ie: `last`).
+performance impact on huge collections. The downside is that the information about the last page is lost (ie: `last`).
 
 ### Partial Pagination Globally
 
-The partial pagination retrieval can be configured for all resources:
+The partial pagination retrieval can be configured for all resources.
+
+#### Partial Pagination Globally using Symfony
 
 ```yaml
 # api/config/packages/api_platform.yaml
@@ -324,12 +446,25 @@ api_platform:
     pagination_partial: true # Disabled by default
 ```
 
+#### Partial Pagination Globally using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_partial' => true, // Disabled by default
+    ],
+];
+```
+
 ### Partial Pagination For a Specific Resource
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -344,6 +479,8 @@ class Book
 
 #### Partial Pagination Client-side Globally
 
+##### Partial Pagination Client-side Globally using Symfony
+
 ```yaml
 # api/config/packages/api_platform.yaml
 
@@ -357,12 +494,32 @@ api_platform:
 
 The partial pagination retrieval can now be changed by toggling a query parameter named `partial`: `GET /books?partial=true`.
 
+##### Partial Pagination Client-side Globally using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ....
+    'defaults' => [
+        'pagination_client_partial' => true, // Disabled by default
+    ],
+    'collection' => [
+        'pagination' => [
+            'partial_parameter_name' => 'partial' // Default value
+        ],
+    ],
+];
+```
+
+The partial pagination retrieval can now be changed by toggling a query parameter named `partial`: `GET /books?partial=true`.
+
 #### Partial Pagination Client-side For a Specific Resource
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiResource;
 
@@ -375,15 +532,16 @@ class Book
 
 ## Cursor-Based Pagination
 
-To configure your resource to use the cursor-based pagination, select your unique sorted field as well as the direction you’ll like the pagination to go via filters and enable the `paginationViaCursor` option.
+To configure your resource to use the cursor-based pagination, select your unique sorted field as well as the direction
+you’ll like the pagination to go via filters and enable the `paginationViaCursor` option.
 Note that for now you have to declare a `RangeFilter` and an `OrderFilter` on the property used for the cursor-based pagination.
 
 The following configuration also works on a specific operation:
 
 ```php
 <?php
-// api/src/Entity/Book.php
-namespace App\Entity;
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
 
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
@@ -406,9 +564,22 @@ class Book
 
 To know more about cursor-based pagination take a look at [this blog post on medium (draft)](https://medium.com/@sroze/74fd1d324723).
 
+## Pagination for Custom State Providers
+
+If you are using custom state providers (not the provided Doctrine ORM, Doctrine ODM,  ElasticSearch or Laravel Eloquent ones)
+and if you want your results to be paginated, you will need to return an instance of a
+`ApiPlatform\State\Pagination\PartialPaginatorInterface` or
+`ApiPlatform\State\Pagination\PaginatorInterface`.
+A few existing classes are provided to make it easier to paginate the results:
+
+- `ApiPlatform\State\Pagination\ArrayPaginator`
+- `ApiPlatform\State\Pagination\TraversablePaginator`
+
 ## Controlling The Behavior of The Doctrine ORM Paginator
 
-The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Doctrine/Orm/Extension/PaginationExtension.php) of API Platform performs some checks on the `QueryBuilder` to guess, in most common cases, the correct values to use when configuring the Doctrine ORM Paginator:
+The [PaginationExtension](https://github.com/api-platform/core/blob/main/src/Doctrine/Orm/Extension/PaginationExtension.php)
+of API Platform performs some checks on the `QueryBuilder` to guess, in most common cases, the correct values to use when
+configuring the Doctrine ORM Paginator:
 
 - `$fetchJoinCollection` argument: Whether there is a join to a collection-valued association. When set to `true`, the Doctrine ORM Paginator will perform an additional query, in order to get the correct number of results.
 
@@ -454,7 +625,7 @@ class Book
 
 For more information, please see the [Pagination](https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/pagination.html) entry in the Doctrine ORM documentation.
 
-## Custom Controller Action
+## Custom Symfony Controller Action
 
 In case you're using a custom controller action, make sure you return the `Paginator` object to get the full Hydra response with `view` (which contains information about first, last, next and previous page). The following examples show how to handle it within a repository method.
 The controller needs to pass through the page number. You will need to use the Doctrine Paginator and pass it to the API Platform Paginator.
@@ -578,13 +749,3 @@ class BookRepository extends ServiceEntityRepository
 }
 ```
 
-## Pagination for Custom State Providers
-
-If you are using custom state providers (not the provided Doctrine ORM, ODM or ElasticSearch ones)
-and if you want your results to be paginated, you will need to return an instance of a
-`ApiPlatform\State\Pagination\PartialPaginatorInterface` or
-`ApiPlatform\State\Pagination\PaginatorInterface`.
-A few existing classes are provided to make it easier to paginate the results:
-
-- `ApiPlatform\State\Pagination\ArrayPaginator`
-- `ApiPlatform\State\Pagination\TraversablePaginator`


### PR DESCRIPTION
As seen with @dunglas, it's better to use `App\ApiResource` instead of `App\Entity` to suit Symfony and Laravel.
It avoids making the equivalence between models and entities in code examples (namespaces among others). 

By the way, I've adapted the comments to be compatible with the 2 as well, so
`// api/src/Entity/Book.php` becomes `// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel`.