### PR TITLE
Replace Security type hints by AccessDecisionManagerInterface

### DIFF
--- a/symfony/security.md
+++ b/symfony/security.md
@@ -319,16 +319,16 @@ namespace App\Security\Voter;
 use App\Entity\Book;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class BookVoter extends Voter
 {
-    private $security = null;
+    private $accessDecisionManager = null;
 
-    public function __construct(Security $security)
+    public function __construct(AccessDecisionManagerInterface $accessDecisionManager)
     {
-        $this->security = $security;
+        $this->accessDecisionManager = $accessDecisionManager;
     }
 
     protected function supports($attribute, $subject): bool
@@ -351,7 +351,7 @@ class BookVoter extends Voter
 
         switch ($attribute) {
             case 'BOOK_CREATE':
-                if ( $this->security->isGranted(Role::ADMIN) ) { return true; }  // only admins can create books
+                if ( $this->accessDecisionManager->decide($token, ['ROLE_ADMIN']) ) { return true; }  // only admins can create books
                 break;
             case 'BOOK_READ':
                 /** ... other authorization rules ... **/


### PR DESCRIPTION
Replace Security type-hinting by AccessDecisionManagerInterface in security.md file

This modification allows to comply with Symfony's recommendations in Voter files
Using AccessDecisionManagerInterface instead of Security is recommended by Symfony documentation.
See Symfony documentation [here](https://symfony.com/doc/current/security/voters.html#checking-for-roles-inside-a-voter) or the image below:

<img width="786" height="392" alt="image" src="https://github.com/user-attachments/assets/dfa210fd-b350-480a-a13b-07fea68ccdbb" />