### PR TITLE
Update alternative docker command lauch to use custom https port

### DIFF
--- a/symfony/index.md
+++ b/symfony/index.md
@@ -88,10 +88,10 @@ docker compose up --wait
 >
 > Be sure that the ports `80`, `443`, and `5432` of the host are not already in use. The usual offenders are Apache, NGINX, and Postgres. If they are running, stop them and run `docker compose up --wait` again.
 >
-> Alternatively, run the following command to start the web server on port `8080` with HTTPS disabled:
+> Alternatively, run the following command to start the web server on port `8080` and `8443`:
 >
 > ```console
-> SERVER_NAME=localhost:80 HTTP_PORT=8080 TRUSTED_HOSTS=localhost docker compose up --wait`
+> SERVER_NAME=localhost:80 HTTP_PORT=8080 HTTPS_PORT=8443 TRUSTED_HOSTS=localhost docker compose up --wait`
 > ```
 
 This starts the following services:


### PR DESCRIPTION
One potential way to fix #2188.
I don't see how we can disable https (as stated in the previous wording).
