### PR TITLE
docs(mcp): fix MCP Bundle link to symfony/ai

### DIFF
--- a/core/mcp.md
+++ b/core/mcp.md
@@ -14,7 +14,7 @@ validation, serialization — to turn your PHP classes into MCP-compliant tool d
 
 ### Installing on Symfony
 
-Install `api-platform/mcp` and the [MCP Bundle](https://github.com/symfony-tools/mcp-bundle):
+Install `api-platform/mcp` and the [MCP Bundle](https://github.com/symfony/ai):
 
 ```console
 composer require api-platform/mcp symfony/mcp-bundle
@@ -22,7 +22,7 @@ composer require api-platform/mcp symfony/mcp-bundle
 
 ### Installing on Laravel
 
-Install `api-platform/mcp` and the [MCP Bundle](https://github.com/symfony-tools/mcp-bundle):
+Install `api-platform/mcp` and the [MCP Bundle](https://github.com/symfony/ai):
 
 ```console
 composer require api-platform/mcp symfony/mcp-bundle


### PR DESCRIPTION
## What

Fixes the MCP Bundle link in `core/mcp.md` (both the Symfony and Laravel install subsections).

## Why

The doc linked the MCP Bundle to `https://github.com/symfony-tools/mcp-bundle`, which does not exist. The `symfony/mcp-bundle` Composer package is a **read-only subtree split** of the `symfony/ai` monorepo — that is where issues and PRs are handled.

Confirmed against the vendored bundle:
- `vendor/symfony/mcp-bundle/README.md`: "This repository is a READ-ONLY sub-tree split. See https://github.com/symfony/ai".
- `vendor/symfony/mcp-bundle/composer.json`: `extra.thanks.url` → `https://github.com/symfony/ai`.
- Bundle namespace is `Symfony\\AI\\McpBundle`.

The `composer require api-platform/mcp symfony/mcp-bundle` lines were already correct and are unchanged.