### PR TITLE
chore: merge up 4.3 into 4.4

### DIFF
--- a/core/filters.md
+++ b/core/filters.md
@@ -523,6 +523,8 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HeaderParameter;
 use ApiPlatform\Metadata\QueryParameter;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource(operations: [
     new GetCollection(
@@ -535,7 +537,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             'X-Request-ID' => new HeaderParameter(
                 description: 'A unique request identifier.',
                 required: true,
-                constraints: [new Assert\Uuid()]
+                constraints: [new Assert\Uuid()],
+                nativeType: new BuiltinType(typeIdentifier: TypeIdentifier::STRING)
             )
         ]
     )
@@ -545,6 +548,9 @@ class User {}
 
 > [!NOTE] When `castToNativeType` is enabled, API Platform infers type validation from the JSON
 > Schema.
+
+If `constraints` are used then a valid type needs to be passed using `nativeType` named argument.
+Otherwise, the values will be passed as an array to each constraints.
 
 The `ApiPlatform\Validator\Util\ParameterValidationConstraints` trait can be used to automatically
 infer validation constraints from the JSON Schema and OpenAPI definitions of a parameter.

--- a/core/filters.md
+++ b/core/filters.md
@@ -126,8 +126,9 @@ Instead of repeating the same parameter configuration on every resource, you can
 default parameters that are automatically applied to all resources. This is done via the `defaults`
 key in your API Platform configuration.
 
-Add a `parameters` map under `defaults` in your API Platform configuration. Each entry maps a
-fully-qualified parameter class name to its options.
+Add a `parameters` map under `defaults` in your API Platform configuration. In Symfony, entries can
+either use the fully-qualified parameter class name as their key, or use a custom name and specify
+the class explicitly with the `class` option.
 
 ```yaml
 # Symfony: api/config/packages/api_platform.yaml
@@ -144,6 +145,30 @@ api_platform:
                 required: false
                 description: "API version"
 ```
+
+To define multiple global parameters using the same parameter class, use named entries with an
+explicit `class`:
+
+```yaml
+# Symfony: api/config/packages/api_platform.yaml
+api_platform:
+    defaults:
+        parameters:
+            api_token:
+                class: ApiPlatform\Metadata\HeaderParameter
+                key: "API-Token"
+                required: true
+                description: "API authentication token"
+
+            request_id:
+                class: ApiPlatform\Metadata\HeaderParameter
+                key: "Request-ID"
+                required: false
+                description: "A unique request identifier"
+```
+
+The name of a named entry is only a configuration identifier. The `key` option defines the parameter
+name exposed at runtime.
 
 ```php
 <?php

--- a/core/filters.md
+++ b/core/filters.md
@@ -970,7 +970,7 @@ class User {}
 ## Parameter Security
 
 You can secure individual parameters using Symfony expression language. When a security expression
-evaluates to `false`, the parameter will be ignored and treated as if it wasn't provided.
+evaluates to `false`, a context appropriate `AccessDeniedException` will be thrown.
 
 ```php
 <?php

--- a/core/mercure.md
+++ b/core/mercure.md
@@ -16,6 +16,14 @@ Mercure hub. Then, the Mercure hub dispatches the updates to all connected clien
 
 ![Mercure subscriptions](images/mercure-subscriptions.png)
 
+## Which Protocol Version Does Your Hub Speak?
+
+Mercure has a 1.0 protocol version that changes how subscribers pick which updates to receive:
+`match=` and `match_urlpattern=` query parameters replace `topic=`. API Platform talks to 0.x hubs
+by default; switching a hub to 1.0 is done by configuring `protocol_version: '1.0'` on the
+[MercureBundle](https://symfony.com/doc/current/mercure.html) side, not on this page. The examples
+below cover both; check with whoever operates your hub if you're not sure which version it runs.
+
 ## Installing Mercure Support
 
 Mercure support is already installed, configured and enabled in
@@ -66,6 +74,54 @@ automatically subscribe to Mercure updates when available:
 ![Screencast](../create-client/images/create-client-demo.gif)
 
 [Learn how to use the discovery capabilities of Mercure in your own clients](https://mercure.rocks/docs/ecosystem/awesome).
+
+## Subscribing to Updates
+
+API Platform publishes each update on the resource's absolute IRI — the same value as the `@id` of
+the JSON-LD document the API serves for that resource. This means the topic to subscribe to is
+nothing you need to build: it's the `@id` you already have from fetching the resource.
+
+A minimal browser client fetches the resource, discovers the hub from the `Link: rel="mercure"`
+header, and subscribes using the resource's `@id` as the topic:
+
+```javascript
+const response = await fetch("/books/1", { headers: { Accept: "application/ld+json" } });
+const book = await response.json();
+
+// Discover the hub through the Link header API Platform adds to the response
+const linkHeader = response.headers.get("Link");
+const [, hubUrlString] = linkHeader.match(/<([^>]+)>;\s*rel="mercure"/);
+const hubUrl = new URL(hubUrlString);
+
+hubUrl.searchParams.append("topic", book["@id"]); // Mercure 0.x
+
+const eventSource = new EventSource(hubUrl);
+eventSource.onmessage = (event) => {
+    console.log(JSON.parse(event.data));
+};
+```
+
+If your hub speaks the Mercure 1.0 protocol, subscribe with `match` instead of `topic`:
+
+```javascript
+hubUrl.searchParams.append("match", book["@id"]); // Mercure 1.0
+```
+
+To subscribe to every book instead of a single one, 1.0 hubs also accept `match_urlpattern`, with a
+[URL Pattern](https://mercure.rocks/docs/1.0/concepts/topics-and-matchers) matching the resources'
+IRIs:
+
+```javascript
+hubUrl.searchParams.append("match_urlpattern", "https://api.example.com/books/:id"); // Mercure 1.0
+```
+
+`match_urlpattern` has no 0.x equivalent: under 0.x, subscribing to a family of resources at once
+means either subscribing to each IRI individually, or using the alternate-topic technique described
+below.
+
+See the [Mercure protocol reference](https://mercure.rocks/docs/1.0/reference/protocol) (1.0) or
+[the spec's subscribers section](https://mercure.rocks/spec#subscribers) (0.x) for the full
+`topic`/`match`/`match_urlpattern` semantics.
 
 ## Dispatching Private Updates (Authorized Mode)
 


### PR DESCRIPTION
The 4.3 → 4.4 merge-up is overdue: four documentation commits have been sitting on `4.3` unmerged.

- `8df157eb022` docs(symfony): document repeated global parameters (#2319)
- `8287eaa26cc` docs(mercure): document 1.0 subscriber-side subscribe (match/match_urlpattern) (#2323)
- `928bf80941f` Improve doc: in the absence of a nativeType, the constraints receive an array value (#2322)
- `42636dd26c6` Update parameter security documentation to reflect that it throws AccessDeniedException (#2320)

Clean merge (ort), no conflicts. `prettier --check "**/*.md"` passes on the result.

> [!IMPORTANT]
> Merge with a **merge commit**, not squash — squashing would flatten the merge-up and make the next
> 4.3 → 4.4 merge conflict.