### PR TITLE
Restore eraseCredentials() for Symfony 7.3 compatibility (until Symfony 8.0) and clear plainPassword manually

### DIFF
--- a/symfony/user.md
+++ b/symfony/user.md
@@ -139,6 +139,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     {
         return (string) $this->email;
     }
+
+    /**
+     * @see UserInterface
+     *
+     * Required until Symfony 8.0, where eraseCredentials() will be removed from the interface.
+     * No-op since plainPassword is cleared manually in the password processor.
+     */
+    public function eraseCredentials(): void
+    {
+        // Intentionally left blank
+    }
 }
 ```
 
@@ -250,6 +261,9 @@ final readonly class UserPasswordHasher implements ProcessorInterface
             $data->getPlainPassword()
         );
         $data->setPassword($hashedPassword);
+
+        // To avoid leaving sensitive data like the plain password in memory or logs, we manually clear it after hashing.
+        $data->setPlainPassword(null);
 
         return $this->processor->process($data, $operation, $uriVariables, $context);
     }


### PR DESCRIPTION
This PR updates the user authentication example to ensure compatibility with Symfony 7.3 and apply current security best practices:

- **Restores the `eraseCredentials()` method** in the `User` entity:
  Although deprecated since Symfony 7.1, the method is still required by the `UserInterface` in Symfony 7.3.
  It will be removed in Symfony 8.0, but must remain for now to avoid runtime errors.

- **Manually clears the `plainPassword` field** in the processor after hashing:
  Since `eraseCredentials()` is no longer called automatically, it's now the developer’s responsibility to ensure sensitive data is cleared.
  This avoids leaving passwords in memory or exposing them via logs, exceptions, or debug tools.

These changes make the example code functional and secure across current Symfony versions.
