### PR TITLE
docs: flip pagination_client_enabled

### DIFF
--- a/core/pagination.md
+++ b/core/pagination.md
@@ -203,7 +203,7 @@ To configure this feature globally, use the following configuration:
 # api/config/packages/api_platform.yaml
 api_platform:
   defaults:
-    pagination_client_enabled: false
+    pagination_client_enabled: true
   collection:
     pagination:
       enabled_parameter_name: pagination # optional


### PR DESCRIPTION
I noticed this after a lot of wondering why I couldn't disable the pagination from the client with the `pagination` query parameter after adding this config snippet. 

I think the docs here are wrong, also it would make sense to _enable_ client side pagination when setting a query parameter allowing the client to de-/activate the pagination. 
