### PR TITLE
docs: update links to use Laravel section references

### DIFF
--- a/laravel/index.md
+++ b/laravel/index.md
@@ -7,16 +7,16 @@ using Laravel!
 
 With API Platform, you can:
 
-- [expose your Eloquent](laravel#exposing-a-model) models in minutes as:
+- [expose your Eloquent](./#exposing-a-model) models in minutes as:
   - a REST API implementing the industry-leading standards, formats and best practices: [JSON-LD](https://en.wikipedia.org/wiki/JSON-LD)/[RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework), [JSON:API](https://jsonapi.org), [HAL](https://stateless.group/hal_specification.html), and many RFCs...
-  - a [GraphQL](laravel#enabling-graphql) API
+  - a [GraphQL](./#enabling-graphql) API
   - or both at the same time, with the same code!
 - automatically expose an [OpenAPI](https://www.openapis.org) specification (formerly Swagger), dynamically generated from your Eloquent models and always up to date
 - automatically expose nice UIs and playgrounds to develop using your API ([Swagger UI](https://swagger.io/tools/swagger-ui/) and [GraphiQL](https://github.com/graphql/graphiql))
 - automatically paginate your collections
-- add validation logic using Laravel [Form Request Validation](laravel#write-operations-authorization-and-validation)
-- add authorization logic using [gates and policies](laravel#authorization) ([compatible with Sanctum, Passport, Socialite...](laravel#authentication))
-- add [filtering logic](laravel#adding-filters)
+- add validation logic using Laravel [Form Request Validation](./#write-operations-authorization-and-validation)
+- add authorization logic using [gates and policies](./#authorization) ([compatible with Sanctum, Passport, Socialite...](./#authentication))
+- add [filtering logic](./#adding-filters)
 <!--* push changed data to the clients in real-time using Laravel Broadcast and [Mercure](https://mercure.rocks) (a popular WebSockets alternative, created by Kévin Dunglas, the original author of API Platform) and receive them using Laravel Echo-->
 - benefits from the API Platform JavaScript tools: [admin](../admin/index.md) and [create client](../create-client/index.md) (supports Next/React, Nuxt/Vue.js, Quasar, Vuetify and more!)
 <!-- * benefits from native HTTP cache (with automatic invalidation) -->
@@ -168,7 +168,7 @@ For instance, go to `http://127.0.0.1:8000/api/books.jsonld` to retrieve the lis
 > [!NOTE]
 > Documentation for Eloquent "API resources" encourages using the JSON:API community format.
 > While we recommend preferring JSON-LD when possible, JSON:API is also supported by API Platform,
-> read the [Content Negotiation](laravel#content-negotiation) section to learn how to enable it.
+> read the [Content Negotiation](./#content-negotiation) section to learn how to enable it.
 
 Of course, you can also use your favorite HTTP client to query the API.
 We are fond of [Hoppscotch](https://hoppscotch.com), a free and open source API client with good support of API Platform.

--- a/laravel/index.md
+++ b/laravel/index.md
@@ -7,16 +7,16 @@ using Laravel!
 
 With API Platform, you can:
 
-- [expose your Eloquent](#exposing-a-model) models in minutes as:
+- [expose your Eloquent](laravel#exposing-a-model) models in minutes as:
   - a REST API implementing the industry-leading standards, formats and best practices: [JSON-LD](https://en.wikipedia.org/wiki/JSON-LD)/[RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework), [JSON:API](https://jsonapi.org), [HAL](https://stateless.group/hal_specification.html), and many RFCs...
-  - a [GraphQL](#enabling-graphql) API
+  - a [GraphQL](laravel#enabling-graphql) API
   - or both at the same time, with the same code!
 - automatically expose an [OpenAPI](https://www.openapis.org) specification (formerly Swagger), dynamically generated from your Eloquent models and always up to date
 - automatically expose nice UIs and playgrounds to develop using your API ([Swagger UI](https://swagger.io/tools/swagger-ui/) and [GraphiQL](https://github.com/graphql/graphiql))
 - automatically paginate your collections
-- add validation logic using Laravel [Form Request Validation](#write-operations-authorization-and-validation)
-- add authorization logic using [gates and policies](#authorization) ([compatible with Sanctum, Passport, Socialite...](#authentication))
-- add [filtering logic](#adding-filters)
+- add validation logic using Laravel [Form Request Validation](laravel#write-operations-authorization-and-validation)
+- add authorization logic using [gates and policies](laravel#authorization) ([compatible with Sanctum, Passport, Socialite...](laravel#authentication))
+- add [filtering logic](laravel#adding-filters)
 <!--* push changed data to the clients in real-time using Laravel Broadcast and [Mercure](https://mercure.rocks) (a popular WebSockets alternative, created by Kévin Dunglas, the original author of API Platform) and receive them using Laravel Echo-->
 - benefits from the API Platform JavaScript tools: [admin](../admin/index.md) and [create client](../create-client/index.md) (supports Next/React, Nuxt/Vue.js, Quasar, Vuetify and more!)
 <!-- * benefits from native HTTP cache (with automatic invalidation) -->
@@ -168,7 +168,7 @@ For instance, go to `http://127.0.0.1:8000/api/books.jsonld` to retrieve the lis
 > [!NOTE]
 > Documentation for Eloquent "API resources" encourages using the JSON:API community format.
 > While we recommend preferring JSON-LD when possible, JSON:API is also supported by API Platform,
-> read the [Content Negotiation](#content-negotiation) section to learn how to enable it.
+> read the [Content Negotiation](laravel#content-negotiation) section to learn how to enable it.
 
 Of course, you can also use your favorite HTTP client to query the API.
 We are fond of [Hoppscotch](https://hoppscotch.com), a free and open source API client with good support of API Platform.

--- a/laravel/security.md
+++ b/laravel/security.md
@@ -5,7 +5,7 @@
 API Platform is compatible with Laravel's [authorization](https://laravel.com/docs/authorization) mechanism.
 
 To utilize policies in API Platform, it is essential to have Laravel's authentication system initialized.
-See the [Authentication section](#authentication) for more information.
+See the [Authentication section](laravel#authentication) for more information.
 
 Once a gate is defined, API Platform will automatically detect your policy.
 

--- a/laravel/security.md
+++ b/laravel/security.md
@@ -5,7 +5,7 @@
 API Platform is compatible with Laravel's [authorization](https://laravel.com/docs/authorization) mechanism.
 
 To utilize policies in API Platform, it is essential to have Laravel's authentication system initialized.
-See the [Authentication section](laravel#authentication) for more information.
+See the [Authentication section](./#authentication) for more information.
 
 Once a gate is defined, API Platform will automatically detect your policy.
 

--- a/laravel/testing.md
+++ b/laravel/testing.md
@@ -220,7 +220,7 @@ As a result, your test environment remains reliable and consistent across multip
 If everything is working properly, you should see `Tests: 5 passed (15 assertions)`.
 Your REST API is now properly tested!
 
-Check out the [API Test Assertions section](#api-test-assertions-with-laravel) to discover the full range of assertions
+Check out the [API Test Assertions section](laravel#api-test-assertions-with-laravel) to discover the full range of assertions
 and other features provided by API Platform's test utilities.
 
 ### Migrating from PHPUnit to Pest
@@ -244,7 +244,7 @@ If for some reason, PHPUnit is not installed refer to the [PHPUnit Installation 
 
 ### Writing Functional Tests with PHPUnit
 
-For instructions on generating the factory, please refer to the  [Generate The Factory section](#generate-the-factory).
+For instructions on generating the factory, please refer to the  [Generate The Factory section](laravel#generate-the-factory).
 
 #### Writing PHPUnit tests
 
@@ -428,7 +428,7 @@ during the test. As a result, your test environment remains reliable and consist
 If everything is working properly, you should see `OK (5 tests, 15 assertions)`.
 Your REST API is now properly tested!
 
-Check out the [API Test Assertions section](#api-test-assertions-with-laravel) to discover the full range of assertions
+Check out the [API Test Assertions section](laravel#api-test-assertions-with-laravel) to discover the full range of assertions
 and other features provided by API Platform's test utilities.
 
 ## Writing Unit Tests

--- a/laravel/testing.md
+++ b/laravel/testing.md
@@ -220,7 +220,7 @@ As a result, your test environment remains reliable and consistent across multip
 If everything is working properly, you should see `Tests: 5 passed (15 assertions)`.
 Your REST API is now properly tested!
 
-Check out the [API Test Assertions section](laravel#api-test-assertions-with-laravel) to discover the full range of assertions
+Check out the [API Test Assertions section](./#api-test-assertions-with-laravel) to discover the full range of assertions
 and other features provided by API Platform's test utilities.
 
 ### Migrating from PHPUnit to Pest
@@ -244,7 +244,7 @@ If for some reason, PHPUnit is not installed refer to the [PHPUnit Installation 
 
 ### Writing Functional Tests with PHPUnit
 
-For instructions on generating the factory, please refer to the  [Generate The Factory section](laravel#generate-the-factory).
+For instructions on generating the factory, please refer to the  [Generate The Factory section](./#generate-the-factory).
 
 #### Writing PHPUnit tests
 
@@ -428,7 +428,7 @@ during the test. As a result, your test environment remains reliable and consist
 If everything is working properly, you should see `OK (5 tests, 15 assertions)`.
 Your REST API is now properly tested!
 
-Check out the [API Test Assertions section](laravel#api-test-assertions-with-laravel) to discover the full range of assertions
+Check out the [API Test Assertions section](./#api-test-assertions-with-laravel) to discover the full range of assertions
 and other features provided by API Platform's test utilities.
 
 ## Writing Unit Tests


### PR DESCRIPTION
This pull request add the laravel prefix in the laravel section since some anchor links are pointing to the root (symfony) documentation

(ps: i don't know if this fix the links since i think this is automatically generated to site using the gh workflow)

For example in this image, this link: https://api-platform.com/docs/#exposing-a-model should be `/docs/laravel#exposing-a-model`
![image](https://github.com/user-attachments/assets/e479f975-d0ec-4934-8c17-ce777618fa2c)
