### PR TITLE
ci: generate llms.txt during docs deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,10 @@ jobs:
         working-directory: docs-website
         run: hugo --minify
 
+      - name: Generate llms.txt
+        working-directory: docs-website
+        run: node tools/llms.mjs
+
       - name: Deploy
         working-directory: docs-website
         run: gsutil -q -m rsync -d -r ./public gs://api-platform-website-v3/


### PR DESCRIPTION
Wires llms.txt generation into the docs deploy pipeline.

Adds a **Generate llms.txt** step to `cd.yml` running `node tools/llms.mjs` after the Hugo build and before the GCS rsync, so `public/llms.txt` and `public/llms-full.txt` ship with every deploy and are served at `https://api-platform.com/docs/llms.txt`.

The generator itself is in the companion PR [api-platform/docs-website#29](https://github.com/api-platform/docs-website/pull/29). It reads `content/outline.yaml` (current version) and emits a curated index + full-text file per the [llmstxt.org](https://llmstxt.org) convention — the agent-agnostic companion to the AGENTS.md work ([skillset#1](https://github.com/api-platform/skillset/pull/1)).