### PR TITLE
docs: backport 4.4-feature docs stranded on main

### DIFF
--- a/core/configuration.md
+++ b/core/configuration.md
@@ -68,6 +68,10 @@ api_platform:
     # Enable the docs.
     enable_docs: true
 
+    # Skip response body construction on HEAD requests so collections are not iterated.
+    # Disable to process HEAD identically to GET.
+    enable_head_request_optimization: true
+
     # Enable the data collector and the WebProfilerBundle integration.
     enable_profiler: true
 
@@ -464,6 +468,10 @@ return [
 
     // Enable the docs.
     'enable_docs' => true,
+
+    // Skip response body construction on HEAD requests so collections are not iterated.
+    // Disable to process HEAD identically to GET.
+    'enable_head_request_optimization' => true,
 
     // Enable the data collector and the WebProfilerBundle integration.
     'enable_profiler' => true,

--- a/core/doctrine-filters.md
+++ b/core/doctrine-filters.md
@@ -137,10 +137,13 @@ To add some search filters, choose over this new list:
 - [PartialSearchFilter](#partial-search-filter) (filter using a `LIKE %value%`; supports nested
   properties via dot notation)
 - [ComparisonFilter](#comparison-filter) (filter with comparison operators `gt`, `gte`, `lt`, `lte`,
-  `ne`; replaces `DateFilter`, `NumericFilter`, and `RangeFilter`)
+  `ne`; replaces `NumericFilter` and `RangeFilter` — it is not a replacement for `DateFilter`, which
+  is kept)
 - [FreeTextQueryFilter](#free-text-query-filter) (allows you to apply multiple filters to multiple
   properties of a resource at the same time, using a single parameter in the URL)
 - [OrFilter](#or-filter) (apply a filter using `orWhere` instead of `andWhere`)
+- [ChainFilter](#chain-filter) (compose several filters on a single parameter key, each
+  self-selecting by value shape)
 
 ### SearchFilter
 
@@ -561,10 +564,13 @@ parameter key, one per operator. For a parameter named `price`, the generated pa
 
 ## Date Filter
 
-> [!TIP] Consider using [`ComparisonFilter`](#comparison-filter) wrapping `ExactFilter` as a modern
-> replacement. `ComparisonFilter` does not extend `AbstractFilter`, works natively with
-> `QueryParameter`, and supports the same date comparison use cases with `gt`, `gte`, `lt`, `lte`
-> operators.
+> [!NOTE] `DateFilter` is a kept filter: there is no modern replacement for it.
+> [`ComparisonFilter`](#comparison-filter) only performs plain `gt`/`gte`/`lt`/`lte`/`ne`
+> comparisons and does not replicate `DateFilter`'s per-property
+> [`null` management](#managing-null-values), its automatic `\DateTime`/`\DateTimeImmutable` binding
+> based on the Doctrine column type, its tolerant handling of invalid or empty date values, or its
+> inclusive `before`/`after` versus exclusive `strictly_before`/`strictly_after` URL vocabulary.
+> Keep `DateFilter` and declare it through a `QueryParameter`.
 
 The date filter allows filtering a collection by date intervals.
 
@@ -599,8 +605,15 @@ class Offer
 }
 ```
 
-> [!TIP] For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take
-> a look [in the Introduction section](#introduction).
+> [!NOTE] Instantiating a legacy filter with `new` (e.g. `new DateFilter()`) directly inside a
+> `QueryParameter` logs a cosmetic `ManagerRegistry must be initialized before accessing it.` ALERT
+> at cache warmup — filtering still works correctly. To silence it, reference the filter by its
+> service id (a string) instead of an inline object, or wrap it in a [`ChainFilter`](#chain-filter),
+> which suppresses the warmup call. See
+> [issue #7361](https://github.com/api-platform/core/issues/7361).
+>
+> For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take a look
+> [in the Introduction section](#introduction).
 
 ### Date Filter using the ApiFilter Attribute Syntax (not recommended)
 
@@ -719,13 +732,91 @@ class Offer
 }
 ```
 
-> [!TIP] For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take
-> a look [in the Introduction section](#introduction).
+> [!NOTE] The inline `new DateFilter(...)` instances above trigger the same cosmetic warmup ALERT
+> described [above](#date-filter-using-the-queryparameter-syntax-recommended)
+> ([#7361](https://github.com/api-platform/core/issues/7361)). Use a service id or a
+> [`ChainFilter`](#chain-filter) to silence it.
+>
+> For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take a look
+> [in the Introduction section](#introduction).
+
+## Chain Filter
+
+> [!NOTE] Since API Platform 4.4, `ChainFilter` is available for both Doctrine ORM
+> (`ApiPlatform\Doctrine\Orm\Filter\ChainFilter`) and MongoDB ODM
+> (`ApiPlatform\Doctrine\Odm\Filter\ChainFilter`).
+
+`ChainFilter` is a decorator that composes several filters on a single query parameter key. Each
+wrapped filter self-selects by the shape of the incoming value: `ComparisonFilter` and `DateFilter`
+ignore plain scalar values (they only react to their operator-map syntax, e.g. `[gt]`/`[lt]` or
+`[before]`/`[after]`), while `ExactFilter` and `PartialSearchFilter` ignore operator-map arrays.
+This lets you combine, for instance, an exact match and a full `DateFilter` on the same property
+without changing the URL vocabulary of either.
+
+The canonical use case is adding exact-match filtering to a date property while keeping
+`DateFilter`'s null management and `before`/`after`/`strictly_before`/`strictly_after` semantics
+intact:
+
+```php
+<?php
+// api/src/ApiResource/Person.php
+namespace App\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\Filter\ChainFilter;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+
+#[ApiResource]
+#[GetCollection(
+    parameters: [
+        'birthdate' => new QueryParameter(
+            property: 'birthdate',
+            filter: new ChainFilter([
+                new ExactFilter(),
+                new DateFilter(),
+            ]),
+        ),
+    ],
+)]
+class Person
+{
+    // ...
+}
+```
+
+Given that the collection endpoint is `/people`, both of the following queries work on the same
+`birthdate` parameter:
+
+- `/people?birthdate=1999-12-31` — exact match, handled by `ExactFilter`
+- `/people?birthdate[after]=1999-01-01` — date interval, handled by `DateFilter`
+- `/people?birthdate[strictly_before]=2000-01-01` — date interval, handled by `DateFilter`
+
+`ChainFilter` forwards `ManagerRegistry` and `Logger` to any wrapped filter that needs them, and
+merges the OpenAPI parameters documented by every wrapped filter. Because it manages this injection
+itself, wrapping a legacy filter in a `ChainFilter` also suppresses the cosmetic
+`ManagerRegistry must be initialized before accessing it.` ALERT described in the
+[#7361 note](#date-filter-using-the-queryparameter-syntax-recommended) — it is a valid alternative
+to referencing the filter by service id when you need to compose it with another filter on the same
+key.
 
 ## Boolean Filter
 
 > [!TIP] Consider using [`ExactFilter`](#exact-filter) as a modern replacement. `ExactFilter` does
-> not extend `AbstractFilter` and works natively with `QueryParameter`.
+> not extend `AbstractFilter` and works natively with `QueryParameter`. For a boolean field, declare
+> the parameter type and disable the array variant so a single `?field=true` parameter is exposed
+> (without `castToArray: false`, `ExactFilter` also documents a `field[]` array variant):
+>
+> ```php
+> 'isAvailableGenericallyInMyCountry' => new QueryParameter(
+>     filter: new ExactFilter(),
+>     schema: ['type' => 'boolean'],
+>     castToNativeType: true,
+>     castToArray: false,
+> ),
+> ```
 
 The boolean filter allows you to search on boolean fields and values.
 
@@ -849,8 +940,12 @@ class Offer
 }
 ```
 
-> [!TIP] For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take
-> a look [in the Introduction section](#introduction).
+> [!NOTE] `new RangeFilter()` inline triggers the same cosmetic warmup ALERT described in the
+> [#7361 note](#date-filter-using-the-queryparameter-syntax-recommended). Use a service id or a
+> [`ChainFilter`](#chain-filter) to silence it.
+>
+> For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take a look
+> [in the Introduction section](#introduction).
 
 ### Result using the Range Filter
 
@@ -893,8 +988,12 @@ class Offer
 }
 ```
 
-> [!TIP] For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take
-> a look [in the Introduction section](#introduction).
+> [!NOTE] `new ExistsFilter()` inline triggers the same cosmetic warmup ALERT described in the
+> [#7361 note](#date-filter-using-the-queryparameter-syntax-recommended). Use a service id or a
+> [`ChainFilter`](#chain-filter) to silence it.
+>
+> For other syntaxes, for e.g., if you want to new syntax with the ApiResource attribute take a look
+> [in the Introduction section](#introduction).
 
 ### Result using the Exists Filter
 
@@ -1326,7 +1425,13 @@ There are two kinds of migration:
   _declare_ them is deprecated (via `#[ApiFilter]` / extending `AbstractFilter`). Move the
   declaration to a `QueryParameter`; the class name and the URL syntax stay the same.
 
-> [!TIP] When instantiating a filter inside a `QueryParameter`, always use named arguments
+> [!NOTE] Declaring a kept filter as an inline `new` instance inside a `QueryParameter` (as shown in
+> the examples below) logs a cosmetic `ManagerRegistry must be initialized before accessing it.`
+> ALERT at cache warmup — filtering still works. Reference the filter by its service id (a string)
+> instead, or wrap it in a [`ChainFilter`](#chain-filter) to silence it. See
+> [issue #7361](https://github.com/api-platform/core/issues/7361).
+>
+> Also, when instantiating a filter inside a `QueryParameter`, always use named arguments
 > (`new DateFilter(nullManagement: ...)` rather than positional). Filter constructors are refined
 > across versions; named arguments keep your declarations forward-compatible.
 
@@ -1376,6 +1481,11 @@ class Offer
 (`?createdAt[before]=2025-01-01`, `?createdAt[after]=2025-01-01`, and the `strictly_*` variants),
 and per-property null management still applies.
 
+> [!NOTE] The `new DateFilter()` instance in the "modern" example above triggers the same cosmetic
+> warmup ALERT described in the
+> [#7361 note](#date-filter-using-the-queryparameter-syntax-recommended). Use a service id or a
+> [`ChainFilter`](#chain-filter) to silence it.
+
 ### Example: Migrating a RangeFilter
 
 Before (legacy):
@@ -1424,6 +1534,11 @@ class Product
 > [!TIP] Since API Platform 5.0, `ComparisonFilter` covers the full range syntax (including a native
 > `[between]=X..Y`), and `RangeFilter` is deprecated in favor of it. When you upgrade to 5.0, switch
 > `new RangeFilter()` to `new ComparisonFilter(new ExactFilter())` — the URL syntax is preserved.
+>
+> Also, the `new RangeFilter()` instance in the "modern" example above triggers the same cosmetic
+> warmup ALERT described in the
+> [#7361 note](#date-filter-using-the-queryparameter-syntax-recommended). Use a service id or a
+> [`ChainFilter`](#chain-filter) to silence it.
 
 ### MongoDB ODM
 
@@ -1440,13 +1555,13 @@ use ApiPlatform\Metadata\QueryParameter;
 #[ApiResource]
 #[GetCollection(
     parameters: [
-        'createdAt' => new QueryParameter(
+        'price' => new QueryParameter(
             filter: new ComparisonFilter(new ExactFilter()),
-            property: 'createdAt',
+            property: 'price',
         ),
     ],
 )]
-class Event
+class Product
 {
     // ...
 }

--- a/core/dto.md
+++ b/core/dto.md
@@ -30,6 +30,10 @@ You can map a DTO Resource directly to a Doctrine Entity using stateOptions. Thi
 configures the built-in State Providers and Processors to fetch/persist data using the Entity and
 map it to your Resource (DTO) using the Symfony Object Mapper.
 
+The Doctrine `stateOptions` also support a `repositoryMethod` parameter to start the provider query
+from a custom repository method. See
+[Customizing the Doctrine Query via `repositoryMethod`](state-providers.md#customizing-the-doctrine-query-via-repositorymethod-symfony-only).
+
 > [!WARNING] You must apply the #[Map] attribute to your DTO class. This signals API Platform to use
 > the Object Mapper for transforming data between the Entity and the DTO.
 

--- a/core/filters.md
+++ b/core/filters.md
@@ -66,6 +66,11 @@ a new instance:
 - **`OrFilter`**: A decorator that forces a filter to combine criteria with `OR` instead of `AND`.
     - Usage:
       `new QueryParameter(filter: new OrFilter(new ExactFilter()), properties: ['name', 'ean'])`
+- **`ChainFilter`** (Doctrine ORM/ODM only): Composes several filters on a single parameter key;
+  each wrapped filter self-selects by the shape of the value. See the
+  [Doctrine Filters documentation](doctrine-filters.md#chain-filter) for details.
+    - Usage:
+      `new QueryParameter(filter: new ChainFilter([new ExactFilter(), new DateFilter()]), property: 'birthdate')`
 - **`BooleanFilter`**: For boolean field filtering (legacy, `ExactFilter` is recommended instead).
     - Usage: `new QueryParameter(filter: BooleanFilter::class)`
 - **`NumericFilter`**: For numeric field filtering (legacy, `ExactFilter` or `ComparisonFilter` is
@@ -256,6 +261,11 @@ This configuration allows clients to filter events by date ranges using queries 
 - `/events?startDate[gte]=2023-01-01` — events starting on or after January 1st 2023
 - `/events?endDate[lt]=2023-12-31` — events ending before December 31st 2023
 - `/events?startDate[gte]=2023-01-01&endDate[lte]=2023-12-31` — events within a date range
+
+> [!NOTE] This is a plain comparison, distinct from [`DateFilter`](doctrine-filters.md#date-filter):
+> it does not provide per-property `null` management, tolerant handling of invalid or empty values,
+> or the `before`/`after` versus `strictly_before`/`strictly_after` vocabulary. Use `DateFilter`
+> when you need those behaviors.
 
 ### Filtering a Single Property
 

--- a/core/openapi.md
+++ b/core/openapi.md
@@ -924,6 +924,36 @@ return [
 > **must** be set according to the
 > [OpenID Connect specification](https://openid.net/specs/openid-connect-core-1_0.html).
 
+## Sending Credentials with Swagger UI Requests
+
+When your API is deployed behind a proxy that uses cookie-based authentication (e.g. Cloudflare
+Access), Swagger UI's requests may be rejected because the authentication cookie is not forwarded by
+default. Enabling `withCredentials` adds a `requestInterceptor` to SwaggerUIBundle that sets
+`credentials: 'include'` on every outgoing request, ensuring cookies are sent alongside token and
+CORS requests.
+
+### Sending Credentials with Swagger UI Requests using Symfony
+
+```yaml
+# api/config/packages/api_platform.yaml
+api_platform:
+    swagger:
+        with_credentials: true
+```
+
+### Sending Credentials with Swagger UI Requests using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ...
+    'swagger_ui' => [
+        'with_credentials' => true,
+    ],
+];
+```
+
 ## Info Object
 
 The [info object](https://swagger.io/specification/#info-object) provides metadata about the API

--- a/core/performance.md
+++ b/core/performance.md
@@ -618,6 +618,50 @@ when `jsonStream` is not enabled, API Platform falls back to the regular Seriali
 > declarations to build its encoders. Make sure every serialized property is public and typed;
 > values exposed only through getters or non-public properties will not be streamed.
 
+## HEAD Request Optimization
+
+Available since API Platform 4.4.
+
+On `HEAD` requests, API Platform no longer builds the response body: the collection is never
+iterated (no row is fetched from the database) and serialization is skipped entirely. This
+optimization is **enabled by default** and reduces the cost of `HEAD` requests, especially on large
+collections.
+
+Compared to the previous behavior, where a `HEAD` request was processed identically to its `GET`
+counterpart, this introduces two observable changes:
+
+- The `Content-Length` header is no longer set on `HEAD` responses (this is permitted by
+  [RFC 9110 §9.3.2](https://www.rfc-editor.org/rfc/rfc9110#section-9.3.2)).
+- Cache-Tags and `xkey` headers used by the
+  [HTTP cache invalidation system](#enabling-the-built-in-http-cache-invalidation-system) are no
+  longer emitted on `HEAD` responses. Previously, a `HEAD` response carried the same tags as its
+  `GET` counterpart and could be purged by tag; it now expires by TTL only.
+
+> **Note:** Independently of this optimization, the `Allow` header no longer advertises `HEAD` for
+> resources that have no `GET` operation, since `HEAD` is defined as `GET` without a response body.
+
+If you rely on the previous behavior, for example if a caching layer purges `HEAD` responses by
+Cache-Tag, disable the optimization to process `HEAD` identically to `GET`:
+
+### Disabling the Optimization using Symfony
+
+```yaml
+# api/config/packages/api_platform.yaml
+api_platform:
+    enable_head_request_optimization: false # process HEAD identically to GET
+```
+
+### Disabling the Optimization using Laravel
+
+```php
+<?php
+// config/api-platform.php
+return [
+    // ...
+    'enable_head_request_optimization' => false, // process HEAD identically to GET
+];
+```
+
 ## Profiling with Blackfire.io
 
 Blackfire.io allows you to monitor the performance of your applications. For more information, visit

--- a/core/state-providers.md
+++ b/core/state-providers.md
@@ -422,6 +422,271 @@ use App\State\BookRepresentationProvider;
 class Book {}
 ```
 
+## Customizing the Doctrine Query via `repositoryMethod` (Symfony only)
+
+When using the built-in Doctrine ORM or MongoDB ODM state providers, you can instruct them to start
+from a custom query builder produced by your entity repository instead of the default
+`createQueryBuilder('o')` / `createAggregationBuilder()` call. This keeps all the standard provider
+behavior (pagination, filters, link handling, identifier WHERE clauses) intact while giving you full
+control over the base query.
+
+Set `repositoryMethod` on the `stateOptions` of the operation:
+
+```php
+<?php
+// api/src/Entity/Product.php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use App\Repository\ProductRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: ProductRepository::class)]
+#[ApiResource]
+#[GetCollection(stateOptions: new Options(repositoryMethod: 'findAvailable'))]
+#[Get(stateOptions: new Options(repositoryMethod: 'findAvailable'))]
+class Product
+{
+    #[ORM\Id, ORM\GeneratedValue, ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    public bool $available = true;
+
+    // ...
+}
+```
+
+The repository method must be `public` and return a `Doctrine\ORM\QueryBuilder` for ORM (or a
+`Doctrine\ODM\MongoDB\Aggregation\Builder` for MongoDB ODM):
+
+```php
+<?php
+// api/src/Repository/ProductRepository.php
+
+namespace App\Repository;
+
+use App\Entity\Product;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @extends EntityRepository<Product>
+ */
+class ProductRepository extends EntityRepository
+{
+    public function findAvailable(): QueryBuilder
+    {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.available = :available')
+            ->setParameter('available', true);
+    }
+}
+```
+
+The providers apply identifier resolution (for item operations), pagination, and filters on top of
+the returned builder. A custom root alias is supported — the link handler reads the builder's root
+alias automatically.
+
+If the method does not exist on the repository, a `RuntimeException` is thrown:
+`The repository method "ProductRepository::findAvailable" does not exist.`
+
+If the method returns a value that is not the expected builder type, a `RuntimeException` is thrown:
+`The repository method "findAvailable" must return a QueryBuilder instance.`
+
+> [!NOTE] Because the filter applies at the item level too, a `Get` operation using a
+> `repositoryMethod` that filters rows will return a 404 response for any item excluded by that
+> filter.
+
+### GraphQL
+
+`repositoryMethod` works identically for GraphQL queries. Use it on the `ApiResource` or on specific
+GraphQL operations:
+
+```php
+<?php
+// api/src/Entity/Product.php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use App\Repository\ProductRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: ProductRepository::class)]
+#[ApiResource(
+    stateOptions: new Options(repositoryMethod: 'findAvailable'),
+    graphQlOperations: [
+        new Query(),
+        new QueryCollection(),
+    ]
+)]
+class Product
+{
+    // ...
+}
+```
+
+### Computed Fields
+
+A common use case is adding a computed scalar to each row using `addSelect`. Doctrine then returns
+mixed rows shaped `[0 => $entity, 'fieldAlias' => $scalar]` instead of plain entities. To map the
+scalar back onto the entity, combine `repositoryMethod` with a `processor` on the operation.
+
+A processor only runs on a read operation when `write: true` is set on that operation. Without this
+flag the processor stage is skipped and the raw array rows reach normalization, which produces
+errors such as "Cannot return null for non-nullable field". Set `write: true` explicitly to enable
+the processor.
+
+**REST example:**
+
+```php
+<?php
+// api/src/Repository/CartRepository.php
+
+namespace App\Repository;
+
+use App\Entity\Cart;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * @extends EntityRepository<Cart>
+ */
+class CartRepository extends EntityRepository
+{
+    public function getCartsWithTotalQuantity(): QueryBuilder
+    {
+        return $this->createQueryBuilder('o')
+            ->leftJoin('o.items', 'items')
+            ->addSelect('COALESCE(SUM(items.quantity), 0) AS totalQuantity')
+            ->addGroupBy('o.id');
+    }
+}
+```
+
+```php
+<?php
+// api/src/Entity/Cart.php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use App\Repository\CartRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: CartRepository::class)]
+#[GetCollection(
+    stateOptions: new Options(repositoryMethod: 'getCartsWithTotalQuantity'),
+    processor: [self::class, 'process'],
+    write: true,
+)]
+class Cart
+{
+    public ?int $totalQuantity = null;
+
+    // ...
+
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        foreach ($data as &$row) {
+            $cart = $row[0];
+            $cart->totalQuantity = $row['totalQuantity'] ?? 0;
+            $row = $cart;
+        }
+
+        return $data;
+    }
+}
+```
+
+**GraphQL example:**
+
+The same `process` method works for GraphQL. Declare it on the `QueryCollection` operation alongside
+`write: true`:
+
+```php
+<?php
+// api/src/Entity/Cart.php
+
+namespace App\Entity;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use ApiPlatform\Metadata\Operation;
+use App\Repository\CartRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: CartRepository::class)]
+#[ApiResource(
+    stateOptions: new Options(repositoryMethod: 'getCartsWithTotalQuantity'),
+    graphQlOperations: [
+        new Query(),
+        new QueryCollection(
+            processor: [self::class, 'process'],
+            write: true,
+        ),
+    ],
+)]
+#[GetCollection(
+    processor: [self::class, 'process'],
+    write: true,
+)]
+class Cart
+{
+    public ?int $totalQuantity = null;
+
+    // ...
+
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        foreach ($data as &$row) {
+            $cart = $row[0];
+            $cart->totalQuantity = $row['totalQuantity'] ?? 0;
+            $row = $cart;
+        }
+
+        return $data;
+    }
+}
+```
+
+With `paginationEnabled: false` the GraphQL query returns a plain list:
+
+```graphql
+{
+    carts {
+        totalQuantity
+    }
+}
+```
+
+With pagination enabled (the default), it returns a Relay connection:
+
+```graphql
+{
+    carts {
+        edges {
+            node {
+                totalQuantity
+            }
+        }
+    }
+}
+```
+
 ## Registering Services Without Autowiring (only for the Symfony variant)
 
 The services in the previous examples are automatically registered because

--- a/core/upgrade-guide.md
+++ b/core/upgrade-guide.md
@@ -2,9 +2,49 @@
 
 ## API Platform 4.3 to 4.4
 
-4.4 is the last 4.x minor. It introduces no breaking changes: everything deprecated here keeps
-working until it is removed in a later major (5.0 or 6.0). Fixing the deprecations now makes the
-upgrade to the next major a no-op.
+4.4 is the last 4.x minor. It ships a single backwards-incompatible change (below); everything else
+is a deprecation that keeps working until it is removed in a later major (5.0 or 6.0). Fixing the
+deprecations now makes the upgrade to the next major a no-op.
+
+### Backwards-Incompatible Changes
+
+#### Denormalization Type Errors on Unconstrained BackedEnum Properties Revert to HTTP 400
+
+Prior to 4.4, `BackedEnum`-typed properties received special treatment: any serializer type mismatch
+during denormalization was unconditionally promoted to HTTP 422. Starting with 4.4, that implicit
+promotion is replaced by a constraint-aware check.
+
+**Who is affected**: code that relied on enum-typed properties producing 422 without any Symfony
+Validator constraint (or Laravel rule) on the property.
+
+**What to do (Symfony)**: add an explicit constraint on the enum property:
+
+```php
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[Assert\Type(Status::class)]
+public Status $status;
+```
+
+Alternatively, enable Symfony Validator's
+[auto-mapping](https://symfony.com/doc/current/validation/auto_mapping.html) on the resource class.
+Auto-mapping generates an implicit `Type` constraint from the PHP type declaration, which is
+sufficient for the 422 promotion to apply.
+
+**What to do (Laravel)**: add a rule for the property in `rules`:
+
+```php
+#[ApiResource(
+    rules: ['status' => 'required']
+)]
+```
+
+Properties that already carry any constraint or rule are unaffected — they continue to produce 422.
+
+For the full rule tables and additional details, see
+[Constraint-Aware 422 for Denormalization Errors](../symfony/validation.md#constraint-aware-422-for-denormalization-errors)
+(Symfony) and the equivalent section in the
+[Laravel validation guide](../laravel/validation.md#constraint-aware-422-for-denormalization-errors).
 
 ### Deprecations
 

--- a/laravel/index.md
+++ b/laravel/index.md
@@ -1000,6 +1000,113 @@ drastically.
 
 To clear the cache, use `php artisan optimize:clear`.
 
+## Booting Without a Database Connection
+
+To expose an Eloquent model, API Platform reads its metadata (columns, types, nullability,
+relations, identifiers) directly from the database schema. This introspection happens while the
+resource metadata is built, which occurs when the service provider boots — including during routing,
+OpenAPI generation, and metadata caching.
+
+As a consequence, **the application cannot boot when no migrated database connection is reachable**.
+Any command that boots the framework will fail with a connection error such as:
+
+```text
+SQLSTATE[HY000] [2002] Connection refused
+could not find driver (Connection: mariadb, SQL: select ... from information_schema.columns ...)
+```
+
+This typically happens in setups where the database is not available at the time the app boots:
+
+- building a Docker image (the database service is not running during `docker build`);
+- running `composer install`, which triggers `@php artisan package:discover` and boots the
+  providers;
+- running static analysis such as [Larastan](https://github.com/larastan/larastan) in a CI/CD
+  pipeline, since it boots the Laravel application.
+
+### Dump the Metadata to a File
+
+The recommended solution is to pre-compute the resource metadata once, while the database is up,
+dump it to a single file, and serve the metadata from that file at boot. The introspection no longer
+runs, so the app boots without any database connection.
+
+Choose where the dump file lives through the `metadata_dump` key of `config/api-platform.php`. The
+file is meant to be committed to your VCS or baked into your Docker image, so pick a path inside the
+project:
+
+```php
+// config/api-platform.php
+return [
+    // ...
+    'metadata_dump' => base_path('api-platform-metadata.dump'),
+];
+```
+
+Generate the file with a reachable, migrated database:
+
+```console
+php artisan api-platform:metadata:dump
+```
+
+The command iterates every resource, builds its metadata (this is the step that hits the database)
+and serializes the result to the configured path. You can override the destination with `--path`:
+
+```console
+php artisan api-platform:metadata:dump --path=/tmp/api-platform-metadata.dump
+```
+
+Once the file exists, the metadata is read from it at boot **when `APP_DEBUG` is `false`** —
+bypassing the database. It is ignored when `APP_DEBUG` is `true`, so local development always
+recomputes fresh metadata (mirroring the [metadata cache](#caching) behavior). Leave `metadata_dump`
+to `null` to disable the feature entirely.
+
+> [!WARNING] The dump is a snapshot. It is **not** refreshed automatically when you change a
+> resource or migrate the database — you must re-run `php artisan api-platform:metadata:dump` (with
+> the database up) and commit the new file. To help you catch a forgotten refresh, API Platform
+> compares the dump against the current state and logs a warning when they diverge:
+>
+> - **at boot**, when your `ApiResource` source files changed since the dump was generated (this
+>   check needs no database, so it runs during a cacheless boot);
+> - **after `php artisan migrate`**, when the database schema no longer matches the dump.
+>
+> The warning never stops the boot — the (possibly stale) dump is still served so a database-less
+> boot keeps working — but it tells you to regenerate the file.
+
+### Building a Docker Image
+
+Commit the dump file (or generate it in an earlier build stage that has a database) and copy it into
+the image. At runtime, with `APP_DEBUG=false`, the app boots from the dump and never queries the
+database during boot.
+
+If you only want to avoid the failure triggered by Composer scripts during the build, run
+`composer install --no-scripts` and run `php artisan api-platform:metadata:dump` later, in a stage
+or step where the database is reachable.
+
+### Static Analysis in CI
+
+[Larastan](https://github.com/larastan/larastan) boots the Laravel application before analyzing it,
+so it hits the same requirement. Commit the dump file and make sure `APP_DEBUG` is `false` during
+analysis; the app then boots from the dump without a database.
+
+### Use SQLite at Build Time
+
+If you would rather not commit a dump file, point the application to a migrated SQLite database
+while building or running analysis, instead of your production database server. SQLite needs no
+separate service, so it is always reachable.
+
+Configure the connection (for example through environment variables) and run the migrations before
+any command that boots the app:
+
+```console
+export DB_CONNECTION=sqlite
+export DB_DATABASE=/tmp/api-platform.sqlite
+
+touch /tmp/api-platform.sqlite
+php artisan migrate --force
+
+# now commands that boot the app succeed
+php artisan optimize
+```
+
 ## Hooking Your Own Business Logic
 
 Now that you learned the basics, be sure to read

--- a/laravel/validation.md
+++ b/laravel/validation.md
@@ -19,3 +19,130 @@ class Book extends Model
 {
 }
 ```
+
+## Constraint-Aware 422 for Denormalization Errors
+
+Starting with API Platform 4.4, type mismatches detected during input denormalization (for example,
+the client sends `"foo"` for an `int` field, or `null` for a non-nullable property) are promoted to
+HTTP 422 validation responses when the affected property has a matching Laravel validation rule.
+When no matching rule exists, API Platform rethrows the original serializer exception as an honest
+HTTP 400.
+
+### How It Works
+
+`DeserializeProvider` catches denormalization exceptions from the Symfony Serializer. It delegates
+to `ApiPlatform\Laravel\State\DenormalizationViolationFactory`, which reads the `rules` declared on
+the operation and applies the following rule table:
+
+| Serializer `currentType` | Matching rule in `rules`                                                          | Code           |
+| ------------------------ | --------------------------------------------------------------------------------- | -------------- |
+| `null`                   | `required`, `filled`                                                              | `blank`        |
+| `null`                   | `present`                                                                         | `null`         |
+| any wrong type           | `string`, `integer`, `int`, `numeric`, `boolean`, `bool`, `array`, `date`, `json` | `invalid_type` |
+| any wrong type           | any other rule (when `nullable` is absent)                                        | `invalid_type` |
+| `null`                   | `nullable` only (no `required`, `present`, or `filled`)                           | 400 (rethrow)  |
+| any                      | (no rule for the property)                                                        | 400 (rethrow)  |
+
+Rules may be declared in string pipe-separated form (`'required|integer'`) or array form
+(`['required', 'integer']`). Object-based rules (`Rule`, `ValidationRule`) and `FormRequest`-class
+rule sets are skipped — `FormRequest` contracts run during the validation phase against the raw
+request, not the denormalized body.
+
+### Example
+
+```php
+// app/Models/Book.php
+
+use ApiPlatform\Metadata\ApiResource;
+use Illuminate\Database\Eloquent\Model;
+
+#[ApiResource(
+    rules: [
+        'title' => 'required|string',
+        'year'  => 'required|integer',
+    ]
+)]
+class Book extends Model
+{
+    protected $fillable = ['title', 'year'];
+}
+```
+
+Sending `null` for the `year` field:
+
+```http
+POST /api/books HTTP/1.1
+Content-Type: application/json
+
+{"title": "Dune", "year": null}
+```
+
+Returns 422 with `blank` code because `required` is present:
+
+```json
+{
+    "type": "/validation_errors/abc123",
+    "title": "Validation Error",
+    "description": "year: This value should not be blank.",
+    "status": 422,
+    "violations": [
+        {
+            "propertyPath": "year",
+            "message": "This value should not be blank.",
+            "code": "blank"
+        }
+    ]
+}
+```
+
+Sending a string for the `year` field:
+
+```http
+POST /api/books HTTP/1.1
+Content-Type: application/json
+
+{"title": "Dune", "year": "nineteen-sixty-five"}
+```
+
+Returns 422 with `invalid_type` code because `integer` is present:
+
+```json
+{
+    "type": "/validation_errors/def456",
+    "title": "Validation Error",
+    "description": "year: This value should be of type integer.",
+    "status": 422,
+    "violations": [
+        {
+            "propertyPath": "year",
+            "message": "This value should be of type integer.",
+            "code": "invalid_type"
+        }
+    ]
+}
+```
+
+If the `year` property had no rule at all, both requests would receive HTTP 400 instead.
+
+### Nullable Fields
+
+A field declared as `nullable` without `required`, `present`, or `filled` explicitly permits `null`
+values, so a `null` submission for such a field is not promoted to 422 and rethrows the original
+400:
+
+```php
+#[ApiResource(
+    rules: [
+        'publishedAt' => 'nullable|date',
+    ]
+)]
+```
+
+Sending `null` for `publishedAt` with only `nullable|date` produces HTTP 400, not 422.
+
+### Relationship with Symfony Validation
+
+The constraint-aware 422 behavior described above operates on the Laravel rules defined on the
+operation. It is independent from the Symfony Validator stack. For the equivalent Symfony
+integration, see the
+[Validation with Symfony documentation](../symfony/validation.md#constraint-aware-422-for-denormalization-errors).

--- a/symfony/validation.md
+++ b/symfony/validation.md
@@ -706,3 +706,131 @@ If the submitted data has denormalization errors, the HTTP status code will be s
 
 You can also enable collecting of denormalization errors globally in the
 [Global Resources Defaults](https://api-platform.com/docs/core/configuration/#global-resources-defaults).
+
+## Constraint-Aware 422 for Denormalization Errors
+
+Starting with API Platform 4.4, type mismatches detected during input denormalization (for example,
+the client sends `"foo"` for an `int` field, or `null` for a non-nullable property) are promoted to
+HTTP 422 validation responses when the affected property has a matching Symfony Validator
+constraint. When no matching constraint exists, API Platform rethrows the original serializer
+exception as an honest HTTP 400.
+
+### How It Works
+
+`DeserializeProvider` catches `NotNormalizableValueException` and `PartialDenormalizationException`
+from the Symfony Serializer. It delegates to
+`ApiPlatform\Validator\DenormalizationViolationFactory`, which reads the Symfony Validator metadata
+for the operation's resource class and applies the following rule table:
+
+| Serializer `currentType` | Matching constraint on the property | HTTP status | Violation code              |
+| ------------------------ | ----------------------------------- | ----------- | --------------------------- |
+| `null`                   | `NotBlank`                          | 422         | `NotBlank::IS_BLANK_ERROR`  |
+| `null`                   | `NotNull`                           | 422         | `NotNull::IS_NULL_ERROR`    |
+| any wrong type           | `Type`                              | 422         | `Type::INVALID_TYPE_ERROR`  |
+| any wrong type           | any other constraint                | 422         | `Type::INVALID_TYPE_ERROR`  |
+| any wrong type           | (no constraint)                     | 400         | original exception rethrown |
+
+In `collectDenormalizationErrors` mode (where the serializer raises
+`PartialDenormalizationException` instead of failing on the first error), properties without any
+constraint still emit a generic `Type::INVALID_TYPE_ERROR` violation so the 422 response surface
+remains consistent with prior behavior.
+
+Validation groups set via `Operation::getValidationContext()['groups']` are respected when looking
+up constraints.
+
+### Example
+
+```php
+<?php
+// api/src/Entity/Book.php
+namespace App\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+#[ApiResource]
+class Book
+{
+    #[ORM\Id, ORM\Column, ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    #[Assert\NotBlank]
+    public string $title;
+
+    #[ORM\Column]
+    #[Assert\NotNull]
+    #[Assert\Type('int')]
+    public int $year;
+}
+```
+
+Sending `null` for the `year` field:
+
+```http
+POST /books HTTP/1.1
+Content-Type: application/ld+json
+
+{"title": "Dune", "year": null}
+```
+
+Returns a 422 using the `NotNull` constraint message:
+
+```json
+{
+    "@context": "/contexts/ConstraintViolationList",
+    "@type": "ConstraintViolationList",
+    "title": "An error occurred",
+    "description": "year: This value should not be null.",
+    "violations": [
+        {
+            "propertyPath": "year",
+            "message": "This value should not be null.",
+            "code": "ad32d13f-c3d4-423b-909a-857b961eb720"
+        }
+    ]
+}
+```
+
+Sending a string for the `year` field:
+
+```http
+POST /books HTTP/1.1
+Content-Type: application/ld+json
+
+{"title": "Dune", "year": "nineteen-sixty-five"}
+```
+
+Returns a 422 using the `Type` constraint message:
+
+```json
+{
+    "@context": "/contexts/ConstraintViolationList",
+    "@type": "ConstraintViolationList",
+    "title": "An error occurred",
+    "description": "year: This value should be of type int.",
+    "violations": [
+        {
+            "propertyPath": "year",
+            "message": "This value should be of type int.",
+            "code": "ba785a8c-82cb-4283-967c-3cf342181b40"
+        }
+    ]
+}
+```
+
+If `year` had no validator constraint at all, both requests would receive HTTP 400 instead.
+
+### Tip: use Symfony Validator auto-mapping
+
+When
+[`framework.validation.auto_mapping`](https://symfony.com/doc/current/validation/auto_mapping.html)
+is enabled, Symfony Validator derives implicit constraints directly from PHP type declarations —
+`string`, `int`, `float`, nullability, `BackedEnum` cases, and more. Every property with a PHP type
+then effectively has a `Type` constraint without any manual annotation.
+
+This means the constraint-aware 422 promotion applies across the board: you get consistent 422
+responses for type mismatches on all typed properties without scattering `#[Assert\Type]`
+everywhere.


### PR DESCRIPTION
## Root cause

The docs merge model is `4.3` -> `4.4` -> `main`. Content authored directly on `main` can never
merge down into `4.4`. Several PRs documenting features that actually ship in **4.4** were merged
straight onto `main` instead, so the `4.4` branch has under-documented itself since. This PR
cherry-picks those commits down onto `4.4` (each with `-x`, so the origin is recorded), stripping
any 5.0-only claims that came along for the ride.

This is why the diff looks large for a "docs sync" PR — it is six feature-doc commits, not a small
fix.

## Commits cherry-picked (oldest first)

| commit (on `main`) | core PR | what it documents |
| --- | --- | --- |
| `dc0205ffe39` | #8197 | Swagger UI `with_credentials` |
| `93df9a9c430` | — | 422 denormalization / BackedEnum 400 (`Backwards-Incompatible Changes` section missing from 4.4's own upgrade guide) |
| `4bf8ef9dad6` | #7115 | `repositoryMethod` Doctrine state option |
| `d948c5270a4` | #8290 | Laravel metadata dump command (shipped in 4.3.14) |
| `f37080b654e` | — | HEAD request body-skip optimization (`enable_head_request_optimization`, doc itself says "Available since API Platform 4.4") |
| `031fd780f30` | #8416 | `ChainFilter` + the DateFilter/ComparisonFilter correction |

Verified each feature actually ships in 4.4 against `api-platform/core` at `upstream/4.4`
(`Configuration.php`, `ApiPlatformExtension.php`, `src/Doctrine/{Orm,Odm}/Filter/ChainFilter.php`,
`src/State/DenormalizationViolationFactoryInterface.php`, `src/Doctrine/Common/State/Options.php`).

## 5.0-only content stripped / corrected

- `core/upgrade-guide.md`: merged the incoming `### Backwards-Incompatible Changes` section
  in front of the existing `### Deprecations` section (matching `main`'s structure) instead of
  leaving duplicated/conflicting content from the cherry-pick.
- `core/openapi.md` (from `dc0205ffe39`): the cherry-picked text claimed "This feature is only
  available with Laravel" for Swagger UI credentials. That's factually wrong on **both** `4.4` and
  `main` — `ApiPlatformExtension.php:703`, `Configuration.php:331`, and
  `SwaggerUi/SwaggerUiProcessor.php:67` show the Symfony side is fully wired (PR #8197 title is
  literally `feat(symfony,laravel): withCredentials option to Swagger UI`). Replaced the "not
  available" note with the actual Symfony YAML config example.
- Nothing else needed stripping: no cherry-picked commit introduced a `ComparisonFilter[between]`
  claim, a "RangeFilter is deprecated" claim, an HTTP QUERY / `api-platform/test` / `routePriority`
  reference, or a DateFilter/ExistsFilter "standalone rewrite" claim. (A pre-existing, already
  future-tense-qualified `[between]`/5.0 note in `doctrine-filters.md` predates this PR and was left
  untouched — out of scope here.)
- Whole-repo `npx prettier@3.9.5 --check` gate: two of the six commits landed with
  line-wrap violations (in both newly-added and, for `core/openapi.md`/`doctrine-filters.md`,
  pre-existing 4.4 content that the added text now touches); fixed with `--write` and folded back
  into the originating commits so history stays one-commit-per-feature.

## Not backported (deliberately)

- `abf523ed587` — HTTP QUERY operation docs, genuinely 5.0-only.
- `ef73d47a1c6`, `15a640ad23d`, `c3cf58fc31f` — prettier/CI housekeeping, not content.
- `4732eb0e15c` ("Using AI Coding Agents with API Platform" guide, adds `core/ai-agents.md` +
  `outline.yaml` entry) — not version-specific and not in this task's scope; flagging for a
  separate decision on whether it also belongs on `4.4`.

## Verification

- `git log --oneline HEAD..upstream/main --no-merges` (after accounting for cherry-pick SHA churn)
  confirms only the four items above remain unbackported.
- `npx prettier@3.9.5 --check "**/*.md" --prose-wrap always` passes repo-wide.
- `outline.yaml` unchanged (no new pages added by these six commits).
