### PR TITLE
Update supported types of custom denormalizer in serialization.md

### DIFF
--- a/core/serialization.md
+++ b/core/serialization.md
@@ -719,9 +719,7 @@ class PlainIdentifierDenormalizer implements DenormalizerInterface, Denormalizer
     public function getSupportedTypes(?string $format): array
     {
         return [
-            'object' => null,
-            '*' => false,
-            Dummy::class => true
+            Dummy::class => false,
         ];
     }
 }


### PR DESCRIPTION
The `getSupportedTypes` method of the custom normalizer in the “Serialization Process” docs are wrong. 

The denormalizer does *not* support *any* type. 

It just supports the `Dummy` class in *non-cacheable* mode (`false`), because `supportsDenormalization` looks at the `$data` *and* `$context` to decide if it's supported.

[See here](https://symfony.com/doc/current/serializer/custom_normalizer.html#improving-performance-of-normalizers-denormalizers) for a description of how `getSupportedTypes` works.

Also related: api-platform/api-platform#2737