### PR TITLE
Remove invalid tip about #[GetCollection] alias

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -72,9 +72,6 @@ for the `GET` method for both `collection` and `item` to create a readonly endpo
 If the operation's name matches a supported HTTP method (`GET`, `POST`, `PUT`, `PATCH` or `DELETE`), the corresponding `method` property
 will be automatically added.
 
-> [!TIP]
-> The `#[GetCollection]` attribute is an alias for `#[Get(collection: true)]`
-
 ---
 
 > [!NOTE]


### PR DESCRIPTION
Removed tip about #[GetCollection] alias in operations documentation, as #[Get] does not have a collection field anymore.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
