### PR TITLE
fix: multiple formats for custom "api_doc" route example

### DIFF
--- a/core/openapi.md
+++ b/core/openapi.md
@@ -512,8 +512,11 @@ Manually register the Swagger UI controller:
 ```yaml
 # app/config/routes.yaml
 api_doc:
-    path: /api_documentation
+    path: /api_documentation.{_format}
     controller: api_platform.swagger_ui.action
+    methods: ['HEAD', 'GET']
+    defaults:
+        _format: html
 ```
 
 Change `/api_documentation` to the URI you wish Swagger UI to be accessible on.


### PR DESCRIPTION
Without the `_format` option, the resulting route is not able to expose other paths like `/api_documentation.jsonopenapi`.