### PR TITLE
Fix duplicate "Creating Custom Doctrine ORM filters" heading in documentation

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -411,7 +411,7 @@ If you need more information about creating custom filters, refer to the followi
 
 - [Creating Custom Doctrine ORM filters](../core/doctrine-filters.md#creating-custom-doctrine-orm-filters)
 - [Creating Custom Doctrine Mongo ODM filters](../core/doctrine-filters.md#creating-custom-doctrine-mongodb-odm-filters)
-- [Creating Custom Doctrine ORM filters](../core/elasticsearch-filters.md#creating-custom-elasticsearch-filters)
+- [Creating Custom Elasticsearch Filters](../core/elasticsearch-filters.md#creating-custom-elasticsearch-filters)
 
 ## ApiFilter Attribute
 


### PR DESCRIPTION

**Description:**

This PR fixes a typo in the documentation where the "Creating Custom Doctrine ORM filters" heading is duplicated. The second heading, which links to the Elasticsearch filters documentation (https://api-platform.com/docs/core/elasticsearch-filters/#creating-custom-elasticsearch-filters), is incorrectly labeled as "Creating Custom Doctrine ORM filters."


**Changes:**

Updated the second duplicate heading to "Creating Custom Elasticsearch filters" for clarity and accuracy.


**Why this change is needed:**

The duplicate heading may confuse users, as the content under the second heading pertains to Elasticsearch filters rather than Doctrine ORM filters. Correcting this ensures the documentation is clear and easy to navigate.

Checklist:

- Reviewed and verified changes locally
- Confirmed that the link points to the correct documentation section


![image](https://github.com/user-attachments/assets/1733bb37-ee3e-477f-935c-316bfb073871)
