### PR TITLE
Correct typo in filters.md

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -295,7 +295,7 @@ public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $q
 
 ### Restricting Properties with `:property` Placeholders
 
-Filters that work on a per-parameter basis can also use the `:property` placeholde and use the
+Filters that work on a per-parameter basis can also use the `:property` placeholder and use the
 parameter's `properties` configuration:
 
 ```php


### PR DESCRIPTION
Fix typo in filters documentation regarding ':property' placeholder.

<!--

If your pull request fixes a BUG, use the last stable branch that contains the bug.

If your pull request documents a NEW FEATURE, use the `main` branch.

Versions and branches are described there: https://api-platform.com/docs/extra/releases/

-->
