### PR TITLE
Docs (Symfony file upload): Change order of enabled formats

### DIFF
--- a/symfony/file-upload.md
+++ b/symfony/file-upload.md
@@ -15,8 +15,8 @@ Enable the multipart format globally in order to use it as the input format of y
 ```yaml
 api_platform:
   formats:
-    multipart: ['multipart/form-data']
     jsonld: ['application/ld+json']
+    multipart: ['multipart/form-data']
 ```
 
 ## Installing VichUploaderBundle


### PR DESCRIPTION
Having multipart at the first position of enabled formats in `api_platform.yaml` negatively affects the api (swagger) documentation. For some reason, all requests will be generated with 'accept: multipart/form-data', which is wrong for most endpoints. See the following GET request which is generated with the "accept: multipart/form-data" header (see the curl command below):

![image](https://github.com/user-attachments/assets/312f53c3-f881-432d-8bc0-c21646033946)

This leads to responses with the error message "Serialization for the format "multipart" is not supported.".

Switching the formats in `api_platform.yaml` to have `jsonld` at the first position solves this issue:

    formats:
        jsonld: ['application/ld+json']
        multipart: ['multipart/form-data']

Now, the request is generated and done properly with the correct accept header:
![image](https://github.com/user-attachments/assets/fa5068d5-36b2-48a4-b292-0615b90c0e44)

I was also able to reproduce this in version 4.0. This fix does not seem to have any other side effects on both versions 4.0 and 4.1. Can somebody confirm this?

Greetings!