### PR TITLE
docs: fix markdown formatting (prettier)

### DIFF
--- a/core/doctrine-filters.md
+++ b/core/doctrine-filters.md
@@ -1373,8 +1373,8 @@ class Offer
 ```
 
 `DateFilter` is kept: only the declaration style changes. The URL syntax is unchanged
-(`?createdAt[before]=2025-01-01`, `?createdAt[after]=2025-01-01`, and the `strictly_*` variants), and
-per-property null management still applies.
+(`?createdAt[before]=2025-01-01`, `?createdAt[after]=2025-01-01`, and the `strictly_*` variants),
+and per-property null management still applies.
 
 ### Example: Migrating a RangeFilter
 

--- a/core/serialization.md
+++ b/core/serialization.md
@@ -308,22 +308,22 @@ class Book
 # api/config/api_platform/resources/Book.yaml
 App\ApiResource\Book:
     normalizationContext:
-        groups: ['get']
+        groups: ["get"]
     operations:
         ApiPlatform\Metadata\Get: ~
         ApiPlatform\Metadata\Get: ~
         ApiPlatform\Metadata\Patch:
             normalizationContext:
-                groups: ['patch']
+                groups: ["patch"]
 
 # The YAML syntax is only supported for Symfony
 # api/config/serializer/Book.yaml
 App\ApiResource\Book:
     attributes:
         name:
-            groups: ['get', 'patch']
+            groups: ["get", "patch"]
         author:
-            groups: ['get']
+            groups: ["get"]
 ```
 
 ```xml
@@ -452,16 +452,16 @@ class Book
 # api/config/api_platform/resources/Book.yaml
 App\ApiResource\Book:
     normalizationContext:
-        groups: ['book']
+        groups: ["book"]
 
 # The YAML syntax is only supported for Symfony
 # api/config/serializer/Book.yaml
 App\ApiResource\Book:
     attributes:
         name:
-            groups: ['book']
+            groups: ["book"]
         author:
-            groups: ['book']
+            groups: ["book"]
 ```
 
 </code-selector>
@@ -597,18 +597,18 @@ class Person
 # api/config/api_platform/resources/Person.yaml
 App\ApiResource\Person:
     normalizationContext:
-        groups: ['person']
+        groups: ["person"]
     denormalizationContext:
-        groups: ['person']
+        groups: ["person"]
 
 # The YAML syntax is only supported for Symfony
 # api/config/serializer/Person.yaml
 App\ApiResource\Person:
     attributes:
         name:
-            groups: ['person']
+            groups: ["person"]
         parent:
-            groups: ['person']
+            groups: ["person"]
 ```
 
 </code-selector>
@@ -870,18 +870,18 @@ App\Entity\Greeting:
     operations:
         ApiPlatform\Metadata\GetCollection:
             normalizationContext:
-                groups: 'greeting:collection:get'
+                groups: "greeting:collection:get"
 
 # The YAML syntax is only supported for Symfony
 # api/config/serializer/Greeting.yaml
 App\Entity\Greeting:
     attributes:
         id:
-            groups: 'greeting:collection:get'
+            groups: "greeting:collection:get"
         name:
-            groups: 'greeting:collection:get'
+            groups: "greeting:collection:get"
         sum:
-            groups: 'greeting:collection:get'
+            groups: "greeting:collection:get"
 ```
 
 </code-selector>
@@ -932,18 +932,18 @@ class Book
 # api/config/api_platform/resources/Book.yaml
 App\ApiResource\Book:
     normalizationContext:
-        groups: ['book:output']
+        groups: ["book:output"]
     denormalizationContext:
-        groups: ['book:input']
+        groups: ["book:input"]
 
 # The YAML syntax is only supported for Symfony
 # api/config/serializer/Book.yaml
 App\ApiResource\Book:
     attributes:
         active:
-            groups: ['book:output', 'admin:input']
+            groups: ["book:output", "admin:input"]
         name:
-            groups: ['book:output', 'book:input']
+            groups: ["book:output", "book:input"]
 ```
 
 </code-selector>

--- a/core/state-providers.md
+++ b/core/state-providers.md
@@ -435,13 +435,13 @@ use the following snippet:
 services:
     # ...
     App\State\BlogPostProvider:
-        tags: [ 'api_platform.state_provider' ]
+        tags: ["api_platform.state_provider"]
 
 # api/config/services.yaml
 services:
     # ...
     App\State\BookRepresentationProvider:
         arguments:
-            $itemProvider: '@api_platform.doctrine.orm.state.item_provider'
-        tags: [ 'api_platform.state_provider' ]
+            $itemProvider: "@api_platform.doctrine.orm.state.item_provider"
+        tags: ["api_platform.state_provider"]
 ```

--- a/core/upgrade-guide.md
+++ b/core/upgrade-guide.md
@@ -12,17 +12,18 @@ upgrade to the next major a no-op.
 
 The legacy Doctrine filter API is deprecated in favor of parameter-based filters declared with the
 `#[QueryParameter]` attribute. The `#[ApiFilter]` attribute, the `Operation::$filters` property, and
-the `AbstractFilter` base class (Doctrine ORM and MongoDB ODM) are all deprecated and removed in 6.0.
+the `AbstractFilter` base class (Doctrine ORM and MongoDB ODM) are all deprecated and removed in
+6.0.
 
 There are two kinds of migration:
 
 - **Replaced filters** — removed in 6.0, swap the class:
 
-    | Legacy filter | Replacement |
-    | ------------- | ----------- |
-    | `SearchFilter` | `ExactFilter` / `PartialSearchFilter` / `IriFilter` (depending on the strategy) |
-    | `BooleanFilter`, `NumericFilter`, `BackedEnumFilter` | `ExactFilter` |
-    | `OrderFilter` | `SortFilter` |
+    | Legacy filter                                        | Replacement                                                                     |
+    | ---------------------------------------------------- | ------------------------------------------------------------------------------- |
+    | `SearchFilter`                                       | `ExactFilter` / `PartialSearchFilter` / `IriFilter` (depending on the strategy) |
+    | `BooleanFilter`, `NumericFilter`, `BackedEnumFilter` | `ExactFilter`                                                                   |
+    | `OrderFilter`                                        | `SortFilter`                                                                    |
 
 - **Kept filters** — `DateFilter`, `RangeFilter` and `ExistsFilter` survive. Only the way you
   _declare_ them is deprecated: move the declaration from `#[ApiFilter]` to `#[QueryParameter]`. The


### PR DESCRIPTION
The **Lint** job (`prettier --check "**/*.md"`, prettier 3.9.5) is red on 4.3. It flags 4 files — 2 from the recent filter/upgrade merges (#2313, #2314) and 2 pre-existing (`serialization.md`, `state-providers.md`, already failing before these). The gate is repo-wide, so all four are reformatted here (formatting only — prose-wrap + table alignment, no content change).

Run locally: `npx prettier --write "**/*.md" --prose-wrap always`.