### PR TITLE
feat(user): remove deprecated eraseCredentials

### DIFF
--- a/symfony/user.md
+++ b/symfony/user.md
@@ -139,14 +139,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         return (string) $this->email;
     }
-
-    /**
-     * @see UserInterface
-     */
-    public function eraseCredentials(): void
-    {
-        $this->plainPassword = null;
-    }
 }
 ```
 
@@ -258,7 +250,6 @@ final readonly class UserPasswordHasher implements ProcessorInterface
             $data->getPlainPassword()
         );
         $data->setPassword($hashedPassword);
-        $data->eraseCredentials();
 
         return $this->processor->process($data, $operation, $uriVariables, $context);
     }


### PR DESCRIPTION
Solves https://github.com/api-platform/docs/issues/2165

In my opinion, there is no need for additional references to 'eraseCredentials' in the documentation, and it should not cause any issues. So I purposed to remove this Symfony deprecation as reported in  https://github.com/api-platform/docs/issues/2165.
