### PR TITLE
docs(jsonld): document resource-level jsonldContext

### DIFF
--- a/core/extending-jsonld-context.md
+++ b/core/extending-jsonld-context.md
@@ -63,6 +63,62 @@ The generated context will now have your custom attributes set:
 Note that you do not have to provide the `@id` attribute. If you do not provide an `@id` attribute,
 the value from `iri` will be used.
 
+### Extending the Context of a Whole Resource
+
+The `jsonldContext` option is also available on `#[ApiResource]` itself. Its main use is declaring
+namespace prefixes once for the whole resource, instead of repeating a full IRI on every property
+that needs one:
+
+```php
+<?php
+// api/src/ApiResource/Book.php with Symfony or app/ApiResource/Book.php with Laravel
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(
+    types: ['https://schema.org/Book'],
+    jsonldContext: ['dct' => 'http://purl.org/dc/terms/'],
+)]
+class Book
+{
+    // ...
+
+    #[ApiProperty(types: ['https://schema.org/name'], iris: ['dct:title'])]
+    public $name;
+
+    // ...
+}
+```
+
+The `dct` prefix is merged into the top-level `@context`, so properties can then reference it
+through a compact IRI such as `dct:title`:
+
+`GET /contexts/Book`
+
+```json
+{
+    "@context": {
+        "@vocab": "http://example.com/apidoc#",
+        "hydra": "http://www.w3.org/ns/hydra/core#",
+        "dct": "http://purl.org/dc/terms/",
+        "name": "dct:title"
+    }
+}
+```
+
+The resource-level context is merged into `@context` before the per-property entries are added, and
+each property's entry is then written to `@context[<propertyName>]`, overwriting anything already
+present at that key. In practice, the two never collide because the resource-level context is meant
+for prefix declarations, while a property's own entry is keyed by the property name; a collision
+only happens if a property is literally named after one of your prefixes, in which case the property
+wins.
+
+If an operation (for example a `Get` or a `Patch`) declares its own `jsonldContext`, that value is
+used as-is for that operation instead of the resource's: the two are not merged together, the
+operation's `jsonldContext` simply takes precedence.
+
 ## Hydra
 
 <p align="center" class="symfonycasts"><a href="https://symfonycasts.com/screencast/api-platform/hydra?cid=apip"><img src="../symfony/images/symfonycasts-player.png" alt="Hydra screencast"><br>Watch the Hydra screencast</a></p>
@@ -122,3 +178,34 @@ resources:
 ```
 
 </code-selector>
+
+### The `hydra:memberAssertion` Property
+
+For every resource exposing a collection operation, the generated Hydra API documentation
+(`GET /docs.jsonld`) automatically adds a `hydra:memberAssertion` entry to the entrypoint's
+`hydra:supportedProperty` for that collection. It asserts, as an `rdf:type` statement, that every
+member returned by the collection is an instance of the resource:
+
+```json
+{
+    "@id": "#Entrypoint/books",
+    "@type": "hydra:Link",
+    "domain": "#Entrypoint",
+    "owl:maxCardinality": 1,
+    "range": "hydra:Collection",
+    "hydra:memberAssertion": {
+        "hydra:property": { "@id": "rdf:type" },
+        "hydra:object": { "@id": "#Book" }
+    },
+    "hydra:supportedOperation": ["..."]
+}
+```
+
+This assertion is generated automatically for every collection and isn't configurable through
+`jsonldContext` or `hydraContext`.
+
+> [!NOTE] Before API Platform 4.4, the same assertion was expressed as an `owl:equivalentClass`
+> restriction (an `owl:onProperty: hydra:member` / `owl:allValuesFrom: #Book` pair nested inside the
+> `range` array). `owl:equivalentClass` no longer appears anywhere in the generated Hydra
+> documentation: if you parse `range` and expect that structure, read `hydra:memberAssertion`
+> instead.


### PR DESCRIPTION
## Summary
- Document the resource-level `#[ApiResource(jsonldContext: ...)]` option (core #8204). Previously `core/extending-jsonld-context.md` only covered the property-level `ApiProperty(jsonldContext: ...)` form, even though `ApiResource::$jsonldContext`'s own docblock (`src/Metadata/ApiResource.php:329-336`) links to this exact page.
- Document `hydra:memberAssertion`, which replaced `owl:equivalentClass` in the generated Hydra documentation (core #7944, `src/Hydra/Serializer/DocumentationNormalizer.php:110`, `src/JsonLd/HydraContext.php:86,547`). It appeared nowhere in the docs.
- States the verified precedence: the resource-level context is merged into `@context` first, then each property's own context entry is written to `@context[<propertyName>]` afterward, overwriting a same-named key — verified in `src/JsonLd/ContextBuilder.php:180-224`. Also notes that an operation-level `jsonldContext` fully replaces (not merges with) the resource-level one, per the copy-only-if-null cascade in `src/Metadata/WithResourceTrait.php:21-37`.

## Test plan
- [x] `npx prettier@3.9.5 --check "**/*.md" --prose-wrap always` passes repo-wide
- [x] Only `core/extending-jsonld-context.md` touched (+87 lines)
- [x] Claims verified against `api-platform/core` at `upstream/4.4`