### PR TITLE
fix: service controller references for "api_doc" route

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -649,9 +649,9 @@ Manually register the Swagger UI controller:
 ```php
 // routes/web.php
 use Illuminate\Support\Facades\Route;
-use ApiPlatform\Laravel\State\SwaggerUiProcessor;
+use ApiPlatform\Laravel\Controller\DocumentationController;
 
-Route::post('/api_documentation', SwaggerUiProcessor::class)
+Route::post('/api_documentation', DocumentationController::class)
     ->name('api_doc');
 ```
 

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -637,7 +637,7 @@ Manually register the Swagger UI controller:
 # app/config/routes.yaml
 api_doc:
   path: /api_documentation
-  controller: api_platform.swagger_ui.processor
+  controller: api_platform.action.documentation
 ```
 
 Change `/api_documentation` to the URI you wish Swagger UI to be accessible on.


### PR DESCRIPTION
This issue was introduced at [#2080](https://github.com/api-platform/docs/pull/2080/files#diff-ddca92eb923034384e57fb330d4e43f5d8c3901ad390de86a8d0899128c9e390R640).

The controller service for this route is [`api_platform.action.documentation`](https://github.com/api-platform/core/blob/825833cfee432e6b0988882d019b4fe4a03f63d5/src/Symfony/Bundle/Resources/config/routing/docs.xml#L8-L12).