### PR TITLE
chore: drop redundant llms.txt CI step (Hugo generates it now)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,10 +82,6 @@ jobs:
         working-directory: docs-website
         run: hugo --minify
 
-      - name: Generate llms.txt
-        working-directory: docs-website
-        run: node tools/llms.mjs
-
       - name: Deploy
         working-directory: docs-website
         run: gsutil -q -m rsync -d -r ./public gs://api-platform-website-v3/


### PR DESCRIPTION
llms.txt + llms-full.txt are now produced by Hugo output formats ([docs-website#30](https://github.com/api-platform/docs-website/pull/30) + [#31](https://github.com/api-platform/docs-website/pull/31)), so the explicit `node tools/llms.mjs` step in `cd.yml` is redundant. The Hugo build emits them on every deploy regardless of branch.

**Merge order:** merge this **before** the companion docs-website PR that removes `tools/llms.mjs` — otherwise a deploy would still call a deleted script.