### PR TITLE
refactor(ext): move doctrine extensions from core to symfony

### DIFF
--- a/core/extensions.md
+++ b/core/extensions.md
@@ -1,4 +1,7 @@
-# Extensions
+# Extensions for Doctrine and Elasticsearch
+
+> [!WARNING]
+> This is not yet available with [Eloquent](https://laravel.com/docs/eloquent), you're welcome to contribute [on GitHub](https://github.com/api-platform/core)
 
 API Platform provides a system to extend queries on items and collections.
 
@@ -127,7 +130,7 @@ Note that your extensions should have a positive priority if defined. Internal e
 | `api_platform.doctrine.orm.query_extension.order`                      | -32      | ApiPlatform\Doctrine\Orm\Extension\OrderExtension              |
 | `api_platform.doctrine.orm.query_extension.pagination`                 | -64      | ApiPlatform\Doctrine\Orm\Extension\PaginationExtension         |
 
-#### Blocking Anonymous Users
+#### Blocking Anonymous Users using Symfony
 
 This example adds a `WHERE` clause condition only when a fully authenticated user without `ROLE_ADMIN` tries to access a resource. It means that anonymous users will be able to access all data. To prevent this potential security issue, the API must ensure that the current user is authenticated.
 

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -19,7 +19,8 @@ composer require api-platform/graphql
 You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 
 > [!NOTE]
-> If you used [the Symfony Variant thanks to Symfony Flex](../symfony/index.md#using-symfony-flex-and-composer-advanced-users) or the Laravel variant, URLs will be prefixed with `/api` by default. For example, the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
+> If you used [the Symfony Variant thanks to Symfony Flex](../symfony/index.md#installing-the-framework)
+> or the Laravel variant, URLs will be prefixed with `/api` by default. For example, the GraphQL endpoint will be: `https://localhost:8443/api/graphql`.
 
 ## Changing Location of the GraphQL Endpoint
 
@@ -138,7 +139,7 @@ api_platform:
 ### Disable GraphQL Playground with Laravel
 
 > [!WARNING]
-> This is not yet available with Laravel, you're welcome to contribute [on Github](github.com/api-platform/core)
+> This is not yet available with Laravel, you're welcome to contribute [on GitHub](https://github.com/api-platform/core)
 
 ### Add another Location for GraphQL Playground
 
@@ -1100,7 +1101,7 @@ resources:
 
 ### Syntax for Filters with a List of Key / Value Arguments
 
-Some filters like the [exists filter](filters.md#exists-filter) or the [order filter](filters.md#order-filter-sorting) take a list of key / value as arguments.
+Some filters like the [exists filter](doctrine-filters.md#exists-filter) or the [order filter](doctrine-filters.md#order-filter-sorting) take a list of key / value as arguments.
 
 The first syntax coming to mind to use them is to write:
 
@@ -1387,7 +1388,8 @@ resources:
 
 </code-selector>
 
-Once enabled, a `page` filter will be available in the collection query (its name [can be changed in the configuration](pagination.md)) and an `itemsPerPage` filter will be available too if [client-side-pagination](pagination.md#client-side) is enabled.
+Once enabled, a `page` filter will be available in the collection query (its name [can be changed in the configuration](pagination.md))
+and an `itemsPerPage` filter will be available too if [client-side-pagination](pagination.md#changing-the-number-of-items-per-page-for-a-specific-resource) is enabled.
 
 A `paginationInfo` field can be queried to obtain the following information:
 
@@ -2812,7 +2814,7 @@ final class BookContextBuilder implements SerializerContextBuilderInterface
 ## Export the Schema in SDL
 
 > [!WARNING]
-> This command is not yet available with Laravel, you're welcome to contribute [on Github](github.com/api-platform/core)
+> This command is not yet available with Laravel, you're welcome to contribute [on GitHub](https://github.com/api-platform/core)
 
 You may need to export your schema in SDL (Schema Definition Language) to import it in some tools.
 

--- a/core/subresources.md
+++ b/core/subresources.md
@@ -348,7 +348,7 @@ class Company {
 ## Security
 
 > [!WARNING]
-> This is not yet available with Laravel, you're welcome to contribute [on Github](github.com/api-platform/core)
+> This is not yet available with Laravel, you're welcome to contribute [on GitHub](https://github.com/api-platform/core)
 
 In order to use Symfony's built-in security system on subresources the security option of the `Link` attribute can be used.
 


### PR DESCRIPTION
As seen with @dunglas, [Doctrine extensions documentation ](https://api-platform.com/docs/core/extensions/) should be in "API PLATFORM FOR SYMFONY" section.

**EDIT:
We'll leave the extensions in `core`, but explain better that it's for doctrine & elasticsearch only.**

:information_source: Also fix several links