### PR TITLE
docs: update UUID recommendation to v7 for better database performance

### DIFF
--- a/symfony/index.md
+++ b/symfony/index.md
@@ -361,7 +361,7 @@ The framework also uses these metadata to serialize and deserialize data from JS
 
 For the sake of simplicity, in this example we used public properties (except for the ID, see below). API Platform (as well
 as Symfony and Doctrine) also supports accessor methods (getters/setters), use them if you want to.
-We used a private property and a getter for the ID to enforce the fact that it is read only (we will let the DBMS generate it). API Platform also has first-grade support for UUIDs v7. You should probably use them instead of auto-incremented IDs.
+We used a private property and a getter for the ID to enforce the fact that it is read only (we will let the DBMS generate it). API Platform also has first-grade support for UUIDs v7. In some cases it is preferable use them instead of auto-incremented IDs.
 
 Because API Platform provides all the infrastructure for us, our API is almost ready!
 


### PR DESCRIPTION
Thanks for the documentation reference!

I noticed the linked 2015 blog post advocates for UUIDv4, but doesn't mention the database performance implications that have become better understood since then.

UUIDv4's random nature can be detrimental to database performance: when inserted as a primary key into B-tree indexes (like MySQL InnoDB or PostgreSQL), random UUIDs can fall into any position in the index. This causes frequent page splits, index fragmentation, slower writes, and poor cache utilization.

Would you be open to recommending UUIDv7 instead? It maintains the benefits of UUIDs while avoiding these performance issues thanks to its time-ordered structure.