### PR TITLE
Patched documentation problem with VichUploaderBundle

### DIFF
--- a/core/content-negotiation.md
+++ b/core/content-negotiation.md
@@ -356,7 +356,7 @@ merge new encoders and normalizers in API Platform.
 ## JSON:API sparse fieldset and sort parameters
 
 > [!WARNING]  
-> The SortFilter is for Eloquent, the Doctrine equivalent is the OrderFilter. 
+> The SortFilter is for Eloquent, the Doctrine equivalent is the OrderFilter.
 > The config/api-platform.php is Laravel specific.
 
 When working with JSON:API you may want to declare the `SparseFieldset` and the
@@ -371,11 +371,11 @@ use ApiPlatform\JsonApi\Filter\SparseFieldset;
 use ApiPlatform\Laravel\Eloquent\Filter\JsonApi\SortFilter;
 
 return [
-	// ...
-	'parameters' => [
-		new QueryParameter(key: 'fields', filter: SparseFieldset::class),
-		new QueryParameter(key: 'sort', filter: SortFilter::class),
-	],
+    // ...
+    'parameters' => [
+        new QueryParameter(key: 'fields', filter: SparseFieldset::class),
+        new QueryParameter(key: 'sort', filter: SortFilter::class),
+    ],
 ];
 ```
 

--- a/core/elasticsearch.md
+++ b/core/elasticsearch.md
@@ -8,7 +8,7 @@ application search, security analytics, metrics, logging, etc.
 API Platform comes natively with the **reading** support for Elasticsearch. It uses internally the official PHP client
 for Elasticsearch: [Elasticsearch-PHP](https://www.elastic.co/guide/en/elasticsearch/client/php-api/current/index.html).
 
-Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4 < 9.0. Support for 
+Be careful, API Platform only supports Elasticsearch >= 7.11.0 < 8.0 and Elasticsearch >= 8.4 < 9.0. Support for
 Elasticsearch 8 was introduced in API Platform 3.2.
 
 ## Enabling Reading Support

--- a/core/errors.md
+++ b/core/errors.md
@@ -330,7 +330,7 @@ Since 3.4, you also have the possibility to link your specific domain exceptions
 directly in your OpenAPI definition !
 
 Let's say that you have a `Greetings` resource, and that one of its providers can throw the following exception for the
-`ApiPlatform\Metadata\GetCollection` Operation: 
+`ApiPlatform\Metadata\GetCollection` Operation:
 
 ```php
 use ApiPlatform\Metadata\ErrorResource;
@@ -369,7 +369,7 @@ class MyDomainException extends \Exception implements ProblemExceptionInterface
 ```
 
 As long as your Exception implements `ApiPlatform\Metadata\Exception\ProblemExceptionInterface` and has the `ErrorResource`
-attribute, you can then map it to your Operation this way: 
+attribute, you can then map it to your Operation this way:
 
 ```php
 use ApiPlatform\Metadata\ApiResource;

--- a/extra/releases.md
+++ b/extra/releases.md
@@ -10,8 +10,8 @@ For example:
 - version 3.2 has been released on 12 October 2023;
 - version 3.3 has been released on 9 April 2024 (we were a little late, it should have been published in March);
 - versions 3.4 has been released on 18 September 2024;
-- versions 4.0 has been released on 27 September 2024; 
-- versions 4.1 has been released on 28 February 2025; 
+- versions 4.0 has been released on 27 September 2024;
+- versions 4.1 has been released on 28 February 2025;
 
 ## Maintenance
 

--- a/symfony/file-upload.md
+++ b/symfony/file-upload.md
@@ -84,6 +84,8 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
         new GetCollection(),
         new Post(
             inputFormats: ['multipart' => ['multipart/form-data']],
+            controller: CreateMediaObjectAction::class, 
+            deserialize: false, 
             openapi: new Model\Operation(
                 requestBody: new Model\RequestBody(
                     content: new \ArrayObject([
@@ -129,6 +131,38 @@ class MediaObject
 ```
 
 Note: From V3.3 onwards, `'multipart/form-data'` must either be including in the global API-Platform config, either in `formats` or `defaults->inputFormats`, or defined as an `inputFormats` parameter on an operation by operation basis.
+
+### Creating the Controller
+At this point, the entity is configured, but we still need to write the action that handles the file upload.
+```php
+<?php
+// api/src/Controller/CreateMediaObjectAction.php
+
+namespace App\Controller;
+
+use App\Entity\MediaObject;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+#[AsController]
+final class CreateMediaObjectAction extends AbstractController
+{
+    public function __invoke(Request $request): MediaObject
+    {
+        $uploadedFile = $request->files->get('file');
+        if (!$uploadedFile) {
+            throw new BadRequestHttpException('"file" is required');
+        }
+
+        $mediaObject = new MediaObject();
+        $mediaObject->file = $uploadedFile;
+
+        return $mediaObject;
+    }
+}
+```
 
 ### Resolving the File URL
 


### PR DESCRIPTION
This PR is aimed to patch documentation problem in case with VichUploaderBundle

See issue for context : https://github.com/api-platform/docs/issues/2058 

fix: patch indentation for mutiples markdown Files. Change documentation for file upload to indicate well the way to use ApiPlatform with VIchUploaderBundle

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
