### PR TITLE
Fix enable pagination client in API Platform configuration

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -203,7 +203,7 @@ To configure this feature globally, use the following configuration:
 # api/config/packages/api_platform.yaml
 api_platform:
   defaults:
-    pagination_client_enabled: false
+    pagination_client_enabled: true
   collection:
     pagination:
       enabled_parameter_name: pagination # optional


### PR DESCRIPTION
The pagination_client_enabled should be true instead of false to enable client side pagination.
