### PR TITLE
Fix incorrect and unused imports in User entity documentation

### DIFF
--- a/symfony/user.md
+++ b/symfony/user.md
@@ -12,8 +12,6 @@ You can follow the [official Symfony Documentation](https://symfony.com/doc/curr
 
 namespace App\Entity;
 
-use ApiPlatform\Metadata\ApiFilter;
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
@@ -231,6 +229,7 @@ namespace App\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
+use App\Entity\User;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**


### PR DESCRIPTION
This pull request fixes two small issues in the User authentication example:

- Removed unused imports: `ApiFilter` and `ApiProperty` in the `User` entity
- Added missing `use App\Entity\User;` in the `UserPasswordHasher` processor

These corrections ensure that the example code works as expected when copied directly, and help improve the overall clarity and accuracy of the documentation for developers following it step by step.