### PR TITLE
docs(symfony): document the API Platform CLI installer

### DIFF
--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -9,7 +9,7 @@ You can choose your preferred stack between Symfony, Laravel, or bootstrapping t
 
 ### Symfony
 
-If you are starting a new project, the easiest way to get API Platform up is to install [API Platform for Symfony](../symfony/index.md).
+If you are starting a new project, the easiest way to get API Platform up is to use the CLI: `api-platform new my-project --framework=symfony`. See [API Platform for Symfony](../symfony/index.md) for details.
 
 It comes with the API Platform core library integrated with [the Symfony framework](https://symfony.com), [the schema generator](../schema-generator/index.md),
 [Doctrine ORM](https://www.doctrine-project.org),

--- a/core/getting-started.md
+++ b/core/getting-started.md
@@ -10,8 +10,9 @@ library manually.
 
 ### Symfony
 
-If you are starting a new project, the easiest way to get API Platform up is to install
-[API Platform for Symfony](../symfony/index.md).
+If you are starting a new project, the easiest way to get API Platform up is to use the CLI:
+`api-platform my-project --framework=symfony`. See [API Platform for Symfony](../symfony/index.md)
+for details.
 
 It comes with the API Platform core library integrated with
 [the Symfony framework](https://symfony.com), [the schema generator](../schema-generator/index.md),

--- a/laravel/index.md
+++ b/laravel/index.md
@@ -41,6 +41,15 @@ cd my-api-platform-laravel-app
 
 ## Installing API Platform
 
+> [!TIP]
+> The API Platform CLI can automate all of the steps below. To scaffold a new Laravel project with API Platform already installed, run:
+>
+> ```console
+> api-platform new my-project --framework=laravel
+> ```
+>
+> This detects the `laravel` installer if available, creates the project, requires `api-platform/laravel`, and runs `php artisan api-platform:install` for you. The manual steps below remain valid for adding API Platform to an existing Laravel project.
+
 In your Laravel project, install the API Platform integration for Laravel:
 
 ```console

--- a/laravel/index.md
+++ b/laravel/index.md
@@ -87,6 +87,17 @@ cd my-api-platform-laravel-app
 
 ## Installing API Platform
 
+> [!TIP] The API Platform CLI can automate all of the steps below. To scaffold a new Laravel project
+> with API Platform already installed, run:
+>
+> ```console
+> api-platform my-project --framework=laravel
+> ```
+>
+> This detects the `laravel` installer if available, creates the project, requires
+> `api-platform/laravel`, and runs `php artisan api-platform:install` for you. The manual steps
+> below remain valid for adding API Platform to an existing Laravel project.
+
 In your Laravel project, install the API Platform integration for Laravel:
 
 ```console

--- a/symfony/caddy.md
+++ b/symfony/caddy.md
@@ -3,33 +3,172 @@
 [The API Platform distribution](index.md) is shipped with [the Caddy web server](https://caddyserver.com).
 The build contains the [Mercure](../core/mercure.md) and the [Vulcain](https://vulcain.rocks) Caddy modules.
 
-Caddy is positioned in front of the web API and of the Progressive Web App.
-It routes requests to either service depending on the value of the `Accept` HTTP header or the extension
-of the requested file.
+Caddy is positioned in front of the web API and of the Progressive Web App (PWA).
+It routes requests to either service depending on the value of the `Accept` HTTP header or the path of the request.
 
 Using the same domain to serve the API and the PWA [improves performance by preventing unnecessary CORS preflight requests
 and encourages embracing the REST principles](https://dunglas.fr/2022/01/preventing-cors-preflight-requests-using-content-negotiation/).
 
-By default, requests having an `Accept` request header containing the `text/html` media type are routed to the Next.js application,
-except for some paths known to be resources served by the API (e.g. the Swagger UI documentation, static files provided by bundles...).
-Other requests are routed to the API.
+## Why `route {}` Is Required
 
-Sometimes, you may want to let the PHP application generate HTML responses.
-For instance, when you create your own Symfony controllers serving HTML pages,
-or when using bundles such as EasyAdmin or SonataAdmin.
+Caddy processes directives in a [predefined global order](https://caddyserver.com/docs/caddyfile/directives#directive-order),
+not in the order they appear in the Caddyfile. In that order, `rewrite` runs **before** `reverse_proxy`. Without
+explicit ordering, a browser request to `/` would match the `@phpRoute` rewrite condition and be rewritten to
+`index.php` before Caddy ever evaluated whether the request should be proxied to Next.js.
 
-To do so, you have to tweak the rules used to route the requests.
-Open `api-platform/api/frankenphp/Caddyfile` and modify the expression.
-You can use [any CEL (Common Expression Language) expression](https://caddyserver.com/docs/caddyfile/matchers#expression) supported by Caddy.
+Wrapping the directives in a `route {}` block enforces **strict first-match-wins evaluation in file order**. The first
+directive that matches a request wins, and Caddy stops evaluating the rest. This is what makes the `@pwa` proxy check
+run before the PHP rewrite:
 
-For instance, if you want to route all requests to a path starting with `/admin` to the API, modify the existing expression like this:
+```caddy
+route {
+    # 1. Check @pwa first — proxy to Next.js if matched
+    reverse_proxy @pwa http://{$PWA_UPSTREAM}
 
-```patch
-# Matches requests for HTML documents, for static files and for Next.js files,
-# except for known API paths and paths with extensions handled by API Platform
+    # 2. Only if @pwa did not match, rewrite to index.php
+    @phpRoute { not path /.well-known/mercure*; not file {path} }
+    rewrite @phpRoute index.php
+
+    # 3. Run PHP for index.php
+    @frontController path index.php
+    php @frontController
+
+    # 4. Serve remaining static files
+    file_server { hide *.php }
+}
+```
+
+## The `@pwa` Matcher
+
+The `@pwa` named matcher is a [CEL (Common Expression Language) expression](https://caddyserver.com/docs/caddyfile/matchers#expression)
+that decides which requests are forwarded to the Next.js application:
+
+```caddy
 @pwa expression `(
-        {header.Accept}.matches("\\btext/html\\b")
--        && !{path}.matches("(?i)(?:^/docs|^/graphql|^/bundles/|^/_profiler|^/_wdt|\\.(?:json|html$|csv$|ya?ml$|xml$))")
-+        && !{path}.matches("(?i)(?:^/admin|^/docs|^/graphql|^/bundles/|^/_profiler|^/_wdt|\\.(?:json|html$|csv$|ya?ml$|xml$))")
-    )`
+        header({'Accept': '*text/html*'})
+        && !path(
+            '/docs*', '/graphql*', '/bundles*', '/contexts*', '/_profiler*', '/_wdt*',
+            '*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
+        )
+    )
+    || path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+    || query({'_rsc': '*'})`
+```
+
+The expression has three independent clauses joined by `||`. A request matches `@pwa` if **any** clause is true.
+
+### Clause 1: HTML requests that are not API paths
+
+A browser navigating to any URL sends `Accept: text/html, */*`. This clause forwards those requests to Next.js unless
+the path is known to be served by the API or carries an extension that API Platform handles through
+[content negotiation](../core/content-negotiation.md).
+
+Paths excluded from Next.js (handled by PHP instead):
+
+| Pattern | Reason |
+|---|---|
+| `/docs*` | Swagger UI and OpenAPI documentation |
+| `/graphql*` | GraphQL endpoint |
+| `/bundles*` | Symfony bundle assets published by `assets:install` |
+| `/contexts*` | JSON-LD context documents |
+| `/_profiler*`, `/_wdt*` | Symfony Web Debug Toolbar and Profiler |
+| `*.json*`, `*.html`, `*.csv`, `*.yml`, `*.yaml`, `*.xml` | Content-negotiated formats served by the API |
+
+### Clause 2: Next.js static assets and well-known files
+
+```
+path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+```
+
+These paths are forwarded to Next.js unconditionally, regardless of the `Accept` header. `/_next/*` and `/__next/*`
+are the internal asset paths used by the Next.js runtime for JavaScript chunks, CSS, images, and hot module
+replacement updates in development.
+
+### Clause 3: React Server Components requests
+
+```
+query({'_rsc': '*'})
+```
+
+Next.js uses the `_rsc` query parameter internally for
+[React Server Components](https://nextjs.org/docs/app/building-your-application/rendering/server-components) data
+fetching. These requests do not carry `text/html` in their `Accept` header, so they would miss clause 1 without this
+dedicated check.
+
+## The `Link` Header
+
+```caddy
+header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
+```
+
+This directive is placed at the **site block level**, outside the `route {}` block, so it applies to every response
+regardless of whether it came from PHP or Next.js. The `?` prefix means the header is only set when not already
+present in the response — a PHP response that sets its own `Link` header is not overwritten.
+
+Setting this at the Caddy level serves two purposes:
+
+1. **API discoverability**: every response advertises the Hydra API documentation URL, allowing clients to
+   auto-discover the API.
+2. **Mercure subscription**: every response advertises the Mercure hub URL, so clients can subscribe to real-time
+   updates without any application code.
+
+The Next.js application does not need to set these headers itself — they arrive on every response automatically.
+
+## The `PWA_UPSTREAM` Environment Variable
+
+```caddy
+reverse_proxy @pwa http://{$PWA_UPSTREAM}
+```
+
+`PWA_UPSTREAM` is resolved at runtime from the container environment. In `compose.yaml` it is set to `pwa:3000`,
+where `pwa` is the Docker Compose service name and `3000` is the default port of the Next.js server.
+
+When the `pwa` service is not running (for example in an API-only project), Caddy returns a `502 Bad Gateway` for any
+request matching `@pwa`. To run without a Next.js frontend, comment out that line in the Caddyfile:
+
+```caddy
+route {
+    # Comment the following line if you don't want Next.js to catch requests for HTML documents.
+    # In this case, they will be handled by the PHP app.
+    # reverse_proxy @pwa http://{$PWA_UPSTREAM}
+
+    @phpRoute { not path /.well-known/mercure*; not file {path} }
+    rewrite @phpRoute index.php
+    @frontController path index.php
+    php @frontController
+    file_server { hide *.php }
+}
+```
+
+## Adjusting the Routing Rules
+
+### Routing an admin path to PHP
+
+If you use EasyAdmin, SonataAdmin, or a custom Symfony controller that serves HTML pages, add the path prefix to the
+exclusion list inside clause 1 so those requests bypass Next.js:
+
+```caddy
+@pwa expression `(
+        header({'Accept': '*text/html*'})
+        && !path(
+            '/admin*',
+            '/docs*', '/graphql*', '/bundles*', '/contexts*', '/_profiler*', '/_wdt*',
+            '*.json*', '*.html', '*.csv', '*.yml', '*.yaml', '*.xml'
+        )
+    )
+    || path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
+    || query({'_rsc': '*'})`
+```
+
+You can use [any CEL expression](https://caddyserver.com/docs/caddyfile/matchers#expression) supported by Caddy.
+
+### Adding a custom API prefix
+
+If your API is mounted under a prefix such as `/api`, add it to the exclusion list:
+
+```caddy
+&& !path(
+    '/api*',
+    '/docs*', '/graphql*', ...
+)
 ```

--- a/symfony/caddy.md
+++ b/symfony/caddy.md
@@ -1,16 +1,120 @@
 # Configuring the Caddy Web Server with Symfony
 
-[The API Platform Symfony variant](index.md), when generated with Docker, is shipped with
-[the Caddy web server](https://caddyserver.com). The build contains the
-[Mercure](../core/mercure.md) and the [Vulcain](https://vulcain.rocks) Caddy modules.
+When you scaffold a project with the [API Platform CLI](index.md), the Symfony application is built
+on top of [`symfony-docker`](https://github.com/dunglas/symfony-docker), which ships
+[the Caddy web server](https://caddyserver.com) running [FrankenPHP](https://frankenphp.dev). The
+build contains the [Mercure](../core/mercure.md) and the [Vulcain](https://vulcain.rocks) Caddy
+modules.
 
-Caddy is positioned in front of the web API and of the Progressive Web App (PWA). It routes requests
-to either service depending on the value of the `Accept` HTTP header or the path of the request.
+The Caddyfile lives at `api/frankenphp/Caddyfile`.
 
-Using the same domain to serve the API and the PWA
-[improves performance by preventing unnecessary CORS preflight requests and encourages embracing the REST principles](https://dunglas.fr/2022/01/preventing-cors-preflight-requests-using-content-negotiation/).
+## How the CLI Serves the API and the PWA
 
-## Why `route {}` Is Required
+By default the API and the Progressive Web App (PWA) are served **separately**:
+
+- Caddy serves the **API** on `https://localhost`.
+- When you scaffold with `--with-pwa`, the Next.js application runs **standalone** with `pnpm dev`
+  on `http://localhost:3000`. It calls the API cross-origin using the `NEXT_PUBLIC_API_ENTRYPOINT`
+  value written to `pwa/.env.local`, and the CLI installs and configures
+  [`nelmio/cors-bundle`](https://github.com/nelmio/NelmioCorsBundle) on the API so those
+  cross-origin requests are allowed.
+
+This keeps the two applications independent and requires no Caddy configuration. If you prefer to
+serve both on the **same domain** through Caddy — which
+[improves performance by preventing unnecessary CORS preflight requests and encourages embracing the REST principles](https://dunglas.fr/2022/01/preventing-cors-preflight-requests-using-content-negotiation/)
+— see
+[Serving the API and the PWA on the Same Domain](#serving-the-api-and-the-pwa-on-the-same-domain)
+below.
+
+## The Shipped Caddyfile
+
+Out of the box, `api/frankenphp/Caddyfile` routes every request to the PHP application. The relevant
+part of the site block looks like this:
+
+```caddy
+{$SERVER_NAME:localhost} {
+    root /app/public
+    encode zstd br gzip
+
+    mercure {
+        # ...Mercure hub configuration...
+    }
+
+    vulcain
+
+    # Extra directives injected by the CLI (see "The Link Header" below)
+    {$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+    @phpRoute {
+        not path /.well-known/mercure*
+        not file {path}
+    }
+    rewrite @phpRoute index.php
+
+    @frontController path index.php
+    php @frontController {
+        worker {
+            file ./public/index.php
+        }
+    }
+
+    file_server {
+        hide *.php
+    }
+}
+```
+
+Any request that is not an existing static file and is not a Mercure subscription is rewritten to
+`index.php` and handled by Symfony through the FrankenPHP worker.
+
+## The `Link` Header
+
+The CLI adds a Hydra + Mercure `Link` header to every response. Rather than editing the Caddyfile
+directly, it injects the directive through the `CADDY_SERVER_EXTRA_DIRECTIVES` environment variable
+in `api/compose.yaml`, inside a recipe block:
+
+```yaml
+###> api-platform/api-platform ###
+CADDY_SERVER_EXTRA_DIRECTIVES:
+    'header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation",
+    </.well-known/mercure>; rel="mercure"`'
+###< api-platform/api-platform ###
+```
+
+The `?` prefix means the header is only set when not already present in the response — a PHP
+response that sets its own `Link` header is not overwritten.
+
+Setting it at the Caddy level serves two purposes:
+
+1. **API discoverability**: every response advertises the Hydra API documentation URL, allowing
+   clients to auto-discover the API.
+2. **Mercure subscription**: every response advertises the Mercure hub URL, so clients can subscribe
+   to real-time updates without any application code.
+
+## Serving the API and the PWA on the Same Domain
+
+If you want Caddy to serve both the API and the Next.js application on a single domain, you need to
+forward HTML requests to the PWA and keep API requests on PHP. This is **not** configured by the
+CLI; the steps below add it on top of a scaffolded project.
+
+### 1. Make the PWA reachable from the Caddy container
+
+Caddy runs inside the `php` container, so it must be able to reach the Next.js server. Either:
+
+- run the PWA in a Docker service named `pwa` listening on port `3000` (then the upstream is
+  `pwa:3000`), or
+- keep running `pnpm dev` on the host and target it with `host.docker.internal:3000`.
+
+Declare the upstream as an environment variable for the `php` service in `api/compose.yaml`:
+
+```yaml
+services:
+    php:
+        environment:
+            PWA_UPSTREAM: pwa:3000
+```
+
+### 2. Wrap the routing directives in a `route {}` block
 
 Caddy processes directives in a
 [predefined global order](https://caddyserver.com/docs/caddyfile/directives#directive-order), not in
@@ -21,7 +125,8 @@ Next.js.
 
 Wrapping the directives in a `route {}` block enforces **strict first-match-wins evaluation in file
 order**. The first directive that matches a request wins, and Caddy stops evaluating the rest. This
-is what makes the `@pwa` proxy check run before the PHP rewrite:
+makes the `@pwa` proxy check run before the PHP rewrite. Replace the `@phpRoute … file_server`
+section of the site block with:
 
 ```caddy
 route {
@@ -34,16 +139,20 @@ route {
 
     # 3. Run PHP for index.php
     @frontController path index.php
-    php @frontController
+    php @frontController {
+        worker {
+            file ./public/index.php
+        }
+    }
 
     # 4. Serve remaining static files
     file_server { hide *.php }
 }
 ```
 
-## The `@pwa` Matcher
+### 3. Define the `@pwa` matcher
 
-The `@pwa` named matcher is a
+Add a `@pwa` named matcher — a
 [CEL (Common Expression Language) expression](https://caddyserver.com/docs/caddyfile/matchers#expression)
 that decides which requests are forwarded to the Next.js application:
 
@@ -62,7 +171,7 @@ that decides which requests are forwarded to the Next.js application:
 The expression has three independent clauses joined by `||`. A request matches `@pwa` if **any**
 clause is true.
 
-### Clause 1: HTML requests that are not API paths
+#### Clause 1: HTML requests that are not API paths
 
 A browser navigating to any URL sends `Accept: text/html, */*`. This clause forwards those requests
 to Next.js unless the path is known to be served by the API or carries an extension that API
@@ -79,7 +188,7 @@ Paths excluded from Next.js (handled by PHP instead):
 | `/_profiler*`, `/_wdt*`                                  | Symfony Web Debug Toolbar and Profiler              |
 | `*.json*`, `*.html`, `*.csv`, `*.yml`, `*.yaml`, `*.xml` | Content-negotiated formats served by the API        |
 
-### Clause 2: Next.js static assets and well-known files
+#### Clause 2: Next.js static assets and well-known files
 
 ```caddy
 path('/favicon.ico', '/manifest.json', '/robots.txt', '/sitemap*', '/_next*', '/__next*')
@@ -89,7 +198,7 @@ These paths are forwarded to Next.js unconditionally, regardless of the `Accept`
 and `/__next/*` are the internal asset paths used by the Next.js runtime for JavaScript chunks, CSS,
 images, and hot module replacement updates in development.
 
-### Clause 3: React Server Components requests
+#### Clause 3: React Server Components requests
 
 ```caddy
 query({'_rsc': '*'})
@@ -100,56 +209,14 @@ Next.js uses the `_rsc` query parameter internally for
 data fetching. These requests do not carry `text/html` in their `Accept` header, so they would miss
 clause 1 without this dedicated check.
 
-## The `Link` Header
-
-```caddy
-header ?Link `</docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation", </.well-known/mercure>; rel="mercure"`
-```
-
-This directive is placed at the **site block level**, outside the `route {}` block, so it applies to
-every response regardless of whether it came from PHP or Next.js. The `?` prefix means the header is
-only set when not already present in the response — a PHP response that sets its own `Link` header
-is not overwritten.
-
-Setting this at the Caddy level serves two purposes:
-
-1. **API discoverability**: every response advertises the Hydra API documentation URL, allowing
-   clients to auto-discover the API.
-2. **Mercure subscription**: every response advertises the Mercure hub URL, so clients can subscribe
-   to real-time updates without any application code.
-
-The Next.js application does not need to set these headers itself — they arrive on every response
-automatically.
-
-## The `PWA_UPSTREAM` Environment Variable
-
-```caddy
-reverse_proxy @pwa http://{$PWA_UPSTREAM}
-```
-
-`PWA_UPSTREAM` is resolved at runtime from the container environment. In `compose.yaml` it is set to
-`pwa:3000`, where `pwa` is the Docker Compose service name and `3000` is the default port of the
-Next.js server.
-
-When the `pwa` service is not running (for example in an API-only project), Caddy returns a
-`502 Bad Gateway` for any request matching `@pwa`. To run without a Next.js frontend, comment out
-that line in the Caddyfile:
-
-```caddy
-route {
-    # Comment the following line if you don't want Next.js to catch requests for HTML documents.
-    # In this case, they will be handled by the PHP app.
-    # reverse_proxy @pwa http://{$PWA_UPSTREAM}
-
-    @phpRoute { not path /.well-known/mercure*; not file {path} }
-    rewrite @phpRoute index.php
-    @frontController path index.php
-    php @frontController
-    file_server { hide *.php }
-}
-```
+When the PWA upstream is unreachable, Caddy returns a `502 Bad Gateway` for any request matching
+`@pwa`. To temporarily fall back to PHP-rendered HTML, comment out the `reverse_proxy @pwa` line
+inside the `route {}` block.
 
 ## Adjusting the Routing Rules
+
+The rules below assume you have enabled single-domain serving and therefore have a `@pwa` matcher to
+tweak.
 
 ### Routing an admin path to PHP
 

--- a/symfony/index.md
+++ b/symfony/index.md
@@ -16,14 +16,13 @@ API Platform also provides ambitious **JavaScript** tools to create web and mobi
 
 API Platform is shipped with **[Docker](../deployment/docker-compose.md)** and **[Kubernetes](../deployment/kubernetes.md)** definitions, to develop and deploy instantly on the cloud.
 
-The easiest and most powerful way to get started is [to download the API Platform distribution](https://github.com/api-platform/api-platform/releases). It contains:
+The easiest way to get started is to use the API Platform CLI to scaffold a new project. It sets up:
 
 - the API skeleton, including [the Core library](../core/index.md), [the Symfony framework](https://symfony.com/) ([optional](../core/bootstrap.md)) and [the Doctrine ORM](https://www.doctrine-project.org/projects/orm.html) ([optional](../core/extending.md))
 - [the client scaffolding tool](../create-client/index.md) to generate [Next.js](../create-client/index.md) web applications from the API documentation ([Nuxt](https://nuxt.com/), [Vue](https://vuejs.org/), [Create React App](https://reactjs.org), [React Native](https://reactnative.dev/), [Quasar](https://quasar.dev/) and [Vuetify](https://vuetifyjs.com/) are also supported)
 - [a beautiful admin interface](../admin/index.md), built on top of React Admin, dynamically created by parsing the API documentation
 - all you need to [create real-time and async APIs using the Mercure protocol](../core/mercure.md)
-- a [Docker](../deployment/docker-compose.md) definition to start a working development environment in a single command, providing containers for the API and the Next.js web application
-- a [Helm](https://helm.sh/) chart to deploy the API in any [Kubernetes](../deployment/kubernetes.md) cluster
+- a [Docker](../deployment/docker-compose.md) definition to start a working development environment in a single command, providing containers for the API and optionally a Next.js web application
 
 ## A Bookshop API
 
@@ -56,31 +55,42 @@ asynchronous jobs to your APIs is straightforward.
 
 ## Installing the Framework
 
-### Using the API Platform Distribution (Recommended)
+### Using the API Platform CLI (Recommended)
 
-Start by [downloading the API Platform distribution](https://github.com/api-platform/api-platform/releases/latest), or [generate a GitHub repository from the template we provide](https://github.com/new?template_name=api-platform&template_owner=api-platform).
-You will add your own code and configuration inside this skeleton.
+First, install the API Platform CLI:
 
-**Note**: Avoid downloading the `.zip` archive, as it may cause potential [permission](https://github.com/api-platform/api-platform/issues/319#issuecomment-307037562) [issues](https://github.com/api-platform/api-platform/issues/777#issuecomment-412515342), prefer the `.tar.gz` archive.
+```console
+# macOS / Linux (Homebrew — recommended)
+brew install api-platform/tap/api-platform
+
+# Or download the binary directly (macOS / Linux)
+curl -sL "https://github.com/api-platform/api-platform/releases/latest/download/api-platform_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').tar.gz" | tar xz -C /usr/local/bin
+
+# Or with Go
+go install github.com/api-platform/api-platform/cmd/api-platform@latest
+```
+
+Then scaffold a new Symfony project:
+
+```console
+api-platform new my-project --framework=symfony
+```
+
+To also scaffold a Next.js PWA frontend, add the `--with-pwa` flag:
+
+```console
+api-platform new my-project --framework=symfony --with-pwa
+```
+
+The CLI creates a `my-project/` directory containing an `api/` subdirectory with the Symfony application and all Docker infrastructure. If you used `--with-pwa`, a `pwa/` subdirectory is also created with a Next.js application.
 
 API Platform is shipped with a [Docker](https://docker.com) definition that makes it easy to get a containerized development
 environment up and running. If you do not already have Docker on your computer, it's the right time to [install it](https://docs.docker.com/get-docker/).
 
-**Note**: On Mac, only [Docker for Mac](https://docs.docker.com/docker-for-mac/) is supported.
-Similarly, on Windows, only [Docker for Windows](https://docs.docker.com/docker-for-windows/) is supported. Docker Machine **is not** supported out of the box.
-
-Open a terminal, and navigate to the directory containing your project skeleton. Run the following command to start all
-services using [Docker Compose](https://docs.docker.com/compose/):
-
-Build the images:
+Enter the project directory and start the services:
 
 ```console
-docker compose build --no-cache
-```
-
-Then, start Docker Compose in detached mode:
-
-```console
+cd my-project/api
 docker compose up --wait
 ```
 
@@ -99,14 +109,24 @@ This starts the following services:
 | Name     | Description                                                                                                                                                                                                                                                                                                                       |
 | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | php      | The API powered by [FrankenPHP](https://frankenphp.dev) (a modern application server for PHP built on top of [Caddy web server](caddy.md) and with native support for [Mercure realtime](../core/mercure.md), [Vulcain relations preloading](https://vulcain.rocks), and [XDebug](debugging.md)), Composer, and sensitive configs |
-| pwa      | Next.js project compatible with Create Client and having Admin preinstalled                                                                                                                                                                                                                                                       |
 | database | PostgreSQL database server                                                                                                                                                                                                                                                                                                        |
+
+If you used `--with-pwa`, a `pwa` container is also started:
+
+| Name | Description                                                                |
+| ---- | -------------------------------------------------------------------------- |
+| pwa  | Next.js project compatible with Create Client and having Admin preinstalled |
 
 The following components are available:
 
+| URL                        | Path   | Language | Description |
+| -------------------------- | ------ | -------- | ----------- |
+| `https://localhost/docs/`  | `api/` | PHP      | The API     |
+
+If you used `--with-pwa`:
+
 | URL                        | Path               | Language   | Description             |
 | -------------------------- | ------------------ | ---------- | ----------------------- |
-| `https://localhost/docs/`  | `api/`             | PHP        | The API                 |
 | `https://localhost/`       | `pwa/`             | TypeScript | The Next.js application |
 | `https://localhost/admin/` | `pwa/pages/admin/` | TypeScript | The Admin               |
 
@@ -128,14 +148,13 @@ you'll get auto-completion for almost everything and awesome quality analysis.
 
 [PHP Intelephense for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=bmewburn.vscode-intelephense-client) also works well, and is free and open source.
 
-The API Platform distribution comes with a dummy entity for test purposes: `api/src/Entity/Greeting.php`. We will remove
-it later.
+The Flex recipe may install demo files for testing purposes. These can be removed once you are ready to build your own resources.
 
-If you're used to the PHP ecosystem, you probably guessed that this test entity uses the industry-leading [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html)
-library as a persistence system. It is shipped, in the API Platform distribution.
+If you're used to the PHP ecosystem, you probably guessed that the project uses the industry-leading [Doctrine ORM](https://www.doctrine-project.org/projects/orm.html)
+library as a persistence system.
 
 Doctrine ORM is the easiest way to persist and query data in an API Platform project thanks to the bridge shipped with the
-distribution, but it's also entirely optional, and [you may prefer to plug your own persistence system](../core/design.md).
+framework, but it's also entirely optional, and [you may prefer to plug your own persistence system](../core/design.md).
 
 The Doctrine Bridge is optimized for performance and development convenience. For instance, when using Doctrine, API Platform
 is able to automatically optimize the generated SQL queries by adding the appropriate `JOIN` clauses. It also provides a
@@ -152,16 +171,13 @@ systems together in the same project.
 > given command in this container. You may want [to create an alias](https://www.linfo.org/alias.html) to make your life easier.
 > So, for example, you could run a command like this: `docker compose exec php <command>`.
 
-### Using Symfony CLI
+### Adding to an Existing Symfony Project
 
-Alternatively, the API Platform server component can also be installed directly on a local machine.
-**This method is recommended only for users who want full control over the directory structure and the installed
-dependencies.**
+If you already have a Symfony project and want to add API Platform to it, you can install it directly using [the Symfony binary](https://symfony.com/download).
 
-[For a good introduction, watch how to install API Platform without the distribution on SymfonyCasts](https://symfonycasts.com/screencast/api-platform/install?cid=apip).
+[For a good introduction, watch how to install API Platform without the CLI on SymfonyCasts](https://symfonycasts.com/screencast/api-platform/install?cid=apip).
 
-The rest of this tutorial assumes that you have installed API Platform using the official distribution. Go straight to the
-next section if it's your case.
+The rest of this tutorial assumes that you have used the CLI to create a new project. If you are adding API Platform to an existing project, adapt the steps below accordingly.
 
 API Platform has an official Symfony Flex recipe. It means that you can easily install it from any Symfony
 application using [the Symfony binary](https://symfony.com/download):
@@ -212,9 +228,7 @@ Open `https://localhost` in your favorite web browser:
 You'll need to add a security exception in your browser to accept the self-signed TLS certificate that has been generated
 for this container when installing the framework.
 
-Later you will probably replace this welcome screen by the homepage of your Next.js application. If you don't plan to create
-a Progressive Web App, you can remove the `pwa/` directory as well as the related lines in `docker-compose*.yml` and in `api/frankenphp/Caddyfile` (don't do it
-now, we'll use this container later in this tutorial).
+If you used `--with-pwa`, the welcome screen will later be replaced by the homepage of your Next.js application. If you no longer need the PWA, you can remove the `pwa/` directory as well as the related service in `compose.yaml` and the `@pwa` matcher block in `api/frankenphp/Caddyfile`.
 
 Click on the "API" button, or go to `https://localhost/docs/`:
 
@@ -224,17 +238,16 @@ API Platform exposes a description of the API in the [OpenAPI](https://www.opena
 It also integrates a customized version of [Swagger UI](https://swagger.io/swagger-ui/), a nice interface rendering the
 OpenAPI documentation.
 Click on an operation to display its details. You can also send requests to the API directly from the UI.
-Try to create a new _Greeting_ resource using the `POST` operation, then access it using the `GET` operation and, finally,
-delete it by executing the `DELETE` operation.
+If the Flex recipe installed demo resources, you can use the `POST` operation to create a resource, retrieve it with `GET`, and delete it with `DELETE`.
 If you access any API URL with the `.html` extension appended, API Platform displays
-the corresponding API request in the UI. Try it yourself by browsing to `https://localhost/greetings.html`. If no extension is present, API Platform will use the `Accept` header to select the format to use. By default, a JSON-LD response is sent ([configurable behavior](../core/content-negotiation.md)).
+the corresponding API request in the UI. If no extension is present, API Platform will use the `Accept` header to select the format to use. By default, a JSON-LD response is sent ([configurable behavior](../core/content-negotiation.md)).
 
 So, if you want to access the raw data, you have two alternatives:
 
 - Add the correct `Accept` header (or don't set any `Accept` header at all if you don't care about security) - preferred when writing API clients
 - Add the format you want as the extension of the resource - for debug purpose only
 
-For instance, go to `https://localhost/greetings.jsonld` to retrieve the list of `Greeting` resources in JSON-LD.
+For instance, if a `books` resource is defined, go to `https://localhost/books.jsonld` to retrieve the list in JSON-LD.
 
 Of course, you can also use your favorite HTTP client to query the API.
 We are fond of [Hoppscotch](https://hoppscotch.com), a free and open source API client with good support of API Platform.
@@ -483,7 +496,7 @@ They are supported as well.
 Learn more about how to map entities with the Doctrine ORM in [the project's official documentation](https://docs.doctrine-project.org/projects/doctrine-orm/en/current/reference/association-mapping.html)
 or in Kévin's book "[Persistence in PHP with the Doctrine ORM](https://www.amazon.fr/gp/product/B00HEGSKYQ/ref=as_li_tl?ie=UTF8&camp=1642&creative=6746&creativeASIN=B00HEGSKYQ&linkCode=as2&tag=kevidung-21)".
 
-Now, delete the file `api/src/Entity/Greeting.php`. This demo entity isn't useful anymore.
+Now, if the Flex recipe installed any demo entities, remove them from `api/src/Entity/` as they are no longer needed.
 Finally, generate a new database migration using [Doctrine Migrations](https://symfony.com/doc/current/doctrine.html#migrations-creating-the-database-tables-schema) and apply it:
 
 ```console
@@ -774,7 +787,7 @@ API Platform also has an awesome [client generator](../create-client/index.md) a
 [React/Redux](../create-client/react.md), [Vue.js](../create-client/vuejs.md), [Quasar](../create-client/quasar.md), and [Vuetify](../create-client/vuetify.md) Progressive Web Apps/Single Page Apps that you can
 easily tune and customize. The generator also supports [React Native](../create-client/react-native.md) if you prefer to leverage all capabilities of mobile devices.
 
-The distribution comes with a skeleton ready to welcome the [Next.js](https://nextjs.org/) flavor of the generated code. To bootstrap your app, run:
+If you created your project with `--with-pwa`, a Next.js skeleton is already present in `pwa/` ready to welcome generated code. To bootstrap your app, run:
 
 ```console
 docker compose exec pwa \

--- a/symfony/index.md
+++ b/symfony/index.md
@@ -126,6 +126,10 @@ When the PWA and the admin are enabled, the installer creates a project director
 `api/` subdirectory (the Symfony API) alongside a `pwa/` directory (the Next.js application) and an
 `admin/` directory (the React-admin SPA). The rest of this tutorial assumes this layout.
 
+By default the installer also writes `AGENTS.md` and `CLAUDE.md` instruction files so AI coding
+agents (Claude Code, Cursor, GitHub Copilot, …) know how to work with API Platform in your project.
+Pass `--no-with-agents` to skip them.
+
 API Platform is shipped with a [Docker](https://docker.com) definition that makes it easy to get a
 containerized development environment up and running. If you do not already have Docker on your
 computer, it's the right time to [install it](https://docs.docker.com/get-docker/).
@@ -167,7 +171,9 @@ This starts the following services:
 
 When generated with `--with-pwa`, the Next.js application lives in the sibling `pwa/` directory. It
 is **not** part of the Docker Compose stack: you run it separately with its own development server
-(see [A Next.js Web App](#a-nextjs-web-app) below).
+(see [A Next.js Web App](#a-nextjs-web-app) below). To serve the API and the PWA on the same domain
+through Caddy instead, see
+[Configuring the Caddy Web Server](caddy.md#serving-the-api-and-the-pwa-on-the-same-domain).
 
 The following components are available:
 


### PR DESCRIPTION
Targets the **4.3** branch. Builds on the CLI-installer docs already on 4.3, adding the pieces that were missing or inaccurate.

Linked to https://github.com/api-platform/api-platform/pull/2980

## What changed

### `symfony/caddy.md` (main change)
The page documented a single-domain Caddy → PWA proxy (`route {}`, `@pwa`, `PWA_UPSTREAM`) as the default, but the CLI does **not** configure that — it ships `symfony-docker`'s Caddyfile and runs the Next.js PWA standalone (`pnpm dev` on `:3000`, cross-origin via CORS). Rewritten so it:
- describes the Caddyfile **actually shipped** (`api/frankenphp/Caddyfile`: FrankenPHP worker, `@phpRoute`, Mercure + Vulcain);
- documents the Hydra + Mercure `Link` header as injected by the CLI through `CADDY_SERVER_EXTRA_DIRECTIVES` in `compose.yaml`;
- moves single-domain API + PWA serving into an **opt-in** section (reachability → `route {}` ordering → `@pwa` matcher), kept for users who want it on top of a scaffolded project.

### `symfony/index.md`
- documents that the installer writes `AGENTS.md` and `CLAUDE.md` by default (`--no-with-agents` to skip) — see api-platform/api-platform#2993;
- cross-links the new Caddy opt-in section from the PWA note.

### `core/getting-started.md`
- the Symfony quick-start now uses the CLI: `api-platform my-project --framework=symfony`.

### `laravel/index.md`
- adds a tip showing the CLI can scaffold a Laravel project: `api-platform my-project --framework=laravel`.