### PR TITLE
[bug] Remove unused SaveMediaObject import from file-upload.md

### DIFF
--- a/symfony/file-upload.md
+++ b/symfony/file-upload.md
@@ -67,7 +67,6 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\OpenApi\Model;
-use App\State\SaveMediaObject;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;


### PR DESCRIPTION
Cleaned up the code by removing an unused import statement. This helps improve readability and maintainability of the documentation. No functional changes were introduced.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
