### PR TITLE
docs(entity): move from core to symfony

### DIFF
--- a/core/index.md
+++ b/core/index.md
@@ -34,7 +34,7 @@ Here is the fully featured REST API you'll get in minutes:
 - Advanced [serialization](serialization.md) thanks to the Symfony Serializer Component (groups support, relation embedding, max depth...)
 - Automatic route registration
 - Automatic entry point generation giving access to all resources
-- [User](user.md) support
+- [User Management using Symfony](../symfony/user.md)
 - [JWT](jwt.md) and [OAuth](https://oauth.net/) support
 - Files and `\DateTime` and serialization and deserialization
 

--- a/outline.yaml
+++ b/outline.yaml
@@ -12,6 +12,7 @@ chapters:
       - migrate-from-fosrestbundle
       - fosuser-bundle
       - nelmio-api-doc
+      - user
   - title: "API Platform for Laravel"
     path: laravel
     items:
@@ -64,7 +65,6 @@ chapters:
       - events
       - file-upload
       - jwt
-      - user
       - form-data
       - bootstrap
       - configuration

--- a/symfony/user.md
+++ b/symfony/user.md
@@ -1,4 +1,4 @@
-# User Entity
+# User Entity with Symfony
 
 This documentation is based on the [official Symfony Documentation](https://symfony.com/doc/current/security/user_providers.html) with some API Platform integrations.
 
@@ -219,7 +219,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
 ## Creating and Updating User Password
 
 There's no built-in way for hashing the plain password on `POST`, `PUT` or `PATCH`.
-Happily you can use the API Platform [state processors](state-processors.md) for auto-hashing plain passwords.
+Happily you can use the API Platform [state processors](../core/state-processors.md) for auto-hashing plain passwords.
 
 First create a new state processor:
 


### PR DESCRIPTION
This documentation only concerns Symfony, so we should move it from `core/` to `symfony/`.