### PR TITLE
docs(admin): openapi custom data provider example

### DIFF
--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -4,33 +4,38 @@ API Platform Admin delegates the authentication support to React Admin.
 Refer to [the chapter dedicated to authentication in the React Admin documentation](https://marmelab.com/react-admin/Authentication.html)
 for more information.
 
-In short, you have to tweak the data provider and the API documentation parser like this:
+## HydraAdmin
+
+The authentication layer for [HydraAdmin component](https://api-platform.com/docs/admin/components/#hydra)
+consists of a few parts, which need to be integrated together.
+
+### Authentication
+
+Add the Bearer token from `localStorage` to request headers.
 
 ```typescript
-// components/admin/Admin.tsx
+const getHeaders = () =>
+  localStorage.getItem("token")
+    ? { Authorization: `Bearer ${localStorage.getItem("token")}` }
+    : {};
+```
 
-import Head from "next/head";
-import { useState } from "react";
-import { Navigate, Route } from "react-router-dom";
-import { CustomRoutes } from "react-admin";
-import {
-  fetchHydra as baseFetchHydra,
-  HydraAdmin,
-  hydraDataProvider as baseHydraDataProvider,
-  useIntrospection,
-} from "@api-platform/admin";
-import { parseHydraDocumentation } from "@api-platform/api-doc-parser";
-import authProvider from "utils/authProvider";
-import { ENTRYPOINT } from "config/entrypoint";
+Extend the Hydra fetch function with custom headers for authentication.
 
-const getHeaders = () => localStorage.getItem("token") ? {
-  Authorization: `Bearer ${localStorage.getItem("token")}`,
-} : {};
+```typescript
 const fetchHydra = (url, options = {}) =>
   baseFetchHydra(url, {
     ...options,
     headers: getHeaders,
   });
+
+```
+
+### Login Redirection
+
+Redirect users to a `/login` path, if no token is available in the `localStorage`.
+
+```typescript
 const RedirectToLogin = () => {
   const introspect = useIntrospection();
 
@@ -40,10 +45,16 @@ const RedirectToLogin = () => {
   }
   return <Navigate to="/login" />;
 };
+```
+
+### Api Documentation Parsing
+
+Handle API documentation parsing and clear an expired token.
+
+```typescript
 const apiDocumentationParser = (setRedirectToLogin) => async () => {
   try {
     setRedirectToLogin(false);
-
     return await parseHydraDocumentation(ENTRYPOINT, { headers: getHeaders });
   } catch (result) {
     const { api, response, status } = result;
@@ -51,23 +62,49 @@ const apiDocumentationParser = (setRedirectToLogin) => async () => {
       throw result;
     }
 
-    // Prevent infinite loop if the token is expired
     localStorage.removeItem("token");
-
     setRedirectToLogin(true);
 
-    return {
-      api,
-      response,
-      status,
-    };
+    return { api, response, status };
   }
 };
-const dataProvider = (setRedirectToLogin) => baseHydraDataProvider({
-  entrypoint: ENTRYPOINT,
-  httpClient: fetchHydra,
-  apiDocumentationParser: apiDocumentationParser(setRedirectToLogin),
-});
+```
+
+### Data Provider
+
+Initialize the data provider with custom headers and the documentation parser.
+
+```typescript
+const dataProvider = (setRedirectToLogin) =>
+  baseHydraDataProvider({
+    entrypoint: ENTRYPOINT,
+    httpClient: fetchHydra,
+    apiDocumentationParser: apiDocumentationParser(setRedirectToLogin),
+  });
+```
+
+### Export Admin Component
+
+Export the admin component, and track the users' authentication status.
+
+```typescript
+import Head from "next/head";
+import { useState } from "react";
+import { Navigate, Route } from "react-router-dom";
+import { CustomRoutes } from "react-admin";
+import {
+    fetchHydra as baseFetchHydra,
+    HydraAdmin,
+    hydraDataProvider as baseHydraDataProvider,
+    useIntrospection,
+} from "@api-platform/admin";
+import { parseHydraDocumentation } from "@api-platform/api-doc-parser";
+import authProvider from "utils/authProvider";
+import { ENTRYPOINT } from "config/entrypoint";
+
+// *****
+// Here put the code parts shown above
+// *****
 
 const Admin = () => {
   const [redirectToLogin, setRedirectToLogin] = useState(false);
@@ -78,7 +115,11 @@ const Admin = () => {
         <title>API Platform Admin</title>
       </Head>
 
-      <HydraAdmin dataProvider={dataProvider(setRedirectToLogin)} authProvider={authProvider} entrypoint={window.origin}>
+      <HydraAdmin
+        dataProvider={dataProvider(setRedirectToLogin)}
+        authProvider={authProvider}
+        entrypoint={window.origin}
+      >
         {redirectToLogin ? (
           <CustomRoutes>
             <Route path="/" element={<RedirectToLogin />} />
@@ -93,8 +134,10 @@ const Admin = () => {
       </HydraAdmin>
     </>
   );
-}
+};
 export default Admin;
 ```
 
-For the implementation of the auth provider, you can find a working example in the [API Platform's demo application](https://github.com/api-platform/demo/blob/main/pwa/utils/authProvider.tsx).
+### Additional Notes
+
+For the implementation of the admin conponent, you can find a working example in the [API Platform's demo application](https://github.com/api-platform/demo/blob/4.0/pwa/components/admin/Admin.tsx).

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -187,7 +187,7 @@ const jsonDataProvider = openApiDataProvider({
 > [!NOTE]
 > The `simpleRestProvider` provider expect the API to include a `Content-Range` header in the response.
 > You can find more about the header syntax in the [Mozilla’s MDN documentation: Content-Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range).
-> 
+>
 > The `getAccessToken` function retrieves the JWT token stored in the browser.
 
 ### Authentication and Authorization

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -47,7 +47,7 @@ const RedirectToLogin = () => {
 };
 ```
 
-### Api Documentation Parsing
+### API Documentation Parsing
 
 Extend the `parseHydraDocumentaion` function from the [API Doc Parser library](https://github.com/api-platform/api-doc-parser)
 to handle the documentation parsing. Customize it to clear

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -49,7 +49,9 @@ const RedirectToLogin = () => {
 
 ### Api Documentation Parsing
 
-Handle API documentation parsing and clear an expired token.
+Extend the `parseHydraDocumentaion` function from the [API Doc Parser library](https://github.com/api-platform/api-doc-parser)
+to handle the documentation parsing. Customize it to clear
+expired tokens when encountering unauthorized `401` response.
 
 ```typescript
 const apiDocumentationParser = (setRedirectToLogin) => async () => {
@@ -72,7 +74,7 @@ const apiDocumentationParser = (setRedirectToLogin) => async () => {
 
 ### Data Provider
 
-Initialize the data provider with custom headers and the documentation parser.
+Initialize the hydra data provider with custom headers and the documentation parser.
 
 ```typescript
 const dataProvider = (setRedirectToLogin) =>
@@ -85,9 +87,11 @@ const dataProvider = (setRedirectToLogin) =>
 
 ### Export Admin Component
 
-Export the admin component, and track the users' authentication status.
+Export the Hydra admin component, and track the users' authentication status.
 
 ```typescript
+// components/admin/Admin.tsx
+
 import Head from "next/head";
 import { useState } from "react";
 import { Navigate, Route } from "react-router-dom";

--- a/admin/authentication-support.md
+++ b/admin/authentication-support.md
@@ -160,7 +160,7 @@ It covers:
 ### Data Provider & HTTP Client
 
 Create a custom HTTP client to add authentication tokens to request headers.
-Configure the data `ApiPlatformAdminDataProvider` data provider, and
+Configure the `openApiDataProvider`, and
 inject the custom HTTP client into the [Simple REST Data Provider for React-Admin](https://github.com/Serind/ra-data-simple-rest).
 
 **File:** `src/components/jsonDataProvider.tsx`

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -69,7 +69,6 @@ const httpClient = async (url, options = {}) => {
 
   try {
     const { status, headers, body, json } = await fetchUtils.fetchJson(url, options);
-    console.log('HTTP Response:', { status, headers, body, json });
     return { status, headers, body, json };
   } catch (error) {
     throw error;

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -39,65 +39,6 @@ export default () => (
 );
 ```
 
-### Custom Data Provider
-
-For more advanced use cases, you can create a custom dataProvider to add features such as authentication,
-logging, or token-based authorization.
-
-Here's an example of how to integrate a simpleRestProvider with a customized httpClient:
-
-```javascript
-import { fetchUtils } from 'react-admin';
-import { openApiDataProvider } from '@api-platform/admin';
-import simpleRestProvider from 'ra-data-simple-rest';
-import { getAccessToken } from './accessToken';
-
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost/api';
-const DOC_URL = `${API_URL}/docs`;
-
-// Custom HTTP client for authenticated requests
-const httpClient = async (url, options = {}) => {
-  options.headers = new Headers({
-    ...options.headers,
-    Accept: 'application/json',
-  });
-
-  const token = getAccessToken();
-  if (token) {
-    options.user = { token: `Bearer ${token}`, authenticated: true };
-  }
-
-  try {
-    const { status, headers, body, json } = await fetchUtils.fetchJson(url, options);
-    return { status, headers, body, json };
-  } catch (error) {
-    throw error;
-  }
-};
-
-// Wrapping the custom HTTP client into a data provider
-const jsonDataProvider = openApiDataProvider({
-  dataProvider: simpleRestProvider(API_URL, httpClient),
-  entrypoint: API_URL,
-  docEntrypoint: DOC_URL,
-});
-
-export default () => (
-  <OpenApiAdmin
-    entrypoint={API_URL}
-    docEntrypoint={DOC_URL}
-    dataProvider={jsonDataProvider}
-  />
-);
-
-```
-
-> [!NOTE]
-> The `getAccessToken` function is a placeholder for your custom logic to retrieve a JWT token.
->
-> Implement this function according to your application's requirements, such as reading the token from local storage,
-> cookies, or a secure context.
-
 ## Mercure Support
 
 Mercure support can be enabled manually by giving the `mercure` prop to the `OpenApiAdmin` component.

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -94,7 +94,6 @@ export default () => (
 ```
 
 > [!NOTE]
->
 > The `getAccessToken` function is a placeholder for your custom logic to retrieve a JWT token.
 >
 > Implement this function according to your application's requirements, such as reading the token from local storage,

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -44,7 +44,7 @@ export default () => (
 For more advanced use cases, you can create a custom dataProvider to add features such as authentication,
 logging, or token-based authorization.
 
-Below is an example of integrating a simpleRestProvider with a custom httpClient:
+Here's an example of how to integrate a simpleRestProvider with a customized httpClient:
 
 ```javascript
 import { fetchUtils } from 'react-admin';

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -39,6 +39,67 @@ export default () => (
 );
 ```
 
+### Custom Data Provider
+
+For more advanced use cases, you can create a custom dataProvider to add features such as authentication, 
+logging, or token-based authorization. 
+
+Below is an example of integrating a simpleRestProvider with a custom httpClient:
+
+```javascript
+import { fetchUtils } from 'react-admin';
+import { openApiDataProvider } from '@api-platform/admin';
+import simpleRestProvider from 'ra-data-simple-rest';
+import { getAccessToken } from './accessToken';
+
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost/api';
+const DOC_URL = `${API_URL}/docs`;
+
+// Custom HTTP client for authenticated requests
+const httpClient = async (url, options = {}) => {
+  options.headers = new Headers({
+    ...options.headers,
+    Accept: 'application/json',
+  });
+
+  const token = getAccessToken();
+  if (token) {
+    options.user = { token: `Bearer ${token}`, authenticated: true };
+  }
+
+  try {
+    const { status, headers, body, json } = await fetchUtils.fetchJson(url, options);
+    console.log('HTTP Response:', { status, headers, body, json });
+    return { status, headers, body, json };
+  } catch (error) {
+    throw error;
+  }
+};
+
+// Wrapping the custom HTTP client into a data provider
+const jsonDataProvider = openApiDataProvider({
+  dataProvider: simpleRestProvider(API_URL, httpClient),
+  entrypoint: API_URL,
+  docEntrypoint: DOC_URL,
+});
+
+export default () => (
+  <OpenApiAdmin
+    entrypoint={API_URL}
+    docEntrypoint={DOC_URL}
+    dataProvider={jsonDataProvider}
+  />
+);
+
+```
+
+> [!NOTE]
+>
+> The `getAccessToken` function is a placeholder for your custom logic to retrieve a JWT token. 
+> 
+>Implement this function according to your application's requirements, such as reading the token from local storage, 
+> cookies, or a secure context.
+
 ## Mercure Support
 
 Mercure support can be enabled manually by giving the `mercure` prop to the `OpenApiAdmin` component.

--- a/admin/openapi.md
+++ b/admin/openapi.md
@@ -41,8 +41,8 @@ export default () => (
 
 ### Custom Data Provider
 
-For more advanced use cases, you can create a custom dataProvider to add features such as authentication, 
-logging, or token-based authorization. 
+For more advanced use cases, you can create a custom dataProvider to add features such as authentication,
+logging, or token-based authorization.
 
 Below is an example of integrating a simpleRestProvider with a custom httpClient:
 
@@ -95,9 +95,9 @@ export default () => (
 
 > [!NOTE]
 >
-> The `getAccessToken` function is a placeholder for your custom logic to retrieve a JWT token. 
-> 
->Implement this function according to your application's requirements, such as reading the token from local storage, 
+> The `getAccessToken` function is a placeholder for your custom logic to retrieve a JWT token.
+>
+> Implement this function according to your application's requirements, such as reading the token from local storage,
 > cookies, or a secure context.
 
 ## Mercure Support


### PR DESCRIPTION
The pull request enhances the documentation for the Admin section by adding a comprehensive example of a custom dataProvider.

**Goal:**
To provide a more advanced, real-world example for developers who need to extend the OpenApiAdmin component with custom authentication and error handling.