### PR TITLE
docs: add missing "docs_formats" configuration for Symfony

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -265,6 +265,13 @@ api_platform:
     # The list of enabled patch formats. The first one will be the default.
     patch_formats: []
 
+    # The list of enabled docs formats. The first one will be the default.
+    docs_formats:
+        jsonld: ['application/ld+json']
+        #jsonapi: ['application/vnd.api+json']
+        jsonopenapi: ['application/vnd.openapi+json']
+        html: ['text/html']
+
     # The list of enabled error formats. The first one will be the default.
     error_formats:
         jsonproblem:


### PR DESCRIPTION
## Description

Adds the missing `docs_formats` configuration section to the Symfony configuration example in the documentation.

This configuration is essential for users who want to:
- Customize the available documentation formats (e.g., enable/disable JSON-LD, OpenAPI, HTML).
- Change the default documentation format (which is the first one in the list).

The equivalent configuration was already present in the Laravel documentation example, but was overlooked in the Symfony one.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
