### PR TITLE
fix: path references in YAML config snippets

### DIFF
--- a/admin/getting-started.md
+++ b/admin/getting-started.md
@@ -42,7 +42,7 @@ export default () => (
 Be sure to make your API send proper [CORS HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) to allow
 the admin's domain to access it.
 
-To do so, if you use the API Platform Distribution, update the value of the `CORS_ALLOW_ORIGIN` parameter in `api/.env` (it will be set to `^https?://localhost:?[0-9]*$`
+To do so, if you use the API Platform Distribution, update the value of the `CORS_ALLOW_ORIGIN` parameter in `.env` (it will be set to `^https?://localhost:?[0-9]*$`
 by default).
 
 If you use a custom installation of Symfony and [API Platform Core](../core/), you will need to adjust the [NelmioCorsBundle configuration](https://github.com/nelmio/NelmioCorsBundle#configuration) to expose the `Link` HTTP header and to send proper CORS headers on the route under which the API will be served (`/api` by default).

--- a/core/configuration.md
+++ b/core/configuration.md
@@ -3,7 +3,7 @@
 Here's the complete configuration of the Symfony bundle including default values:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
 
     # The title of the API.
@@ -322,7 +322,7 @@ api_platform:
 If you need to globally configure all the resources instead of adding configuration in each one, it's possible to do so with the `defaults` key:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
 
     defaults:

--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -41,7 +41,7 @@ The first required step is to configure allowed formats. The following configura
 and of a custom format called `myformat` and having `application/vnd.myformat` as [MIME type](https://en.wikipedia.org/wiki/Media_type).
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     formats:
         jsonld:   ['application/ld+json']
@@ -68,7 +68,7 @@ Support for the JSON:API PATCH format is automatically enabled if JSON:API suppo
 JSON Merge Patch support must be enabled explicitly:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     patch_formats:
         json:     ['application/merge-patch+json']
@@ -84,7 +84,7 @@ API Platform will try to send to the client the error format matching with the f
 Available formats can also be configured:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     error_formats:
         jsonproblem:                   ['application/problem+json']
@@ -197,7 +197,7 @@ Refer to the Symfony documentation to learn [how to create and register such cla
 Then, register the new format in the configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     formats:
         # ...
@@ -214,7 +214,7 @@ Using composition is the recommended way to implement a custom normalizer. You c
 own implementation of `CustomItemNormalizer`:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     'App\Serializer\CustomItemNormalizer':
         arguments: [ '@api_platform.serializer.normalizer.item' ]

--- a/core/controllers.md
+++ b/core/controllers.md
@@ -13,7 +13,7 @@ implements the [Action-Domain-Responder](https://github.com/pmjones/adr) pattern
 [MVC](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller).
 
 The distribution of API Platform also eases the implementation of the ADR pattern: it automatically registers action classes
-stored in `api/src/Controller` as autowired services.
+stored in `src/Controller` as autowired services.
 
 Thanks to the [autowiring](http://symfony.com/doc/current/components/dependency_injection/autowiring.html) feature of the
 Symfony Dependency Injection container, services required by an action can be type-hinted in its constructor, it will be
@@ -106,7 +106,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -178,7 +178,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -248,7 +248,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -321,7 +321,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -418,7 +418,7 @@ class BookController extends AbstractController
 ```
 
 ```yaml
-# api/config/routes.yaml
+# config/routes.yaml
 book_post_publication:
     path: /books/{id}/publication
     methods: ['POST']

--- a/core/data-persisters.md
+++ b/core/data-persisters.md
@@ -63,7 +63,7 @@ Otherwise, if you use a custom dependency injection configuration, you need to r
 `api_platform.data_persister` tag. The `priority` attribute can be used to order persisters.
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\DataPersister\BlogPostDataPersister: ~
@@ -138,7 +138,7 @@ final class UserDataPersister implements ContextAwareDataPersisterInterface
 Even with service autowiring and autoconfiguration enabled, you must still configure the decoration:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\DataPersister\UserDataPersister:
@@ -229,7 +229,7 @@ final class BlogPostDataPersister implements ContextAwareDataPersisterInterface,
 ```
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\DataPersister\BlogPostDataPersister: ~

--- a/core/data-providers.md
+++ b/core/data-providers.md
@@ -64,7 +64,7 @@ If you use the default configuration, the corresponding service will be automati
 To declare the service explicitly, or to set a custom priority, you can use the following snippet:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataProvider\BlogPostCollectionDataProvider':
@@ -118,7 +118,7 @@ Otherwise, if you use a custom dependency injection configuration, you need to r
 providers.
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataProvider\BlogPostItemDataProvider': ~
@@ -163,7 +163,7 @@ final class BlogPostSubresourceDataProvider implements SubresourceDataProviderIn
 Declare the service in your services configuration:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataProvider\BlogPostSubresourceDataProvider':

--- a/core/default-order.md
+++ b/core/default-order.md
@@ -29,7 +29,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         order:
@@ -70,7 +70,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         order: ['foo', 'bar']
@@ -104,7 +104,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         order: ['author.username']
@@ -146,7 +146,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     get: ~
     get_desc_custom:

--- a/core/deprecations.md
+++ b/core/deprecations.md
@@ -91,7 +91,7 @@ class Review
 ```
 
 ```yaml
-# api/config/api_platform/resources/Review.yaml
+# config/api_platform/resources/Review.yaml
 resources:
     # ...
     App\Entity\Review:

--- a/core/dto.md
+++ b/core/dto.md
@@ -29,7 +29,7 @@ final class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
     App\Entity\Book:
         attributes:
@@ -129,7 +129,7 @@ final class BookInputDataTransformer implements DataTransformerInterface
 We now register it:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataTransformer\BookInputDataTransformer': ~
@@ -192,7 +192,7 @@ final class BookOutputDataTransformer implements DataTransformerInterface
 We now register it:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataTransformer\BookOutputDataTransformer': ~
@@ -267,7 +267,7 @@ final class BookInputDataTransformer implements DataTransformerInterface
 ```
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataTransformer\BookInputDataTransformer': ~
@@ -340,7 +340,7 @@ final class BookInputDataTransformerInitializer implements DataTransformerInitia
 Register it:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\DataTransformer\BookInputDataTransformerInitializer': ~
@@ -392,7 +392,7 @@ final class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
     App\Entity\Book:
         collectionOperations:

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -21,7 +21,7 @@ composer require elasticsearch/elasticsearch:^6.0
 Then, enable it inside the API Platform configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 parameters:
     # ...
     env(ELASTICSEARCH_HOST): 'http://localhost:9200'
@@ -210,7 +210,7 @@ For example, consider an index being similar to a database in an SQL database an
 So the `User` and `Tweet` resources of the previous example would become `user` and `tweet` types in an index named `app`:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 parameters:
     # ...
     env(ELASTICSEARCH_HOST): 'http://localhost:9200'

--- a/core/extending-jsonld-context.md
+++ b/core/extending-jsonld-context.md
@@ -88,7 +88,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get:

--- a/core/extensions.md
+++ b/core/extensions.md
@@ -102,7 +102,7 @@ final class CurrentUserExtension implements QueryCollectionExtensionInterface, Q
 Finally, if you're not using the autoconfiguration, you have to register the custom extension with either of those tags:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
 
     # ...
@@ -134,7 +134,7 @@ This example adds a `WHERE` clause condition only when a fully authenticated use
 To secure the access to endpoints, use the following access control rule:
 
 ```yaml
-# app/config/package/security.yaml
+# config/package/security.yaml
 security:
     # ...
     access_control:

--- a/core/file-upload.md
+++ b/core/file-upload.md
@@ -21,7 +21,7 @@ This will create a new configuration file that you will need to slightly change
 to make it look like this.
 
 ```yaml
-# api/config/packages/vich_uploader.yaml
+# config/packages/vich_uploader.yaml
 vich_uploader:
     db_driver: orm
 

--- a/core/filters.md
+++ b/core/filters.md
@@ -26,7 +26,7 @@ to a Resource in two ways:
    For example having a filter service declaration:
 
     ```yaml
-    # api/config/services.yaml
+    # config/services.yaml
     services:
         # ...
         offer.date_filter:
@@ -60,7 +60,7 @@ to a Resource in two ways:
     ```
 
     ```yaml
-    # api/config/api_platform/resources.yaml
+    # config/api_platform/resources.yaml
     App\Entity\Offer:
         collectionOperations:
             get:
@@ -123,7 +123,7 @@ to a Resource in two ways:
 ### Search Filter
 
 If Doctrine ORM or MongoDB ODM support is enabled, adding filters is as easy as registering a filter service in the
-`api/config/services.yaml` file and adding an attribute to your resource configuration.
+`config/services.yaml` file and adding an attribute to your resource configuration.
 
 The search filter supports `exact`, `partial`, `start`, `end`, and `word_start` matching strategies:
 
@@ -591,7 +591,7 @@ A conflict will occur if `exists` is also the name of a property with the search
 Luckily, the query parameter name to use is configurable:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     collection:
         exists_parameter_name: 'not_null' # the URL query parameter to use is now "not_null"
@@ -761,7 +761,7 @@ A conflict will occur if `order` is also the name of a property with the search 
 Luckily, the query parameter name to use is configurable:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     collection:
         order_parameter_name: '_order' # the URL query parameter to use is now "_order"
@@ -975,7 +975,7 @@ A conflict will occur if `order` is also the name of a property with the term fi
 parameter name to use is configurable:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     collection:
         order_parameter_name: '_order' # the URL query parameter to use is now "_order"
@@ -1283,7 +1283,7 @@ If you don't use Symfony's automatic service loading, you have to register the f
 Use the following service definition (remember, by default, this isn't needed!):
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     # This whole definition can be omitted if automatic service loading is enabled
@@ -1298,7 +1298,7 @@ In the previous example, the filter can be applied on any property. However, tha
 it can also be enabled for some properties:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     'App\Filter\RegexpFilter':
         arguments: [ '@doctrine', ~, '@?logger', { email: ~, anOtherProperty: ~ } ]
@@ -1501,7 +1501,7 @@ final class UserFilter extends SQLFilter
 Now, we must configure the Doctrine filter.
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 doctrine:
     orm:
         filters:

--- a/core/form-data.md
+++ b/core/form-data.md
@@ -72,7 +72,7 @@ final class DeserializeListener
 ## Creating the Service Definition
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\EventListener\DeserializeListener':

--- a/core/fosuser-bundle.md
+++ b/core/fosuser-bundle.md
@@ -26,7 +26,7 @@ If you are using the API Platform Standard Edition, you will need to enable the 
 configuration options:
 
 ```yaml
-# api/config/packages/framework.yaml
+# config/packages/framework.yaml
 framework:
     form: { enabled: true }
 ```
@@ -36,7 +36,7 @@ framework:
 To enable the provided bridge with FOSUserBundle, you need to add the following configuration to API Platform:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     enable_fos_user: true
 ```

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -169,7 +169,7 @@ As an alternative to annotations, you can map entity classes using YAML or XML:
 <code-selector>
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
     App\Entity\Product: ~
     App\Entity\Offer:
@@ -203,7 +203,7 @@ resources:
 If you prefer to use YAML or XML files instead of annotations, you must configure API Platform to load the appropriate files:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     mapping:
         paths: 

--- a/core/graphql.md
+++ b/core/graphql.md
@@ -28,7 +28,7 @@ You can now use GraphQL at the endpoint: `https://localhost:8443/graphql`.
 Sometimes you may want to have the GraphQL endpoint at a different location. This can be done by manually configuring the GraphQL controller.
 
 ```yaml
-# api/config/routes.yaml
+# config/routes.yaml
 api_graphql_entrypoint:
     path: /api/graphql
     controller: api_platform.graphql.action.entrypoint
@@ -46,7 +46,7 @@ The GraphiQL IDE can also be found at `/graphql/graphiql`.
 If you need to disable it, it can be done in the configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         graphiql:
@@ -59,7 +59,7 @@ api_platform:
 If you want to add a different location besides `/graphql/graphiql`, you can do it like this:
 
 ```yaml
-# app/config/routes.yaml
+# config/routes.yaml
 graphiql:
     path: /docs/graphiql
     controller: api_platform.graphql.action.graphiql
@@ -74,7 +74,7 @@ It can be found at `/graphql/graphql_playground`.
 You can disable it if you want in the configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         graphql_playground:
@@ -87,7 +87,7 @@ api_platform:
 You can add a different location besides `/graphql/graphql_playground`:
 
 ```yaml
-# app/config/routes.yaml
+# config/routes.yaml
 graphql_playground:
     path: /docs/graphql_playground
     controller: api_platform.graphql.action.graphql_playground
@@ -98,7 +98,7 @@ graphql_playground:
 When going to the GraphQL endpoint, you can choose to launch the IDE you want.
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         # Choose between graphiql or graphql-playground
@@ -109,7 +109,7 @@ api_platform:
 You can also disable this feature by setting the configuration value to `false`.
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         default_ide: false
@@ -122,7 +122,7 @@ If you wish to send a [POST request using the `application/graphql` Content-Type
 you need to enable it in the [allowed formats of API Platform](content-negotiation.md#configuring-formats-globally):
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     formats:
         # ...
@@ -230,7 +230,7 @@ If you use autoconfiguration (the default Symfony configuration) in your applica
 Else, you need to tag your resolver like this:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\Resolver\BookCollectionResolver:
@@ -664,7 +664,7 @@ final class WriteStage implements WriteStageInterface
 Decorate the API Platform stage service:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\Stage\WriteStage':
@@ -1047,7 +1047,7 @@ See also the [pagination documentation](pagination.md#disabling-the-pagination).
 The pagination can be disabled for all GraphQL resources using this configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         collection:
@@ -1252,7 +1252,7 @@ Then register the service:
 <code-selector>
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\Error\ErrorHandler:
@@ -1362,7 +1362,7 @@ If you use a positive priority (or no priority), your normalizer will always be 
 For instance, you can register a custom normalizer like this:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     App\Serializer\Exception\MyExceptionNormalizer:
         tags:
@@ -1475,7 +1475,7 @@ You would need to use the search filter like this:
 To avoid this issue, you can configure the nesting separator to use, for example, `__` instead of `_`:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     graphql:
         nesting_separator: __
@@ -1593,7 +1593,7 @@ If you use autoconfiguration (the default Symfony configuration) in your applica
 Else, you need to tag your type class like this:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     App\Type\Definition\DateTimeType:
@@ -1613,7 +1613,7 @@ In some cases, you would want to modify the extracted types for instance to use 
 To do so, you need to decorate the `api_platform.graphql.type_converter` service:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\Type\TypeConverter':
@@ -1859,7 +1859,7 @@ Following the specification, the upload must be done with a `multipart/form-data
 You need to enable it in the [allowed formats of API Platform](content-negotiation.md#configuring-formats-globally):
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     formats:
         # ...

--- a/core/identifiers.md
+++ b/core/identifiers.md
@@ -33,7 +33,7 @@ final class Person
 ```
 
 ```yaml
-# api/config/api_platform/resources/Person.yaml
+# config/api_platform/resources/Person.yaml
 App\Entity\Person:
     properties:
         code:

--- a/core/jwt.md
+++ b/core/jwt.md
@@ -34,11 +34,11 @@ Note that the `setfacl` command relies on the `acl` package. This is installed b
 
 This takes care of keypair creation (including using the correct passphrase to encrypt the private key), and setting the correct permissions on the keys allowing the web server to read them.
 
-Since these keys are created by the `root` user from a container, your host user will not be able to read them during the `docker-compose build caddy` process. Add the `config/jwt/` folder to the `api/.dockerignore` file so that they are skipped from the result image.
+Since these keys are created by the `root` user from a container, your host user will not be able to read them during the `docker-compose build caddy` process. Add the `config/jwt/` folder to the `.dockerignore` file so that they are skipped from the result image.
 
 If you want the keys to be auto generated in `dev` environment, see an example in the [docker-entrypoint script of api-platform/demo](https://github.com/api-platform/demo/blob/master/api/docker/php/docker-entrypoint.sh).
 
-The keys should not be checked in to the repository (i.e. it's in `api/.gitignore`). However, note that a JWT token could
+The keys should not be checked in to the repository (i.e. it's in `.gitignore`). However, note that a JWT token could
 only pass signature validation against the same pair of keys it was signed with. This is especially relevant in a production
 environment, where you don't want to accidentally invalidate all your clients' tokens at every deployment.
 
@@ -58,7 +58,7 @@ If you choose to use the Doctrine entity user provider, start by [creating your 
 Then update the security configuration:
 
 ```yaml
-# api/config/packages/security.yaml
+# config/packages/security.yaml
 security:
     # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
@@ -98,7 +98,7 @@ security:
 You must also declare the route used for `/authentication_token`:
 
 ```yaml
-# api/config/routes.yaml
+# config/routes.yaml
 authentication_token:
     path: /authentication_token
     methods: ['POST']
@@ -115,7 +115,7 @@ also want to [configure Swagger UI for JWT authentication](#documenting-the-auth
 If your API uses a [path prefix](https://symfony.com/doc/current/routing/external_resources.html#prefixing-the-urls-of-imported-routes), the security configuration would look something like this instead:
 
 ```yaml
-# api/config/packages/security.yaml
+# config/packages/security.yaml
 security:
     # https://symfony.com/doc/current/security.html#c-hashing-passwords
     password_hashers:
@@ -157,7 +157,7 @@ security:
 ### Be sure to have lexik_jwt_authentication configured on your user_identity_field
 
 ```yaml
-# api/config/packages/lexik_jwt_authentication.yaml
+# config/packages/lexik_jwt_authentication.yaml
 lexik_jwt_authentication:
     secret_key: '%env(resolve:JWT_SECRET_KEY)%'
     public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
@@ -173,7 +173,7 @@ Want to test the routes of your JWT-authentication-protected API?
 ### Configuring API Platform
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     swagger:
          api_keys:
@@ -298,7 +298,7 @@ final class JwtDecorator implements OpenApiFactoryInterface
 And register this service in `config/services.yaml`:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
 

--- a/core/messenger.md
+++ b/core/messenger.md
@@ -49,7 +49,7 @@ final class Person
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
   App\Entity\Person:
     collectionOperations:

--- a/core/mongodb.md
+++ b/core/mongodb.md
@@ -21,7 +21,7 @@ If the `mongodb` PHP extension is not installed yet, [install it beforehand](htt
 If you are using the [API Platform Distribution](../distribution/index.md), modify the `Dockerfile` to add the extension:
 
 ```diff
-# api/Dockerfile
+# Dockerfile
   pecl install \
    apcu-${APCU_VERSION} \
 +  mongodb \
@@ -75,7 +75,7 @@ Execute the contrib recipe to have it already configured.
 Change the MongoDB environment variables to match your Docker image:
 
 ```shell
-# api/.env
+# .env
 MONGODB_URL=mongodb://api-platform:!ChangeMe!@db-mongodb
 MONGODB_DB=api
 ```
@@ -83,7 +83,7 @@ MONGODB_DB=api
 Change the configuration of API Platform to add the right mapping path:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     # ...
 

--- a/core/nelmio-api-doc.md
+++ b/core/nelmio-api-doc.md
@@ -14,7 +14,7 @@ For new projects, prefer using the built-in Swagger support and/or NelmioApiDoc 
 To enable the NelmioApiDoc integration, copy the following configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     # ...
 

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -54,7 +54,7 @@ In the following example, we will see how to override the title of the Swagger d
 the `GET` operation of `/foos` path.
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
     App\OpenApi\OpenApiFactory:
         decorates: 'api_platform.openapi.factory'
         arguments: [ '@App\OpenApi\OpenApiFactory.inner' ]
@@ -158,7 +158,7 @@ class Product // The class name will be used to name exposed resources
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
     App\Entity\Product:
       properties:
@@ -416,7 +416,7 @@ Sometimes you may want to have the API at one location, and the Swagger UI at a 
 ### Disabling Swagger UI or ReDoc
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     # ...
     enable_swagger_ui: false
@@ -426,7 +426,7 @@ api_platform:
 ### Manually Registering the Swagger UI Controller
 
 ```yaml
-# app/config/routes.yaml
+# config/routes.yaml
 swagger_ui:
     path: /docs
     controller: api_platform.swagger.action.ui

--- a/core/operation-path-naming.md
+++ b/core/operation-path-naming.md
@@ -13,10 +13,10 @@ Service name                                          | Entity name  | Path resu
 `api_platform.path_segment_name_generator.dash`       | `MyResource` | `/my-resources`
 
 The default resolver is `api_platform.path_segment_name_generator.underscore`.
-To change it to the dash resolver, add the following lines to `api/config/packages/api_platform.yaml`:
+To change it to the dash resolver, add the following lines to `config/packages/api_platform.yaml`:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     path_segment_name_generator: api_platform.path_segment_name_generator.dash
 ```
@@ -70,7 +70,7 @@ do.
 Otherwise, you must register this class as a service like in the following example:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\Operation\SingularPathSegmentNameGenerator': ~
@@ -79,7 +79,7 @@ services:
 ### Configuring It
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     path_segment_name_generator: 'App\Operation\SingularPathSegmentNameGenerator'
 ```

--- a/core/operations.md
+++ b/core/operations.md
@@ -89,7 +89,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     collectionOperations:
         get: ~ # nothing more to add if we want to keep the default controller
@@ -145,7 +145,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     collectionOperations:
         get:
@@ -212,7 +212,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     collectionOperations:
         get: ~
@@ -290,7 +290,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     collectionOperations:
         post:
@@ -387,7 +387,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -458,7 +458,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     attributes:
         route_prefix: /library

--- a/core/pagination.md
+++ b/core/pagination.md
@@ -44,7 +44,7 @@ of total items in the collection.
 The name of the page parameter can be changed with the following configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     collection:
         pagination:
@@ -62,7 +62,7 @@ However, for small collections, it can be convenient to fully disable the pagina
 The pagination can be disabled for all resources using this configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         pagination_enabled: false
@@ -93,7 +93,7 @@ You can configure API Platform Core to let the client enable or disable the pagi
 use the following configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         pagination_client_enabled: true
@@ -136,7 +136,7 @@ In the same manner, the number of items per page is configurable and can be set 
 The number of items per page can be configured for all resources:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         pagination_items_per_page: 30 # Default value
@@ -162,7 +162,7 @@ class Book
 #### Changing the Number of Items per Page Client-side Globally
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         pagination_client_items_per_page: true
@@ -197,7 +197,7 @@ class Book
 The number of maximum items per page can be configured for all resources:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         pagination_maximum_items_per_page: 50
@@ -246,7 +246,7 @@ performance impact on really big collections. The downside is that the informati
 The partial pagination retrieval can be configured for all resources:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 
 api_platform:
     defaults:
@@ -274,7 +274,7 @@ class Book
 #### Partial Pagination Client-side Globally
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 
 api_platform:
     defaults:

--- a/core/performance.md
+++ b/core/performance.md
@@ -182,7 +182,7 @@ There is a default restriction with this feature. We allow up to 30 joins per qu
 bit of configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     eager_loading:
         max_joins: 100
@@ -196,7 +196,7 @@ can be a good solution to fix this issue.
 If you want to fetch only partial data according to serialization groups, you can enable `fetch_partial` parameter:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     eager_loading:
         fetch_partial: true
@@ -211,7 +211,7 @@ As mentioned above, by default we force eager loading for all relations. This be
 configuration in order to apply it only on join relations having the `EAGER` fetch mode:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     eager_loading:
         force_eager: false
@@ -307,7 +307,7 @@ configuration.
 If for any reason you don't want the eager loading feature, you can turn it off in the configuration:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     eager_loading:
         enabled: false
@@ -322,7 +322,7 @@ When using the default pagination, the Doctrine paginator will execute a `COUNT`
 If you don't mind not having the last page available, you can enable partial pagination and avoid the `COUNT` query:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     collection:
         pagination:

--- a/core/security.md
+++ b/core/security.md
@@ -49,7 +49,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     attributes:
         security: 'is_granted("ROLE_USER")'
@@ -83,7 +83,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     properties:
         adminOnlyProperty:
@@ -136,7 +136,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     itemOperations:
         get: ~
@@ -193,7 +193,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         security: 'is_granted("ROLE_USER")'
@@ -316,7 +316,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     attributes:
         security: 'is_granted("ROLE_USER")'

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -49,7 +49,7 @@ or YAML. Since annotations are easy to understand, we will use them in the follo
 Note: if you aren't using the API Platform distribution, you will need to enable annotation support in the serializer configuration:
 
 ```yaml
-# api/config/packages/framework.yaml
+# config/packages/framework.yaml
 framework:
     serializer: { enable_annotations: true }
 ```
@@ -60,7 +60,7 @@ all set!
 If you want to use YAML or XML, please add the mapping path in the serializer configuration:
 
 ```yaml
-# api/config/packages/framework.yaml
+# config/packages/framework.yaml
 framework:
     serializer:
         mapping:
@@ -102,7 +102,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 resources:
     App\Entity\Book:
         attributes:
@@ -111,7 +111,7 @@ resources:
             denormalization_context:
                 groups: ['write']
 
-# api/config/serialization/Book.yaml
+# config/serialization/Book.yaml
 App\Entity\Book:
     attributes:
         name:
@@ -191,7 +191,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         normalization_context:
@@ -202,7 +202,7 @@ App\Entity\Book:
             normalization_context:
                 groups: ['put']
 
-# api/config/serializer/Book.yaml
+# config/serializer/Book.yaml
 App\Entity\Book:
     attributes:
         name:
@@ -272,13 +272,13 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         normalization_context:
             groups: ['book']
 
-# api/config/serializer/Book.yaml
+# config/serializer/Book.yaml
 App\Entity\Book:
     attributes:
         name:
@@ -311,7 +311,7 @@ class Person
 ```
 
 ```yaml
-# api/config/serializer/Person.yaml
+# config/serializer/Person.yaml
 App\Entity\Person:
     attributes:
         name:
@@ -365,7 +365,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         denormalization_context:
@@ -421,7 +421,7 @@ class Person
 ```
 
 ```yaml
-# api/config/api_platform/resources/Person.yaml
+# config/api_platform/resources/Person.yaml
 App\Entity\Person:
     attributes:
         normalization_context:
@@ -429,7 +429,7 @@ App\Entity\Person:
         denormalization_context:
             groups: ['person']
 
-# api/config/serializer/Person.yaml
+# config/serializer/Person.yaml
 App\Entity\Person:
     attributes:
         name:
@@ -478,7 +478,7 @@ class Person
 ```
 
 ```yaml
-# api/config/api_platform/resources/Person.yaml
+# config/api_platform/resources/Person.yaml
 App\Entity\Person:
     attributes:
         normalization_context:
@@ -490,7 +490,7 @@ App\Entity\Person:
             readableLink: false
             writableLink: false
 
-# api/config/serializer/Person.yaml
+# config/serializer/Person.yaml
 App\Entity\Person:
     attributes:
         name:
@@ -649,14 +649,14 @@ class Greeting
 ```
 
 ```yaml
-# api/config/api_platform/resources/Greeting.yaml
+# config/api_platform/resources/Greeting.yaml
 App\Entity\Greeting:
     collectionOperations:
         get:
             normalization_context:
                 groups: 'greeting:collection:get'
 
-# api/config/serializer/Greeting.yaml
+# config/serializer/Greeting.yaml
 App\Entity\Greeting:
     attributes:
         id:
@@ -711,7 +711,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book: 
     attributes:
         normalization_context:
@@ -719,7 +719,7 @@ App\Entity\Book:
         denormalization_context:
             groups: ['book:input']
 
-# api/config/serializer/Book.yaml
+# config/serializer/Book.yaml
 App\Entity\Book:
     attributes:
         active:
@@ -738,7 +738,7 @@ API Platform implements a `ContextBuilder`, which prepares the context for seria
 `createFromRequest` method:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\Serializer\BookContextBuilder':
@@ -798,7 +798,7 @@ an example; it is always important to make sure your normalizer gets loaded firs
 is appropriate for your application; higher values are loaded earlier):
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     'App\Serializer\BookAttributeNormalizer':
         arguments: [ '@security.token_storage' ]
@@ -879,13 +879,13 @@ To use this feature, declare a new name converter service. For example, you can 
 `snake_case` with the following configuration:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     'Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter': ~
 ```
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     name_converter: 'Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter'
 ```
@@ -898,7 +898,7 @@ In the following example, we will see how we add extra information to the serial
 date on each request in `GET`:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     'App\Serializer\ApiNormalizer':
         # By default .inner is passed as argument
@@ -1006,7 +1006,7 @@ class Book
 You can also use the YAML configuration format:
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     properties:
         id:
@@ -1058,7 +1058,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources/Book.yaml
+# config/api_platform/resources/Book.yaml
 App\Entity\Book:
     attributes:
         normalization_context:

--- a/core/subresources.md
+++ b/core/subresources.md
@@ -74,7 +74,7 @@ class Question
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Answer: ~
 App\Entity\Question:
     properties:
@@ -136,7 +136,7 @@ class Answer
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Answer:
     subresourceOperations:
         api_questions_answer_get_subresource:

--- a/core/url-generation-strategy.md
+++ b/core/url-generation-strategy.md
@@ -25,7 +25,7 @@ You may want to use absolute URLs (for instance if resources are used in another
 It can be configured globally:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 api_platform:
     defaults:
         url_generation_strategy: !php/const ApiPlatform\Core\Api\UrlGeneratorInterface::ABS_URL
@@ -50,7 +50,7 @@ class Book
 ```
 
 ```yaml
-# api/config/api_platform/resources.yaml
+# config/api_platform/resources.yaml
 App\Entity\Book:
     attributes:
         url_generation_strategy: !php/const ApiPlatform\Core\Api\UrlGeneratorInterface::ABS_URL

--- a/core/validation.md
+++ b/core/validation.md
@@ -328,7 +328,7 @@ class MySequencedGroup
 Just creating the class is not enough because Symfony does not see this service as being used. Therefore to prevent the service to be removed, you need to enforce it to be public.
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     App\Validator\MySequencedGroup: ~
         public: true
@@ -450,10 +450,10 @@ class MyEntityDataPersister implements DataPersisterInterface
 }
 ```
 
-Register the new data persister in `api/config/services.yaml`:
+Register the new data persister in `config/services.yaml`:
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     _defaults:
         bind:
@@ -466,7 +466,7 @@ As stated in the [Symfony documentation](https://symfony.com/doc/current/validat
 You can retrieve the payload field by setting the `serialize_payload_fields` to an empty `array` in the API Platform config:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 
 api_platform:
     validator:
@@ -478,7 +478,7 @@ Then, the serializer will return all payload values in the error response.
 If you want to serialize only some payload fields, define them in the config like this:
 
 ```yaml
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 
 api_platform:
     validator:
@@ -594,7 +594,7 @@ If you use a custom dependency injection configuration, you need to register the
 `api_platform.metadata.property_schema_restriction` tag. The `priority` attribute can be used for service ordering.
 
 ```yaml
-# api/config/services.yaml
+# config/services.yaml
 services:
     # ...
     'App\PropertySchemaRestriction\CustomPropertySchemaRestriction': ~

--- a/deployment/heroku.md
+++ b/deployment/heroku.md
@@ -65,7 +65,7 @@ composer require symfony/apache-pack
 As Heroku doesn't support Varnish out of the box, let's disable its integration:
 
 ```diff
-# api/config/packages/api_platform.yaml
+# config/packages/api_platform.yaml
 -    http_cache:
 -        invalidation:
 -            enabled: true
@@ -82,7 +82,7 @@ and persist application logs. Because API Platform writes logs on `STDERR`, it w
 However, if you use Monolog instead of the default logger, you'll need to configure it to output to `STDERR` instead of
 in a file.
 
-Open `api/config/packages/prod/monolog.yaml` and apply the following patch:
+Open `config/packages/prod/monolog.yaml` and apply the following patch:
 
 ```diff
      handlers:

--- a/deployment/traefik.md
+++ b/deployment/traefik.md
@@ -182,7 +182,7 @@ If you want to implement custom DNS such as production DNS in local, just add th
 127.0.0.1       your.domain.com
 ```
 
-If you do that, you'll have to update the `CORS_ALLOW_ORIGIN` environment variable `api/.env` to accept the specified URL.
+If you do that, you'll have to update the `CORS_ALLOW_ORIGIN` environment variable `.env` to accept the specified URL.
 
 ## Known Issues
 

--- a/distribution/debugging.md
+++ b/distribution/debugging.md
@@ -14,7 +14,7 @@ To avoid deploying API Platform to production with an active Xdebug extension,
 it's recommended to add a custom stage to the end of the `api/Dockerfile`.
 
 ```Dockerfile
-# api/Dockerfile
+# Dockerfile
 FROM api_platform_php as api_platform_php_dev
 
 ARG XDEBUG_VERSION=3.1.3

--- a/distribution/index.md
+++ b/distribution/index.md
@@ -122,7 +122,7 @@ you'll get auto-completion for almost everything and awesome quality analysis.
 
 [PHP IntelliSense for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-intellisense) also works well, and is free and open source.
 
-The API Platform distribution comes with a dummy entity for test purpose: `api/src/Entity/Greeting.php`. We will remove
+The API Platform distribution comes with a dummy entity for test purpose: `src/Entity/Greeting.php`. We will remove
 it later.
 
 If you're used to the PHP ecosystem, you probably guessed that this test entity uses the industry-leading [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html)
@@ -362,7 +362,7 @@ Modify the classes to map them to database tables using the annotations provided
 
 Modify these files as described in these patches:
 
-`api/src/Entity/Book.php`
+`src/Entity/Book.php`
 
 ```diff
  use ApiPlatform\Core\Annotation\ApiResource;
@@ -405,7 +405,7 @@ Modify these files as described in these patches:
      public function __construct()
 ```
 
-`api/src/Entity/Review.php`
+`src/Entity/Review.php`
 
 ```diff
  namespace App\Entity;
@@ -459,7 +459,7 @@ They are supported as well.
 Learn more about how to map entities with the Doctrine ORM in [the project's official documentation](https://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/association-mapping.html)
 or in Kévin's book "[Persistence in PHP with the Doctrine ORM](https://www.amazon.fr/gp/product/B00HEGSKYQ/ref=as_li_tl?ie=UTF8&camp=1642&creative=6746&creativeASIN=B00HEGSKYQ&linkCode=as2&tag=kevidung-21)".
 
-Now, delete the file `api/src/Entity/Greeting.php`. This demo entity isn't useful anymore.
+Now, delete the file `src/Entity/Greeting.php`. This demo entity isn't useful anymore.
 Finally, generate a new database migration using [Doctrine Migrations](https://symfony.com/doc/current/doctrine.html#migrations-creating-the-database-tables-schema) and apply it:
 
 ```console
@@ -569,7 +569,7 @@ to validate user-submitted data. Let's add some validation rules to our data mod
 
 Modify the following files as described in these patches:
 
-`api/src/Entity/Book.php`
+`src/Entity/Book.php`
 
 ```diff
  use ApiPlatform\Core\Annotation\ApiResource;
@@ -598,7 +598,7 @@ Modify the following files as described in these patches:
      public ?\DateTimeImmutable $publicationDate = null;
 ```
 
-`api/src/Entity/Review.php`
+`src/Entity/Review.php`
 
 ```diff
  use ApiPlatform\Core\Annotation\ApiResource;

--- a/distribution/testing.md
+++ b/distribution/testing.md
@@ -35,7 +35,7 @@ Place your data fixtures files in a directory named `fixtures/`.
 Then, create some fixtures for [the bookstore API you created in the tutorial](index.md):
 
 ```yaml
-# api/fixtures/books.yaml
+# fixtures/books.yaml
 App\Entity\Book:
     book_{1..100}:
         isbn: <isbn13()>
@@ -46,7 +46,7 @@ App\Entity\Book:
 ```
 
 ```yaml
-# api/fixtures/reviews.yaml
+# fixtures/reviews.yaml
 App\Entity\Review:
     review_{1..200}:
         rating: <numberBetween(0, 5)>

--- a/extra/troubleshooting.md
+++ b/extra/troubleshooting.md
@@ -35,7 +35,7 @@ If you are still using the old, unmaintained v1 of JMSSerializerBundle, the best
 In v1 of JMSSerializerBundle, the `serializer` alias is registered for the JMS Serializer service by default. However, API Platform requires the Symfony Serializer (and not the JMS one) to work properly. If you cannot upgrade for some reason, this behavior can be deactivated using the following configuration:
 
 ```yaml
-# api/config/packages/jms_serializer.yaml
+# config/packages/jms_serializer.yaml
 jms_serializer:
     enable_short_alias: false
 ```

--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -30,7 +30,7 @@ Here we will generate a data model for an address book with the following data:
 * a [`PostalAddress`](https://schema.org/PostalAddress) which inherits from [`ContactPoint`](https://schema.org/ContactPoint), which itself inherits from [`StructuredValue`](https://schema.org/StructuredValue), etc.
 
 ```yaml
-# api/config/schema.yaml
+# config/schema.yaml
 # The list of types and properties we want to use
 types:
     # Parent class of Person


### PR DESCRIPTION
AFAIK, the documentation is built around the paths from [`api-platform/api-platform`](https://github.com/api-platform/api-platform/tree/v2.6.0/api/config).

* Added missing `api/` directory references where missing;
* Replaced `app/` with `api/`.
