### PR TITLE
docs(errors): warn that exception_to_status is not merged with defaults

### DIFF
--- a/core/errors.md
+++ b/core/errors.md
@@ -164,13 +164,12 @@ return [
 ];
 ```
 
-> [!WARNING]
-> The `exception_to_status` configuration is **not merged** with the defaults: as soon as you declare
-> your own mapping, it replaces the built-in one entirely. If you omit the default handlers shown
-> above, exceptions that were previously mapped to `400` (such as the
-> `Symfony\Component\Serializer\Exception\ExceptionInterface` thrown when denormalizing a relation to a
-> non-existing item, or an invalid backed enum value) will fall through to the `500` fallback. Always
-> keep the default lines and append your custom mappings to them.
+> [!WARNING] The `exception_to_status` configuration is **not merged** with the defaults: as soon as
+> you declare your own mapping, it replaces the built-in one entirely. If you omit the default
+> handlers shown above, exceptions that were previously mapped to `400` (such as the
+> `Symfony\Component\Serializer\Exception\ExceptionInterface` thrown when denormalizing a relation
+> to a non-existing item, or an invalid backed enum value) will fall through to the `500` fallback.
+> Always keep the default lines and append your custom mappings to them.
 
 Any type of `Exception` can be thrown, API Platform will convert it to a Symfony's `HttpException`
 (note that it means the exception will be flattened and lose all of its custom properties). The

--- a/core/errors.md
+++ b/core/errors.md
@@ -164,6 +164,14 @@ return [
 ];
 ```
 
+> [!WARNING]
+> The `exception_to_status` configuration is **not merged** with the defaults: as soon as you declare
+> your own mapping, it replaces the built-in one entirely. If you omit the default handlers shown
+> above, exceptions that were previously mapped to `400` (such as the
+> `Symfony\Component\Serializer\Exception\ExceptionInterface` thrown when denormalizing a relation to a
+> non-existing item, or an invalid backed enum value) will fall through to the `500` fallback. Always
+> keep the default lines and append your custom mappings to them.
+
 Any type of `Exception` can be thrown, API Platform will convert it to a Symfony's `HttpException`
 (note that it means the exception will be flattened and lose all of its custom properties). The
 framework also takes care of serializing the error description according to the request format. For


### PR DESCRIPTION
## Documentation

Closes api-platform/core#6116

When a custom `exception_to_status` mapping is declared, it **replaces** the built-in defaults entirely instead of merging with them. If a user omits the default handlers, exceptions previously mapped to `400` — notably `Symfony\Component\Serializer\Exception\ExceptionInterface` thrown when denormalizing a relation to a non-existing item, or an invalid backed enum value — fall through to the `500` fallback.

The example already carried inline "keep those lines" comments; this adds an explicit warning callout explaining *why* the default lines must be kept.