### PR TITLE
fix(deployment): fix menu generation after doc revamp of #2141

### DIFF
--- a/outline.yaml
+++ b/outline.yaml
@@ -82,7 +82,7 @@ chapters:
     items:
       - index
       - getting-started
-      - schema-org
+      - schema
       - customizing
       - advanced-customization
       - handling-relations


### PR DESCRIPTION
renaming of `admin/schema-org.md` to `admin/schema.md` in #2141 did lead to crash of deployment, as menu can not be generated anymore in build: https://github.com/api-platform/docs/actions/runs/14727992117/job/41335196797

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
