### PR TITLE
docs: fix filter deprecations removed in 6.0, not 5.0

### DIFF
--- a/core/doctrine-filters.md
+++ b/core/doctrine-filters.md
@@ -1529,7 +1529,7 @@ Multiple parameters targeting the same relation path share the same JOIN (ORM) o
 ### Nested Properties with the Legacy ApiFilter Syntax (deprecated)
 
 > [!WARNING] The legacy method using the `ApiFilter` attribute is **deprecated** and scheduled for
-> **removal** in API Platform **5.0**. We strongly recommend migrating to the new `QueryParameter`
+> **removal** in API Platform **6.0**. We strongly recommend migrating to the new `QueryParameter`
 > syntax described above.
 
 For legacy code, the built-in filters that extend `AbstractFilter` support nested properties using
@@ -1595,7 +1595,7 @@ The above allows you to find offers by their respective product's color:
 ## Enabling a Filter for All Properties of a Resource
 
 > [!WARNING] The legacy method using the `ApiFilter` attribute is **deprecated** and scheduled for
-> **removal** in API Platform **5.0**. We strongly recommend migrating to the new `QueryParameter`
+> **removal** in API Platform **6.0**. We strongly recommend migrating to the new `QueryParameter`
 > syntax, which is detailed in the [Introduction](#introduction). You can use the `:property`
 > placeholder instead and it is recommended to use a filter for each type of data you are filtering.
 
@@ -1961,7 +1961,7 @@ use Doctrine\ORM\QueryBuilder;
 
 class MyCustomFilter implements FilterInterface
 {
-    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 5.0.
+    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 6.0.
 
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
@@ -1981,6 +1981,12 @@ class MyCustomFilter implements FilterInterface
     }
 }
 ```
+
+`BackwardCompatibleFilterDescriptionTrait` supplies a `getDescription()` method that returns an
+empty array, satisfying the legacy `FilterInterface::getDescription()` requirement without you
+having to implement it by hand. It lets a custom filter keep working with the deprecated filter
+chain while you migrate it to `#[QueryParameter]`, and it will be removed in API Platform 6.0
+together with `getDescription()` itself.
 
 #### Implementing a Custom ORM Filter
 
@@ -2008,7 +2014,7 @@ use Doctrine\ORM\QueryBuilder;
 
 class MonthFilter implements FilterInterface
 {
-    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 5.0.
+    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 6.0.
 
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
@@ -2252,7 +2258,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
 
 class MonthFilter implements FilterInterface
 {
-    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 5.0.
+    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 6.0.
 
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
@@ -2294,7 +2300,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
 
 class MonthFilter implements FilterInterface
 {
-    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 5.0.
+    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 6.0.
 
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {


### PR DESCRIPTION
## What changed

`core/doctrine-filters.md` stated in several places that the legacy `#[ApiFilter]` syntax and the
`BackwardCompatibleFilterDescriptionTrait` were scheduled for removal in API Platform **5.0**. This
is wrong and misleads users into rushing a migration a full major version early — the code says
**6.0**.

Verified against the shipped source in `api-platform/core`:

- `src/Metadata/ApiFilter.php`:
  ```
  @deprecated since API Platform 4.4, use the {@see QueryParameter} attribute instead. Will be removed in 6.0.
  ```
- `src/Metadata/BackwardCompatibleFilterDescriptionTrait.php`:
  ```
  The trait will be removed in 6.0 together with FilterInterface::getDescription().
  ```

### Fixes

1. Two `> [!WARNING]` callouts about the legacy `#[ApiFilter]` syntax: "scheduled for removal in
   API Platform **5.0**" -> **6.0** (`core/doctrine-filters.md:1532`, `:1598`).
2. Four inline code comments on `use BackwardCompatibleFilterDescriptionTrait;`: "keep it until
   **5.0**" -> "keep it until **6.0**" (`core/doctrine-filters.md:1964`, `2017`(orig 2011),
   `2261`(orig 2255), `2303`(orig 2297)).
3. Added one short paragraph after the first ORM skeleton example explaining what
   `BackwardCompatibleFilterDescriptionTrait` does (it supplies the legacy `getDescription()`
   implementation so a custom filter keeps working with the deprecated filter chain while being
   migrated to `#[QueryParameter]`) and that it is removed in 6.0 — the trait was promoted to
   public API in api-platform/core#8326 but was previously only ever shown as a bare comment.
   The other three call sites keep just the corrected inline comment, to avoid repeating the
   paragraph four times.

No other filter content on this page was touched (ComparisonFilter/RangeFilter/search-filter
sections are out of scope here).

## Test plan

- [x] Verified both removal-version claims against `src/Metadata/ApiFilter.php` and
      `src/Metadata/BackwardCompatibleFilterDescriptionTrait.php` in `api-platform/core`.
- [x] `npx prettier@3.9.5 --check "**/*.md" --prose-wrap always` passes.
- [x] `git diff` reviewed line-by-line — no unrelated `5.0` references altered (the
      `ComparisonFilter`/`RangeFilter` 5.0 mentions elsewhere on this page are legitimate and left
      untouched).
