### PR TITLE
Update note on supported Elasticsearch versions to include 8.4+

### DIFF
--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -8,12 +8,19 @@ application search, security analytics, metrics, logging, etc.
 API Platform comes natively with the **reading** support for Elasticsearch. It uses internally the official PHP client
 for Elasticsearch: [Elasticsearch-PHP](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html).
 
-Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0.
+Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4. Support for Elasticsearch
+8 was introduced in Api-platform 3.2.
 
 ## Enabling Reading Support
 
-To enable the reading support for Elasticsearch, simply require the Elasticsearch-PHP package using Composer:
+To enable the reading support for Elasticsearch, simply require the Elasticsearch-PHP package using Composer. For 
+Elasticsearch 8.4 or greater:
 
+```console
+composer require elasticsearch/elasticsearch:^8.4
+```
+
+For Elasticsearch 7:
 ```console
 composer require elasticsearch/elasticsearch:^7.11
 ```

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -9,7 +9,7 @@ API Platform comes natively with the **reading** support for Elasticsearch. It u
 for Elasticsearch: [Elasticsearch-PHP](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html).
 
 Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4 < 9.0. Support for 
-Elasticsearch 8 was introduced in Api-platform 3.2.
+Elasticsearch 8 was introduced in API Platform 3.2.
 
 ## Enabling Reading Support
 

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -13,7 +13,7 @@ Elasticsearch 8 was introduced in Api-platform 3.2.
 
 ## Enabling Reading Support
 
-To enable the reading support for Elasticsearch, simply require the Elasticsearch-PHP package using Composer. For 
+To enable the reading support for Elasticsearch, simply require the Elasticsearch-PHP package using Composer. For
 Elasticsearch 8:
 
 ```console

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -8,13 +8,13 @@ application search, security analytics, metrics, logging, etc.
 API Platform comes natively with the **reading** support for Elasticsearch. It uses internally the official PHP client
 for Elasticsearch: [Elasticsearch-PHP](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html).
 
-Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4. Support for Elasticsearch
-8 was introduced in Api-platform 3.2.
+Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4 < 9.0. Support for 
+Elasticsearch 8 was introduced in Api-platform 3.2.
 
 ## Enabling Reading Support
 
 To enable the reading support for Elasticsearch, simply require the Elasticsearch-PHP package using Composer. For 
-Elasticsearch 8.4 or greater:
+Elasticsearch 8:
 
 ```console
 composer require elasticsearch/elasticsearch:^8.4


### PR DESCRIPTION
Support for Elasticsearch 8 was introduced in [3.2.0](https://github.com/api-platform/core/releases/tag/v3.2.0) but the docs were never updated to reflect this. They currently states on the [Elasticsearch page](https://api-platform.com/docs/core/elasticsearch/)

> Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0.

This PR updates that note to reflect the current [composer.json constraints](https://github.com/api-platform/core/blob/88f5ac50d20d6510686a7552310cc567fcca45bf/src/Elasticsearch/composer.json#L30).

Note that [Elasticsearch 9](https://www.elastic.co/guide/en/elastic-stack/9.0/release-notes-elasticsearch-9.0.0.html) is currently in RC. It's unclear from their documentation if there will be breaking changes in regards to Api-platforms integration.
