### PR TITLE
graphql.md: add "MediaObject Normalization" chapter

### DIFF
--- a/core/graphql.md
+++ b/core/graphql.md
@@ -2945,7 +2945,7 @@ For handling the upload of multiple files, iterate over `$context['args']['input
 ### Normalization of MediaObjects
 
 In the constructor of the `MediaObjectNormalizer`, the injected Normalizer must be replaced with the one from the
-graphql-namespace:
+`api_platform.graphql.normalizer.item` from GraphQL:
 
 ```PHP
 <?php

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -2947,20 +2947,23 @@ For handling the upload of multiple files, iterate over `$context['args']['input
 In the constructor of the `MediaObjectNormalizer`, the injected Normalizer must be replaced with the one from the
 `api_platform.graphql.normalizer.item` from GraphQL:
 
-```PHP
+```php
 <?php
 // api/src/Serializer/MediaObjectNormalizer.php
 
-...
+use App\Storage\StorageInterface;
+use ApiPlatform\GraphQl\Serializer\ItemNormalizer;
 
-public function __construct(
-    #[Autowire(service: 'api_platform.graphql.normalizer.item')]
-    private readonly NormalizerInterface $normalizer,
-    private readonly StorageInterface $storage
-) {}
-
-...
-```
+final readonly class MediaObjectNormalizer
+{
+    public function __construct(
+        #[Autowire(service: ItemNormalizer::class)]
+        private NormalizerInterface $normalizer,
+        private StorageInterface $storage
+    ) {}
+    
+    // ...
+}
 
 ### Using the `createMediaObject` Mutation
 

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -2942,6 +2942,26 @@ final class CreateMediaObjectResolver implements MutationResolverInterface
 
 For handling the upload of multiple files, iterate over `$context['args']['input']['files']`.
 
+### Normalization of MediaObjects
+
+In the constructor of the `MediaObjectNormalizer`, the injected Normalizer must be replaced with the one from the
+graphql-namespace:
+
+```PHP
+<?php
+// api/src/Serializer/MediaObjectNormalizer.php
+
+...
+
+public function __construct(
+    #[Autowire(service: 'api_platform.graphql.normalizer.item')]
+    private readonly NormalizerInterface $normalizer,
+    private readonly StorageInterface $storage
+) {}
+
+...
+```
+
 ### Using the `createMediaObject` Mutation
 
 Following the specification, the upload must be done with a `multipart/form-data` content type.


### PR DESCRIPTION
graphql-normalizer needs to be injected

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
