### PR TITLE
docs(httpcache): document PurgeTagProviderInterface for sub-resource invalidation

### DIFF
--- a/core/performance.md
+++ b/core/performance.md
@@ -347,6 +347,11 @@ services:
             - name: api_platform.http_cache.purge_tag_provider
 ```
 
+#### Laravel
+
+Any class implementing `PurgeTagProviderInterface` placed inside your `app/` directory is automatically
+discovered and registered by API Platform's autoconfiguration. No further setup is required.
+
 ## Setting Custom HTTP Cache Headers
 
 The `cacheHeaders` attribute can be used to set custom HTTP cache headers:

--- a/core/performance.md
+++ b/core/performance.md
@@ -285,9 +285,12 @@ final class UserResourcesSubscriber implements EventSubscriberInterface
 ### Invalidating Additional Tags on Mutation
 
 Implement `ApiPlatform\HttpCache\PurgeTagProviderInterface` to add extra cache tags to invalidate
-when an entity is mutated. This is useful for any tags the built-in listener cannot resolve on its
+when a resource is mutated. This is useful for any tags the built-in listener cannot resolve on its
 own: sub-resource collection IRIs (e.g. `/parents/{parentId}/children`), surrogate-key prefixes,
 class-based tags, or any custom invalidation strategy.
+
+The interface provides three methods so you can differentiate between operations and receive the
+previous state of the resource on updates:
 
 ```php
 <?php
@@ -299,13 +302,34 @@ use App\Entity\Child;
 
 final class ChildPurgeTagProvider implements PurgeTagProviderInterface
 {
-    public function getTagsForResource(object $entity): iterable
+    public function getTagsForInsert(object $resource): iterable
     {
-        if (!$entity instanceof Child || null === $entity->getParent()) {
+        if (!$resource instanceof Child || null === $resource->getParent()) {
             return [];
         }
 
-        yield '/parents/'.$entity->getParent()->getId().'/children';
+        yield '/parents/'.$resource->getParent()->getId().'/children';
+    }
+
+    public function getTagsForUpdate(object $resource, object $previousResource): iterable
+    {
+        // Invalidate both the old and new parent collection when the parent changes
+        if ($resource instanceof Child && null !== $resource->getParent()) {
+            yield '/parents/'.$resource->getParent()->getId().'/children';
+        }
+
+        if ($previousResource instanceof Child && null !== $previousResource->getParent()) {
+            yield '/parents/'.$previousResource->getParent()->getId().'/children';
+        }
+    }
+
+    public function getTagsForDelete(object $resource): iterable
+    {
+        if (!$resource instanceof Child || null === $resource->getParent()) {
+            return [];
+        }
+
+        yield '/parents/'.$resource->getParent()->getId().'/children';
     }
 }
 ```
@@ -321,18 +345,6 @@ services:
     App\HttpCache\ChildPurgeTagProvider:
         tags:
             - name: api_platform.http_cache.purge_tag_provider
-```
-
-#### Laravel
-
-Register and tag the implementation in a service provider:
-
-```php
-$this->app->bind(\App\HttpCache\ChildPurgeTagProvider::class);
-$this->app->tag(
-    [\App\HttpCache\ChildPurgeTagProvider::class],
-    \ApiPlatform\HttpCache\PurgeTagProviderInterface::class
-);
 ```
 
 ## Setting Custom HTTP Cache Headers

--- a/core/performance.md
+++ b/core/performance.md
@@ -282,6 +282,59 @@ final class UserResourcesSubscriber implements EventSubscriberInterface
 }
 ```
 
+### Invalidating Additional Tags on Mutation
+
+Implement `ApiPlatform\HttpCache\PurgeTagProviderInterface` to add extra cache tags to invalidate
+when an entity is mutated. This is useful for any tags the built-in listener cannot resolve on its
+own: sub-resource collection IRIs (e.g. `/parents/{parentId}/children`), surrogate-key prefixes,
+class-based tags, or any custom invalidation strategy.
+
+```php
+<?php
+// src/HttpCache/ChildPurgeTagProvider.php
+namespace App\HttpCache;
+
+use ApiPlatform\HttpCache\PurgeTagProviderInterface;
+use App\Entity\Child;
+
+final class ChildPurgeTagProvider implements PurgeTagProviderInterface
+{
+    public function getTagsForResource(object $entity): iterable
+    {
+        if (!$entity instanceof Child || null === $entity->getParent()) {
+            return [];
+        }
+
+        yield '/parents/'.$entity->getParent()->getId().'/children';
+    }
+}
+```
+
+#### Symfony
+
+With [autowiring and autoconfiguration](https://symfony.com/doc/current/service_container/autowiring.html)
+enabled (the default), the service is automatically registered. To declare the service explicitly:
+
+```yaml
+# config/services.yaml
+services:
+    App\HttpCache\ChildPurgeTagProvider:
+        tags:
+            - name: api_platform.http_cache.purge_tag_provider
+```
+
+#### Laravel
+
+Register and tag the implementation in a service provider:
+
+```php
+$this->app->bind(\App\HttpCache\ChildPurgeTagProvider::class);
+$this->app->tag(
+    [\App\HttpCache\ChildPurgeTagProvider::class],
+    \ApiPlatform\HttpCache\PurgeTagProviderInterface::class
+);
+```
+
 ## Setting Custom HTTP Cache Headers
 
 The `cacheHeaders` attribute can be used to set custom HTTP cache headers:


### PR DESCRIPTION
## Summary

- Adds a new "Invalidating Additional Tags on Mutation" section in `core/performance.md`
- Documents `PurgeTagProviderInterface` with a concrete sub-resource collection example
- Covers Symfony (tagged service) and Laravel (manual `$app->tag()`) wiring

Related to api-platform/core#7970