### PR TITLE
Improve create-client documentation

### DIFF
--- a/create-client/custom.md
+++ b/create-client/custom.md
@@ -125,3 +125,7 @@ fn main() {
   ];
 }
 ```
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/index.md
+++ b/create-client/index.md
@@ -21,6 +21,26 @@ It is able to generate apps using the following frontend stacks:
 Create Client works especially well with APIs built with the
 [API Platform](https://api-platform.com) framework.
 
+## Usage
+
+```console
+npm init @api-platform/client entrypoint outputDirectory
+```
+
+You can run `npm init @api-platform/client -- --help` to see all available options:
+
+| Option                                         | Description                                                                                                                                       |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-r, --resource [resourceName]`                | Generate CRUD for the given resource only                                                                                                         |
+| `-g, --generator [generator]`                  | Generator to use: `next`, `nuxt`, `quasar`, `react`, `react-native`, `typescript`, `vue`, `vuetify`, or a path to a [custom generator](custom.md) |
+| `-f, --format [hydra\|openapi3\|openapi2]`     | API documentation format (default: `hydra`)                                                                                                       |
+| `-t, --template-directory [templateDirectory]` | Custom templates directory                                                                                                                        |
+| `-p, --hydra-prefix [hydraPrefix]`             | The Hydra prefix used by the API                                                                                                                  |
+| `--bearer [bearer]`                            | Token for bearer auth (Hydra only)                                                                                                                |
+| `--username [username]`                        | Username for basic auth (Hydra only)                                                                                                              |
+| `--password [password]`                        | Password for basic auth (Hydra only)                                                                                                              |
+| `-s, --server-path [serverPath]`               | Path to Express server file for dynamic route addition (Next.js only)                                                                             |
+
 ## Features
 
 - Generates high-quality TypeScript:

--- a/create-client/nextjs.md
+++ b/create-client/nextjs.md
@@ -145,3 +145,7 @@ If you want to generate a production build locally with docker compose, follow
 
 ![List](images/nextjs/create-client-nextjs-list.png)
 ![Show](images/nextjs/create-client-nextjs-show.png)
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/nuxt.md
+++ b/create-client/nuxt.md
@@ -100,3 +100,7 @@ Go to `https://localhost:3000/books/` to start using your app.
 ## Screenshots
 
 ![List](images/nuxt/create-client-nuxt-list.png) ![Edit](images/nuxt/create-client-nuxt-edit.png)
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/quasar.md
+++ b/create-client/quasar.md
@@ -79,3 +79,7 @@ quasar dev
 Go to `http://localhost:9000/books/` to start using your app.
 
 **Note:** In order to Mercure to work with the demo, you have to use the port 3000.
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/react-native.md
+++ b/create-client/react-native.md
@@ -117,3 +117,7 @@ expo start
 ![Show](images/react-native/create-client-react-native-show.png)
 ![Add](images/react-native/create-client-react-native-add.png)
 ![Delete](images/react-native/create-client-react-native-delete.png)
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/react.md
+++ b/create-client/react.md
@@ -90,3 +90,7 @@ Go to `https://localhost/books/` to start using your app.
 ![Show](images/react/create-client-react-show.png)
 ![Edit](images/react/create-client-react-edit.png)
 ![Delete](images/react/create-client-react-delete.png)
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/troubleshooting.md
+++ b/create-client/troubleshooting.md
@@ -1,5 +1,9 @@
 # Troubleshooting
 
+> [!TIP]
+>
+> Run `npm init @api-platform/client -- --help` to see all available options.
+
 ## Self-Signed TLS Certificate
 
 If you are running API Platform on development machine which does not have valid TLS certificate,
@@ -11,15 +15,27 @@ NODE_TLS_REJECT_UNAUTHORIZED=0 npm init @api-platform/client --generator typescr
 
 ## Authenticated API
 
-The generator does not perform any authentication, so you must ensure that all referenced Hydra
-paths for your API are accessible anonymously. If you are using API Platform this will at least
-include:
+The generator needs to access the API documentation to introspect your resources. If your API
+requires authentication, you can use the built-in authentication options (Hydra format only):
+
+```console
+# Bearer token authentication
+npm init @api-platform/client -- --bearer "your-token" https://localhost/api src/
+
+# Basic authentication
+npm init @api-platform/client -- --username "admin" --password "secret" https://localhost/api src/
+```
+
+If you do not use these options, you must ensure that all referenced Hydra paths for your API are
+accessible anonymously. If you are using API Platform, this includes at least:
 
 ```console
 api_entrypoint                             ANY      ANY      ANY    /{index}.{_format}
 api_doc                                    ANY      ANY      ANY    /docs.{_format}
 api_jsonld_context                         ANY      ANY      ANY    /contexts/{shortName}.{_format}
 ```
+
+See [Symfony Security](../core/security.md) for details on how to configure access control rules.
 
 ## ApiDocumentation doesn't exist
 

--- a/create-client/typescript.md
+++ b/create-client/typescript.md
@@ -35,3 +35,7 @@ You will obtain 2 `.ts` files arranged as following:
     - interfaces/
         - foo.ts
         - bar.ts
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/vuejs.md
+++ b/create-client/vuejs.md
@@ -77,3 +77,7 @@ npm run dev
 Go to `http://localhost:5173/books/` to start using your app.
 
 **Note:** In order to Mercure to work with the demo, you have to use the port 3000.
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.

--- a/create-client/vuetify.md
+++ b/create-client/vuetify.md
@@ -63,3 +63,7 @@ npm run dev
 Go to `http://localhost:3000/books/` to start using your app.
 
 **Note:** In order to Mercure to work with the demo, you have to use the port 3000.
+
+## Troubleshooting
+
+Having issues? Check the [Troubleshooting](troubleshooting.md) page.


### PR DESCRIPTION
Fixes https://github.com/api-platform/docs/issues/2047

- Add a usage section with all CLI options in the index page
- Document `--bearer`, `--username` and `--password` auth options in the troubleshooting page
- Add `--help` tip at the top of the troubleshooting page
- Add a troubleshooting link at the bottom of every generator page