### PR TITLE
docs(extra): link to API Platform docs in contrib guide

### DIFF
--- a/extra/contribution-guides.md
+++ b/extra/contribution-guides.md
@@ -2,7 +2,10 @@
 
 ## API Platform Core  
 - [General Contribution Guide](https://github.com/api-platform/core/blob/main/CONTRIBUTING.md)  
-- [Laravel-Specific Contribution Guide](https://github.com/api-platform/core/blob/main/src/Laravel/CONTRIBUTING.md)  
+- [Laravel-Specific Contribution Guide](https://github.com/api-platform/core/blob/main/src/Laravel/CONTRIBUTING.md)
+
+## API Platform Documentation
+- [General Contribution Guide](https://github.com/api-platform/docs/blob/main/CONTRIBUTING.md)  
 
 ## API Platform Tools  
 - [Schema Generator Contribution Guide](https://github.com/api-platform/schema-generator/blob/main/CONTRIBUTING.md)  


### PR DESCRIPTION
Add the missing link to API Platform documentation in the contribution guide.